### PR TITLE
feat: efficiency improvements — language filter, model routing, progress output

### DIFF
--- a/docs/exec-plans/active/autosearch-0403-efficiency-improvements.md
+++ b/docs/exec-plans/active/autosearch-0403-efficiency-improvements.md
@@ -1,0 +1,64 @@
+# AutoSearch 效率优化 — 砍浪费不加功能
+
+## Goal
+
+基于 native WebSearch vs AutoSearch 对比实测（2026-04-03），修复三个确认的浪费点：无效渠道、模型过重、中间无反馈。目标：同等质量，token 降 5x，体验从"15 分钟黑洞"变成有进度反馈。
+
+## 背景数据（实测）
+
+- 主题：MCP Protocol Ecosystem 2025-2026
+- Native WebSearch：3 秒，~2K tokens，10 个链接，概括性摘要
+- AutoSearch：903 秒，~105K tokens，56 次工具调用，50+ cited sources，深度报告
+- 结论：质量差距大（AutoSearch 远胜），但 50x token 和 300x 时间有大量可砍的浪费
+
+## 已确认不需要改的
+
+- **渠道并行**：search_runner.py 已用 asyncio.gather 并行执行，不是瓶颈
+- **去重时机**：search_runner.py 已在 LLM 评估前做 URL 级去重
+
+---
+
+## F001: 语言/领域预过滤 — done
+
+在 select-channels 中加入语言维度思考步骤。不硬编码渠道列表，让 agent 自己判断语言匹配。
+
+**为什么**：英文技术主题搜小红书/抖音/微博 = 必然零产出。但渠道列表会一直变，硬编码会过时。
+
+#### Steps
+
+- [x] S1: Rule 0 added — reads SKILL.md Language section, no hardcoded lists
+- [x] S2: Output section updated — requires excluded channels list with reasons
+
+## F002: Agent 模型降级 — done (S3 pending)
+
+researcher agent 从 Opus 降到 Sonnet。搜索执行 + 评估 + 合成不需要 Opus 级推理。
+
+**为什么**：105K tokens 全跑 Opus，费用是 Sonnet 的 ~5x。pipeline-flow.md 自己设计的模型路由表就写了大部分 phase 用 Haiku/Sonnet。但实际 spawn 时继承了主对话的 Opus。
+
+#### Steps
+
+- [x] S1: Found: command file ran pipeline in Opus context. agents/researcher.md had model: sonnet but was never spawned.
+- [x] S2: Command file restructured into Phase A (config, Opus) + Phase B (spawn autosearch:researcher, Sonnet). Pipeline work now runs in Sonnet.
+- [ ] S3: 跑一次实测对比 — 同主题 Sonnet vs Opus researcher，对比报告质量和 token 消耗 ← verify: 两份报告 + token 数据
+
+## F003: 渐进式输出 — done
+
+解决"15 分钟黑洞"体验。用户在搜索过程中能看到进度。
+
+**为什么**：MindSearch 的核心卖点就是过程可见。AutoSearch 跑 15 分钟无反馈，用户以为卡死了。
+
+#### Steps
+
+- [x] S1: Researcher runs as foreground Agent — user sees all its text output. No SendMessage needed.
+- [x] S2a: Added progress output format to pipeline-flow/SKILL.md: `[Phase N/6] ✓ {name} — {metric}` after each phase. Agent output is directly visible to user.
+
+## Decision Log
+
+- 2026-04-03: F001 选择"agent 自己判断语言"而不是"硬编码排除列表"。原因：渠道 skills 会一直新增，硬编码列表过时风险高。
+- 2026-04-03: F002 降到 Sonnet 而非 Haiku。原因：synthesis 阶段需要较强写作能力，Haiku 可能不够。pipeline-flow 的路由表也把 synthesis 标为 Sonnet。
+- 2026-04-03: F003 优先尝试 SendMessage 方案（S2a），拆 agent 是 fallback（S2b）。原因：拆 agent 会丢失跨 phase 的上下文连续性。
+
+## Open Questions
+
+- Early stopping 是否要和搜索深度选择绑定？已讨论方向（ceiling + floor），待后续细化。
+- F002 降级后如果 synthesis 质量下降明显，是否只对 Phase 2-3 用 Sonnet，Phase 4 回 Opus？需要 S3 实测数据决定。

--- a/skills/pipeline-flow/SKILL.md
+++ b/skills/pipeline-flow/SKILL.md
@@ -19,6 +19,24 @@ Not all phases need the same model. Use cheaper models for structured/batch task
 
 When spawning agents for batch tasks (scoring, rubric checking), use `model: "haiku"`.
 
+# Progress Output
+
+After completing each phase, output a one-line progress summary the user can read. Use this exact format:
+
+```
+[Phase N/6] ✓ {phase name} — {key metric or finding}
+```
+
+Examples:
+- `[Phase 1/6] ✓ Recall — 47 items mapped, 8 gaps identified`
+- `[Phase 2/6] ✓ Search — 38 results from 8 channels (12 new discoveries)`
+- `[Phase 3/6] ✓ Evaluate — 31 relevant, 7 filtered out`
+- `[Phase 4/6] ✓ Synthesize — report drafted, 24 cited sources`
+- `[Phase 5/6] ✓ Rubrics — 21/25 passed (84%)`
+- `[Phase 6/6] ✓ Learn — 3 patterns saved, 1 skill evolved`
+
+This solves the "15-minute black hole" problem. Users need to see progress, not silence.
+
 # Purpose
 
 This skill defines the 7-phase pipeline that makes AutoSearch produce results better than native Claude. Follow these phases in order.

--- a/skills/select-channels/SKILL.md
+++ b/skills/select-channels/SKILL.md
@@ -15,6 +15,21 @@ The selected channels determine WHERE queries are sent.
 
 # Selection Rules
 
+## Rule 0: Language relevance filter
+
+Before applying any other rule, exclude channels whose language does not match the topic.
+
+Read each channel's `## Language` section in its SKILL.md. If the channel's language coverage has no overlap with the topic's language, exclude it and log the reason.
+
+Examples:
+- English technical topic → exclude zhihu, csdn, juejin, bilibili, 36kr, weibo, xiaohongshu, douyin, xiaoyuzhou, xueqiu, infoq-cn, wechat (Chinese-only channels)
+- Chinese topic → exclude devto, stackoverflow, reddit, hn (English-only channels with negligible Chinese content)
+- Mixed/multilingual topic → keep both, prioritize by relevance
+
+Do not hardcode channel lists. Read the SKILL.md Language section for each candidate channel. Channels evolve — the Language section is the source of truth.
+
+Log every exclusion: `excluded: {channel} — language mismatch ({channel_language} vs {topic_language})`
+
 ## Rule 1: Always include these (2-3 channels)
 
 - GitHub repos (`github-repos`) — for any topic involving code or tools
@@ -91,19 +106,24 @@ More than 10 channels produces diminishing returns. If the rules above suggest m
 
 # Output
 
-List the selected channels with one-line justification each:
+List both selected and excluded channels:
 
 ```
+Excluded channels:
+- xiaohongshu — language mismatch (Chinese-only vs English topic)
+- douyin — language mismatch (Chinese-only vs English topic)
+- xueqiu — language mismatch (Chinese-only vs English topic)
+
 Selected channels:
 1. github-repos — core tool discovery
 2. web-ddgs — broad web coverage
-3. zhihu — Chinese developer perspective (GAP: dimension 8)
-4. google-scholar — academic coverage (GAP: dimension 4)
-5. producthunt — recent product launches (GAP: dimension 7)
-6. reddit — community sentiment
+3. google-scholar — academic coverage (GAP: dimension 4)
+4. producthunt — recent product launches (GAP: dimension 7)
+5. reddit — community sentiment
+6. arxiv — academic papers (GAP: dimension 3)
 ```
 
-Pass this list to gene-query.md for platform-targeted query generation.
+Pass the selected list to gene-query.md for platform-targeted query generation.
 
 # Quality Bar
 


### PR DESCRIPTION
## What

Implement 3 efficiency improvements from the exec plan to cut token waste and fix UX.

## Why

实测数据：AutoSearch 用 105K tokens / 903 秒完成一次搜索，vs native WebSearch 2K tokens / 3 秒。质量远胜但有大量可砍浪费。

## Scope

- [x] Skills / PROTOCOL
- [x] Docs / config

## Changes

**F001: Language pre-filter** (`select-channels/SKILL.md`)
- Rule 0: read channel SKILL.md Language section, exclude mismatched channels
- Output section: log excluded channels with reasons
- No hardcoded lists — channels evolve, Language section is source of truth

**F002: Model routing** (`~/.claude/commands/autosearch.md`)
- Command file split: Phase A (config) in Opus, Phase B (pipeline) spawns researcher agent in Sonnet
- `agents/researcher.md` already had `model: sonnet` — now actually used
- Expected: ~5x token cost reduction on pipeline work
- S3 comparison test pending (next session)

**F003: Progress output** (`pipeline-flow/SKILL.md`)
- `[Phase N/6] ✓ {name} — {metric}` after each phase
- Solves "15-minute black hole" — user sees progress throughout

## Test

- [x] `pytest -m "not network"` passes (215 passed)
- [ ] F002 S3: Sonnet vs Opus quality comparison (next session)
- [ ] Manual: `/autosearch "test"` shows progress lines

## CHANGELOG

- [x] N/A — exec plan updated in-repo instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)