### PR TITLE
fix: code quality — XSS, dedup, shell safety, comments (F006)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.04.7"
+    "version": "2026.04.04.8"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.04.7",
+      "version": "2026.04.04.8",
       "author": {
         "name": "0xmariowu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.04.7",
+  "version": "2026.04.04.8",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.04.8
+
 ## 2026.04.04.7
 
 ### Changes

--- a/channels/bilibili/search.py
+++ b/channels/bilibili/search.py
@@ -46,7 +46,7 @@ def _parse_duration(duration: str) -> tuple[str, int | None]:
     for part in parts:
         total = total * 60 + int(part)
 
-    # SearXNG discards durations that appear to exceed one hour.
+    # Discard durations exceeding one hour (likely misparse).
     if total > 60 * 60:
         return "", None
     return raw, total

--- a/lib/assemble_html.py
+++ b/lib/assemble_html.py
@@ -18,6 +18,7 @@ with <section id="..."> and <h2>/<h3> for TOC generation.
 from __future__ import annotations
 
 import argparse
+import html as html_stdlib  # noqa: F811 — shadows local `html` var in assemble()
 import json
 import re
 import sys
@@ -114,7 +115,7 @@ def assemble(body_path: Path, meta: dict, output_path: Path) -> None:
 
     html = template
     html = html.replace("{{LANG}}", lang)
-    html = html.replace("{{TITLE}}", title)
+    html = html.replace("{{TITLE}}", html_stdlib.escape(title))
     html = html.replace("{{TOC}}", toc)
     html = html.replace("{{BODY}}", body)
     html = html.replace("{{FOOTER}}", footer)

--- a/lib/assemble_slides.py
+++ b/lib/assemble_slides.py
@@ -14,17 +14,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
+from lib.assemble_html import detect_lang
+
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATE_PATH = ROOT / "lib" / "templates" / "slides.html"
-
-
-def detect_lang(body: str) -> str:
-    chinese_chars = len(re.findall(r"[\u4e00-\u9fff]", body[:2000]))
-    return "zh-CN" if chinese_chars > 50 else "en"
 
 
 def assemble(body_path: Path, meta: dict, output_path: Path) -> None:

--- a/scripts/run_search.sh
+++ b/scripts/run_search.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 VENV_PYTHON="$HOME/.autosearch/venv/bin/python"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SEARCH_RUNNER="$SCRIPT_DIR/../lib/search_runner.py"


### PR DESCRIPTION
## Summary

- HTML-escape title in `assemble_html.py` to prevent XSS
- Deduplicate `detect_lang` — `assemble_slides.py` now imports from `assemble_html`
- Add `set -euo pipefail` to `run_search.sh`
- Fix misleading SearXNG comment in `bilibili/search.py`

## Test plan

- [x] `grep html_stdlib.escape lib/assemble_html.py` matches
- [x] `grep "from lib.assemble_html import detect_lang" lib/assemble_slides.py` matches
- [x] `grep SearXNG channels/bilibili/search.py` returns empty
- [x] ruff clean, 408 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)