### PR TITLE
refactor: lazy-load channel plugins on first use (F008)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.04.7"
+    "version": "2026.04.04.8"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.04.7",
+      "version": "2026.04.04.8",
       "author": {
         "name": "0xmariowu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.04.7",
+  "version": "2026.04.04.8",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.04.8
+
 ## 2026.04.04.7
 
 ### Changes

--- a/lib/search_runner.py
+++ b/lib/search_runner.py
@@ -331,7 +331,14 @@ def make_result(
 
 # --- Channel execution ---
 
-CHANNEL_METHODS = load_channel_plugins()
+CHANNEL_METHODS: dict | None = None
+
+
+def _ensure_channels_loaded() -> None:
+    """Lazy-load channel plugins on first use, not at import time."""
+    global CHANNEL_METHODS
+    if CHANNEL_METHODS is None:
+        CHANNEL_METHODS = load_channel_plugins()
 
 
 async def run_single_query(query_obj: dict) -> list[dict]:
@@ -351,6 +358,7 @@ async def run_single_query(query_obj: dict) -> list[dict]:
         )
         return []
 
+    _ensure_channels_loaded()
     method = CHANNEL_METHODS.get(channel)
     if method is None:
         print(f"[search_runner] unknown channel: {channel}", file=sys.stderr)


### PR DESCRIPTION
## Summary

- `CHANNEL_METHODS` initialized as `None`, loaded on first `run_single_query()` call
- Importing `search_runner` no longer triggers all 33 channel imports at module load time
- All 11 existing test patches remain compatible (they replace the module attribute directly)

## Test plan

- [x] `python3 -c "from lib import search_runner; assert search_runner.CHANNEL_METHODS is None"` passes
- [x] 28 core tests pass (circuit breaker, retry, engine mocks)
- [x] 408 full tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)