### PR TITLE
fix: search_runner crash + judge knowledge_growth edge case

### DIFF
--- a/autosearch/v2/judge.py
+++ b/autosearch/v2/judge.py
@@ -168,7 +168,7 @@ def score_knowledge_growth(evidence_file: str) -> float:
     - gap_closure: (initial_gaps - remaining_gaps) / max(initial_gaps, 1)
     - confidence_ratio: high_confidence / max(final_entries, 1)
 
-    Returns NEUTRAL (0.5) when the file does not exist (single-session mode).
+    Returns NEUTRAL (0.5) when the file does not exist or has no meaningful data.
     """
     kg = load_state_json(evidence_file, "knowledge-growth.json")
     if not kg:
@@ -179,6 +179,10 @@ def score_knowledge_growth(evidence_file: str) -> float:
     initial_gaps = coerce_float(kg.get("initial_gaps"), 0)
     remaining_gaps = coerce_float(kg.get("remaining_gaps"), 0)
     high_confidence = coerce_float(kg.get("high_confidence"), 0)
+
+    # No meaningful data yet — return neutral instead of penalizing
+    if initial == 0 and final == 0 and initial_gaps == 0:
+        return NEUTRAL_DIMENSION_SCORE
 
     # Growth: how much did the knowledge map expand?
     growth_ratio = (

--- a/autosearch/v2/search_runner.py
+++ b/autosearch/v2/search_runner.py
@@ -572,12 +572,16 @@ async def main(queries: list[dict]) -> None:
     DDGS_BATCH_DELAY = 1.5
 
     async def run_ddgs_batched() -> list[list[dict]]:
-        all_results = []
+        all_results: list[list[dict]] = []
         for i in range(0, len(ddgs_queries), DDGS_BATCH_SIZE):
             batch = ddgs_queries[i : i + DDGS_BATCH_SIZE]
             batch_tasks = [run_single_query(q) for q in batch]
             batch_results = await asyncio.gather(*batch_tasks, return_exceptions=True)
-            all_results.extend(batch_results)
+            for br in batch_results:
+                if isinstance(br, Exception):
+                    print(f"[search_runner] ddgs batch error: {br}", file=sys.stderr)
+                else:
+                    all_results.append(br)
             if i + DDGS_BATCH_SIZE < len(ddgs_queries):
                 await asyncio.sleep(DDGS_BATCH_DELAY)
         return all_results

--- a/autosearch/v2/tests/test_judge.py
+++ b/autosearch/v2/tests/test_judge.py
@@ -315,6 +315,91 @@ def test_invalid_json_lines(tmp_path: Path) -> None:
     assert score["dimensions"]["adoption"] == pytest.approx(0.5)
 
 
+def test_knowledge_growth_no_file(tmp_path: Path) -> None:
+    """Returns NEUTRAL when knowledge-growth.json does not exist."""
+    score = score_file(
+        write_jsonl(
+            tmp_path / "kg-none.jsonl",
+            [result("https://example.com/1", "github", "judge", title="judge")],
+        )
+    )
+    assert_dimensions(score, knowledge_growth=0.5)
+
+
+def test_knowledge_growth_empty_data(tmp_path: Path) -> None:
+    """Returns NEUTRAL when file exists but all values are zero."""
+    write_state_json(
+        tmp_path,
+        "knowledge-growth.json",
+        {
+            "initial_entries": 0,
+            "final_entries": 0,
+            "initial_gaps": 0,
+            "remaining_gaps": 0,
+            "high_confidence": 0,
+        },
+    )
+    score = score_file(
+        write_jsonl(
+            tmp_path / "kg-empty.jsonl",
+            [result("https://example.com/1", "github", "judge", title="judge")],
+        )
+    )
+    assert_dimensions(score, knowledge_growth=0.5)
+
+
+def test_knowledge_growth_full_session(tmp_path: Path) -> None:
+    """Scores growth, gap closure, and confidence correctly."""
+    write_state_json(
+        tmp_path,
+        "knowledge-growth.json",
+        {
+            "initial_entries": 10,
+            "final_entries": 20,
+            "initial_gaps": 8,
+            "remaining_gaps": 2,
+            "high_confidence": 15,
+        },
+    )
+    score = score_file(
+        write_jsonl(
+            tmp_path / "kg-full.jsonl",
+            [result("https://example.com/1", "github", "judge", title="judge")],
+        )
+    )
+    # growth_ratio = min((20-10)/max(10,1), 1.0) = 1.0
+    # gap_closure = (8-2)/max(8,1) = 0.75
+    # confidence_ratio = 15/max(20,1) = 0.75
+    # score = 0.4*0.75 + 0.35*0.75 + 0.25*1.0 = 0.3 + 0.2625 + 0.25 = 0.8125
+    assert_dimensions(score, knowledge_growth=pytest.approx(0.8125))
+
+
+def test_knowledge_growth_gaps_regressed(tmp_path: Path) -> None:
+    """Gap regression (more gaps than before) returns 0 for gap_closure."""
+    write_state_json(
+        tmp_path,
+        "knowledge-growth.json",
+        {
+            "initial_entries": 10,
+            "final_entries": 10,
+            "initial_gaps": 3,
+            "remaining_gaps": 5,
+            "high_confidence": 5,
+        },
+    )
+    score = score_file(
+        write_jsonl(
+            tmp_path / "kg-regress.jsonl",
+            [result("https://example.com/1", "github", "judge", title="judge")],
+        )
+    )
+    # growth_ratio = 0.0 (no growth)
+    # gap_closure = 0.0 (regression)
+    # confidence_ratio = 5/10 = 0.5
+    # score = 0.4*0 + 0.35*0.5 + 0.25*0 = 0.175
+    assert_dimensions(score, knowledge_growth=pytest.approx(0.175))
+
+
 def test_cli_exit_codes(tmp_path: Path) -> None:
     evidence = write_jsonl(
         tmp_path / "cli.jsonl",


### PR DESCRIPTION
## Summary

- **search_runner.py**: `asyncio.gather(..., return_exceptions=True)` returns Exception objects mixed into results list. Code called `.extend()` on them → `TypeError` crash on any DDGS network error. Fixed by filtering exceptions before appending.
- **judge.py**: `score_knowledge_growth()` returned 0.0 when `knowledge-growth.json` exists with all-zero values, penalizing sessions that created the file but had no data yet. Now returns NEUTRAL (0.5) matching the docstring contract.
- **test_judge.py**: Added 4 tests for `score_knowledge_growth()` — the 8th dimension had zero direct test coverage.

Found during review of PR #15 (which was closed as already-merged via PR #16).

## Test plan
- [x] 20/20 judge tests passing (16 existing + 4 new)
- [x] Tests cover: no-file, empty-data, full-session, gap-regression scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)