### PR TITLE
fix: remove exec re-exec from pre-push hook (F007)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,18 +7,14 @@ if [ "$branch" = "main" ]; then
   exit 0
 fi
 
-# Rebase on main, then re-exec to pick up any hook changes from rebased commits
-if [ "${_HUSKY_POST_REBASE:-}" != "1" ]; then
-  git fetch origin main --quiet
-  if ! git rebase origin/main --quiet; then
-    echo "Rebase on main failed — resolve conflicts first."
-    git rebase --abort
-    exit 1
-  fi
-  echo "Rebased on origin/main"
-  export _HUSKY_POST_REBASE=1
-  exec bash "$(git rev-parse --show-toplevel)/.husky/pre-push" "$@"
+# Rebase on main before push
+git fetch origin main --quiet
+if ! git rebase origin/main --quiet; then
+  echo "Rebase on main failed — resolve conflicts first."
+  git rebase --abort
+  exit 1
 fi
+echo "Rebased on origin/main"
 
 # Prefer project venv (has pytest and all deps), fall back to uv-managed Python 3.11+
 # In worktrees, --show-toplevel points to the worktree, not the main repo.


### PR DESCRIPTION
## Summary

- Remove `exec bash` re-exec after rebase in `.husky/pre-push`
- Rebase now falls through directly to pytest and version check
- Eliminates re-execution attack surface (M3 from security audit)

## Test plan

- [x] `grep "exec bash" .husky/pre-push` returns empty
- [x] `bash -n .husky/pre-push` passes syntax check
- [x] Hook structure: (1) main passthrough → (2) fetch+rebase → (3) pytest → (4) version check

🤖 Generated with [Claude Code](https://claude.com/claude-code)