### PR TITLE
fix: git hygiene — gitignore, env.example, secret patterns (F003)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ state/*.json
 state/delivery/
 state/knowledge-maps/
 state/session-*
+state/research-contexts/
 
 # Evidence — generated search results (keep .gitkeep for directory structure)
 evidence/*.jsonl

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,7 +9,7 @@ if [ -z "$PROJECT_COMMITTER" ]; then
 fi
 
 # Secret detection
-SECRET_PATTERNS='(API_KEY|SECRET_KEY|PRIVATE_KEY|AUTH_TOKEN|PASSWORD)\s*=\s*["\x27][^\s"'\'']+|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AIzaSy[a-zA-Z0-9_-]{33}'
+SECRET_PATTERNS='(API_KEY|SECRET_KEY|PRIVATE_KEY|AUTH_TOKEN|PASSWORD)\s*=\s*["\x27][^\s"'\'']+|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AIzaSy[a-zA-Z0-9_-]{33}|sk-ant-[a-zA-Z0-9_-]{40,}|sk-or-[a-zA-Z0-9_-]{20,}|tvly-[a-zA-Z0-9_-]{20,}|github_pat_[a-zA-Z0-9_]{22,}|exa-[a-zA-Z0-9_-]{20,}'
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.example$|\.test\.py$|tests/fixtures/|\.md$)' || true)
 if [ -n "$STAGED_FILES" ]; then
   MATCHES=$(echo "$STAGED_FILES" | while IFS= read -r f; do grep -nEH "$SECRET_PATTERNS" "$f" 2>/dev/null; done || true)

--- a/env.example
+++ b/env.example
@@ -10,3 +10,12 @@
 
 # SearXNG — local meta-search instance (default: http://localhost:8888)
 # SEARXNG_URL=http://localhost:8888
+
+# OpenRouter — used by integration tests for LLM judge scoring
+# OPENROUTER_API_KEY=
+
+# xReach — social media search
+# XREACH_API_KEY=
+
+# YouTube — innertube API key for pagination (public key, embedded in YouTube pages)
+# YOUTUBE_INNERTUBE_KEY=


### PR DESCRIPTION
## Summary

- Add `state/research-contexts/` to `.gitignore`
- Add `OPENROUTER_API_KEY`, `XREACH_API_KEY`, `YOUTUBE_INNERTUBE_KEY` to `env.example`
- Add modern secret key patterns to pre-commit hook: `sk-ant-`, `sk-or-`, `tvly-`, `github_pat_`, `exa-`

## Test plan

- [x] `grep research-contexts .gitignore` matches
- [x] `env.example` has 3 new keys
- [x] Pre-commit detects `sk-or-` and `sk-ant-` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)