### PR TITLE
feat(avo): per-query tracking + gap loop-back + query boosting

### DIFF
--- a/skills/gene-query/SKILL.md
+++ b/skills/gene-query/SKILL.md
@@ -70,18 +70,20 @@ These rules exist because AVO analysis found that r005 (commercial companies) an
 
 # Input Sources (General)
 
-Build the gene pool from three places:
+Build the gene pool from four places:
 
 - The task itself: entities, artifacts, constraints, and pain language from the user or goal case
 - Winning history: patterns from `state/patterns.jsonl` (filter to `winning_pattern` and `platform_insight` types only — ignore `session_stats`, `outcome_boost`, and `winning_words` entries, which are statistical noise that does not inform query strategy) and proven queries from `state/outcomes.jsonl`
+- Query performance data: read `state/query-outcomes.jsonl` if it exists. Group by query text or semantic family (queries sharing 2+ content words). Boost: include queries with `relevant_rate >= 0.7` AND `results_count >= 3` — these are proven performers. Suppress: do not generate queries that closely match patterns with `relevant_rate <= 0.2` OR `results_count == 0` for the same `topic_type` — these are proven failures.
 - Your own judgment: missing synonyms, domain terms, and alternate framings not yet present in state
 
 # Mix Ratio
 
 Generate candidate queries with this mix:
 
-- 20% LLM suggestions
-- 20% winning patterns
+- 15% LLM suggestions
+- 15% winning patterns (from state/patterns.jsonl)
+- 10% high-performing queries (from state/query-outcomes.jsonl, boost proven winners)
 - 60% gene combinations
 
 Keep the ratio in spirit, not as rigid bookkeeping.
@@ -109,6 +111,8 @@ Prefer specific combinations that narrow meaning without becoming long natural-l
 Keep one anchor term that strongly binds the topic.
 Add one discriminator that changes what results appear.
 Add a third term only when it meaningfully sharpens retrieval.
+
+Target query length: 3-5 words for most channels. Academic channels (arxiv, semantic-scholar, google-scholar) may use up to 7 words when specificity demands it. If a gene combination produces a query longer than the limit, split it into two shorter queries rather than keeping one long one. Short, precise queries consistently outperform long natural-language phrases on search APIs (SE-Search found 33.8% improvement with atomic queries).
 
 Prefer concrete tokens over generic prose.
 Prefer symptoms over emotional adjectives.

--- a/skills/llm-evaluate/SKILL.md
+++ b/skills/llm-evaluate/SKILL.md
@@ -116,6 +116,29 @@ Use a layered parse strategy:
 
 If extraction still fails, keep going with your own explicit per-result judgments rather than leaving relevance unset.
 
+# Output Writing
+
+After completing all evaluation batches, collect all `next_queries` suggested across batches.
+Deduplicate them (same intent = same query, drop the duplicate).
+Write the deduplicated list to a session-scoped file:
+
+`evidence/{session_id}-next-queries.jsonl`
+
+One line per query, in search_runner.py format with gap metadata:
+
+```json
+{"channel": "arxiv", "query": "self-evolving search multi-round", "max_results": 10, "gap_dimension": "academic-papers", "current_relevant": 0}
+```
+
+Fields:
+- `channel`: the platform most likely to fill this gap
+- `query`: the search query text (3-7 words)
+- `max_results`: default 10
+- `gap_dimension`: which task dimension this query addresses (from the gap analysis)
+- `current_relevant`: count of relevant results already covering this dimension — allows Phase 3b to filter by critical gaps (current_relevant <= 1)
+
+If no gaps were found, write an empty file. The file must always exist after Phase 3 so Phase 3b can check it without error handling.
+
 # Quality Bar
 
 This skill exists because keyword overlap confuses "found matching keywords" with "found the right thing."

--- a/skills/pipeline-flow/SKILL.md
+++ b/skills/pipeline-flow/SKILL.md
@@ -125,7 +125,56 @@ search_runner.py already did normalization, dedup, and date extraction. Claude o
 
 Do NOT re-run normalize or extract-dates — search_runner.py already handled those.
 
-After Phase 3, you should have evaluated search results ready for synthesis.
+After Phase 3, you should have evaluated search results and a next-queries file ready.
+
+# Phase 3a: Per-Query Outcome Tracking
+
+After llm-evaluate completes, compute per-query metrics from the evaluated results.
+
+For each unique `query` value in the results:
+1. `results_count` = total results with this query
+2. `relevant_count` = results where `metadata.llm_relevant == true`
+3. `relevant_rate` = relevant_count / results_count
+4. `new_urls_count` = results whose URLs were not in prior sessions (approximate: set to results_count if no prior data exists)
+5. `channel` = the `source` field from the first result with this query
+
+Append one record per query to `state/query-outcomes.jsonl` (create if absent):
+
+```json
+{"session": "{session_id}", "ts": "{ISO 8601 now}", "query": "{query text}", "channel": "{channel}", "results_count": 12, "relevant_count": 8, "relevant_rate": 0.67, "new_urls_count": 8, "topic_type": "{academic|tool|general}"}
+```
+
+This file is append-only. It feeds `gene-query` in future sessions to boost high-performing query patterns.
+
+Time: ~10 seconds (arithmetic on existing data, no API calls)
+
+# Phase 3b: Gap-Driven Loop-Back (conditional, at most once)
+
+Read `evidence/{session_id}-next-queries.jsonl` (written by llm-evaluate in Phase 3).
+
+**If the file is empty or absent**: skip Phase 3b, proceed to Phase 4.
+
+**If the file contains queries**:
+1. Keep only queries targeting CRITICAL gaps: `current_relevant <= 1`
+2. Drop queries for dimensions with 2+ relevant results (already adequate)
+3. Cap at 5 queries maximum
+
+**If no queries remain after filtering**: skip Phase 3b, proceed to Phase 4.
+
+**Run the gap queries**:
+```bash
+python lib/search_runner.py '[{...filtered queries...}]' >> results.jsonl
+```
+
+Re-run `llm-evaluate.md` on the NEW results only (those not already evaluated).
+Append new per-query tracking records to `state/query-outcomes.jsonl`.
+
+**Rules**:
+- Run Phase 3b at most ONCE per session — no recursive loops
+- If Phase 3b produces 0 new relevant results, log the gap as "unfillable this session"
+- Do NOT update `state/timing.json` end_ts after Phase 3b (latency measures the initial pipeline)
+
+Time: ~15-30 seconds (5 queries max)
 
 # Phase 4: Synthesize + Deliver
 


### PR DESCRIPTION
## Summary

Closes the feedback granularity gap between AutoSearch and academic state-of-art (SE-Search, ACE). Three changes that move evolution from session-level to query-level:

- **llm-evaluate**: `next_queries` now written to `evidence/{session_id}-next-queries.jsonl` with `gap_dimension` + `current_relevant` tags (previously produced in-context then discarded)
- **pipeline-flow**: Phase 3a computes per-query metrics to `state/query-outcomes.jsonl`. Phase 3b runs bounded gap search (critical gaps only, max 5 queries, at most once)
- **gene-query**: Reads `query-outcomes.jsonl` to boost proven queries (relevant_rate >= 0.7) and suppress failures (relevant_rate <= 0.2). Adds atomic query rule (3-5 words default)

## Data flow before vs after

```
BEFORE: search → evaluate → [next_queries discarded] → synthesize
AFTER:  search → evaluate → write next_queries file
                          → Phase 3a: per-query tracking
                          → Phase 3b: gap loop-back (conditional)
                          → synthesize
```

## New state files (created by pipeline execution)

- `state/query-outcomes.jsonl` — one record per query per session, append-only
- `evidence/{session_id}-next-queries.jsonl` — per-session gap queries

## Test plan

- [x] 215 tests pass
- [ ] Run /autosearch session and verify query-outcomes.jsonl created
- [ ] Verify next-queries.jsonl has gap_dimension + current_relevant fields
- [ ] If critical gaps exist, verify Phase 3b ran
- [ ] Second session: verify gene-query includes boosted queries from prior session

🤖 Generated with [Claude Code](https://claude.com/claude-code)