### PR TITLE
chore: add pyright type checking (basic mode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Ruff format check
         run: ruff format --check .
 
+      - name: Type check
+        run: |
+          pip install pyright
+          pyright
+        continue-on-error: true
+
       - name: Test
         run: pytest -x -q
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "typeCheckingMode": "basic",
+  "pythonVersion": "3.11",
+  "include": ["autosearch"],
+  "reportMissingImports": false,
+  "reportMissingModuleSource": false
+}


### PR DESCRIPTION
## Summary
- Add `pyrightconfig.json` with basic mode for initial type checking rollout
- Add pyright CI step with `continue-on-error: true` (will be made strict after fixing existing issues)

Part of F002 cross-project dev discipline sync.

## Test plan
- [ ] CI pyright step runs without config errors
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)