### PR TITLE
feat: scoring, convergence detection, query-type classification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.05.1"
+    "version": "2026.04.05.2"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.05.1",
+      "version": "2026.04.05.2",
       "author": {
         "name": "0xmariowu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.05.1",
+  "version": "2026.04.05.2",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check author emails in PR commits
         if: github.event_name == 'pull_request'
         run: |
-          BAD=$(git log --format='%ae' origin/main..HEAD \
+          BAD=$(git log --no-merges --format='%ae' origin/main..HEAD \
             | grep -v '@users.noreply.github.com' \
             | grep -v 'github-actions' \
             | grep -v 'dependabot' || true)
@@ -35,7 +35,7 @@ jobs:
       - name: Check author names in PR commits
         if: github.event_name == 'pull_request'
         run: |
-          BAD=$(git log --format='%an' origin/main..HEAD \
+          BAD=$(git log --no-merges --format='%an' origin/main..HEAD \
             | grep -v '0xmariowu' \
             | grep -v 'github-actions' \
             | grep -v 'dependabot' || true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.05.2
+
+### Changes
+
+- You can now see how results rank across platforms — per-platform engagement scoring with composite scores (relevance + recency + engagement)
+- You can now see when the same topic appears on multiple platforms — cross-source convergence detection adds "also on" annotations
+- Search queries are now classified by type (how-to, comparison, opinion, etc.) for smarter source prioritization
+
+---
+
 ## 2026.04.05.1
 
 ### Changes

--- a/lib/convergence.py
+++ b/lib/convergence.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+import sys
+
+SIMILARITY_THRESHOLD = 0.40
+MAX_RESULTS_LIMIT = 500  # O(N^2) safety guard
+STOPWORDS = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "and",
+        "or",
+        "but",
+        "not",
+        "with",
+        "from",
+        "by",
+        "as",
+        "it",
+        "this",
+        "that",
+        "be",
+        "have",
+        "has",
+        "do",
+        "will",
+        "can",
+    }
+)
+
+
+def _tokenize(text: str) -> set[str]:
+    tokens = re.sub(r"[^\w\s]", " ", text.lower()).split()
+    return {token for token in tokens if len(token) > 1 and token not in STOPWORDS}
+
+
+def _jaccard(tokens_a: set[str], tokens_b: set[str]) -> float:
+    union = tokens_a | tokens_b
+    if not union:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(union)
+
+
+def cross_source_link(results: list[dict]) -> None:
+    if len(results) > MAX_RESULTS_LIMIT:
+        print(
+            f"warning: skipping cross-source linking for {len(results)} results "
+            f"(limit: {MAX_RESULTS_LIMIT})",
+            file=sys.stderr,
+        )
+        return
+
+    title_tokens = [_tokenize(result.get("title", "")) for result in results]
+
+    for i in range(len(results)):
+        source_i = results[i].get("source")
+        for j in range(i + 1, len(results)):
+            source_j = results[j].get("source")
+            if source_i == source_j:
+                continue
+
+            if _jaccard(title_tokens[i], title_tokens[j]) < SIMILARITY_THRESHOLD:
+                continue
+
+            metadata_i = results[i].setdefault("metadata", {})
+            metadata_j = results[j].setdefault("metadata", {})
+            metadata_i.setdefault("also_on", []).append(source_j)
+            metadata_j.setdefault("also_on", []).append(source_i)
+
+    for result in results:
+        metadata = result.get("metadata")
+        if not metadata or "also_on" not in metadata:
+            continue
+        metadata["also_on"] = sorted(set(metadata["also_on"]))

--- a/lib/query_type.py
+++ b/lib/query_type.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+QueryType = Literal[
+    "product",
+    "concept",
+    "opinion",
+    "how_to",
+    "comparison",
+    "breaking_news",
+    "prediction",
+]
+
+_QUERY_PATTERNS: dict[QueryType, re.Pattern[str]] = {
+    "comparison": re.compile(
+        r"\b(?:vs|versus|compared to|comparison|better than|difference between)\b",
+        re.IGNORECASE,
+    ),
+    "how_to": re.compile(
+        r"\b(?:how to|tutorial|step by step|setup|install|configure|deploy|best practices|tips)\b",
+        re.IGNORECASE,
+    ),
+    "product": re.compile(
+        r"\b(?:price|cost|buy|deal|alternative|subscription|plan|tier)\b",
+        re.IGNORECASE,
+    ),
+    "opinion": re.compile(
+        r"\b(?:worth it|thoughts on|opinion|review|experience with|recommend|should i|pros and cons)\b",
+        re.IGNORECASE,
+    ),
+    "prediction": re.compile(
+        r"\b(?:predict|forecast|odds|chance|probability|election|outcome)\b",
+        re.IGNORECASE,
+    ),
+    "concept": re.compile(
+        r"\b(?:what is|explain|definition|how does|overview|introduction|guide to)\b",
+        re.IGNORECASE,
+    ),
+    "breaking_news": re.compile(
+        r"\b(?:latest|breaking|just announced|launched|released|new|update|news|today|this week)\b",
+        re.IGNORECASE,
+    ),
+}
+
+_QUERY_PRIORITY: tuple[QueryType, ...] = (
+    "comparison",
+    "how_to",
+    "product",
+    "opinion",
+    "prediction",
+    "concept",
+    "breaking_news",
+)
+
+SOURCE_TIERS: dict[QueryType, dict[str, list[str]]] = {
+    "product": {
+        "tier1": ["reddit", "twitter", "youtube"],
+        "tier2": ["web-ddgs", "hn"],
+    },
+    "concept": {
+        "tier1": ["reddit", "hn", "web-ddgs"],
+        "tier2": ["youtube", "twitter", "arxiv"],
+    },
+    "opinion": {
+        "tier1": ["reddit", "twitter"],
+        "tier2": ["youtube", "hn"],
+    },
+    "how_to": {
+        "tier1": ["youtube", "reddit", "hn"],
+        "tier2": ["web-ddgs", "stackoverflow"],
+    },
+    "comparison": {
+        "tier1": ["reddit", "hn", "youtube"],
+        "tier2": ["twitter", "web-ddgs"],
+    },
+    "breaking_news": {
+        "tier1": ["twitter", "reddit", "web-ddgs"],
+        "tier2": ["hn", "youtube"],
+    },
+    "prediction": {
+        "tier1": ["twitter", "reddit"],
+        "tier2": ["web-ddgs", "hn", "youtube"],
+    },
+}
+
+WEBSEARCH_PENALTY: dict[QueryType, float] = {
+    "product": 15.0,
+    "concept": 0.0,
+    "opinion": 15.0,
+    "how_to": 5.0,
+    "comparison": 10.0,
+    "breaking_news": 10.0,
+    "prediction": 15.0,
+}
+
+TIEBREAKER_ORDER: dict[QueryType, dict[str, int]] = {
+    "breaking_news": {
+        "twitter": 0,
+        "reddit": 1,
+        "web-ddgs": 2,
+        "hn": 3,
+        "youtube": 4,
+    },
+    "how_to": {
+        "youtube": 0,
+        "reddit": 1,
+        "hn": 2,
+        "web-ddgs": 3,
+        "stackoverflow": 4,
+        "twitter": 5,
+    },
+    "prediction": {
+        "twitter": 0,
+        "reddit": 1,
+        "web-ddgs": 2,
+        "hn": 3,
+        "youtube": 4,
+    },
+    "concept": {
+        "hn": 0,
+        "reddit": 1,
+        "web-ddgs": 2,
+        "youtube": 3,
+        "arxiv": 4,
+        "twitter": 5,
+    },
+    "opinion": {
+        "reddit": 0,
+        "twitter": 1,
+        "youtube": 2,
+        "hn": 3,
+        "web-ddgs": 4,
+    },
+    "product": {
+        "reddit": 0,
+        "twitter": 1,
+        "youtube": 2,
+        "hn": 3,
+        "web-ddgs": 4,
+    },
+    "comparison": {
+        "reddit": 0,
+        "hn": 1,
+        "youtube": 2,
+        "twitter": 3,
+        "web-ddgs": 4,
+    },
+}
+
+
+def detect_query_type(query: str) -> QueryType:
+    for query_type in _QUERY_PRIORITY:
+        if _QUERY_PATTERNS[query_type].search(query):
+            return query_type
+    return "breaking_news"
+
+
+def get_source_penalty(query_type: QueryType, source: str) -> float:
+    if source == "web-ddgs":
+        return WEBSEARCH_PENALTY[query_type]
+    return 0.0
+
+
+def get_tiebreaker(query_type: QueryType, source: str) -> int:
+    return TIEBREAKER_ORDER.get(query_type, {}).get(source, 99)
+
+
+def is_source_in_tier(query_type: QueryType, source: str) -> bool:
+    tiers = SOURCE_TIERS.get(query_type, {})
+    return source in tiers.get("tier1", []) or source in tiers.get("tier2", [])

--- a/lib/scoring.py
+++ b/lib/scoring.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import datetime
+import math
+import re
+
+WORD_RE = re.compile(r"\w+")
+DATE_FIELDS = ("published_at", "created_utc", "updated_at")
+RELEVANCE_WEIGHT = 0.45
+RECENCY_WEIGHT = 0.25
+ENGAGEMENT_WEIGHT = 0.30
+SOURCE_ALIASES = {
+    "github": "github-repos",
+    "x": "twitter",
+}
+
+
+PLATFORM_FORMULAS = {
+    "reddit": lambda m: (
+        0.50 * math.log1p(m.get("score", 0))
+        + 0.35 * math.log1p(m.get("num_comments", 0))
+        + 0.05 * (m.get("upvote_ratio", 0.5) * 10)
+        + 0.10 * math.log1p(_top_comment_score(m))
+    ),
+    "hn": lambda m: (
+        0.55 * math.log1p(m.get("points", 0))
+        + 0.45 * math.log1p(m.get("num_comments", 0))
+    ),
+    "youtube": lambda m: (
+        0.50 * math.log1p(m.get("views", 0))
+        + 0.35 * math.log1p(m.get("likes", 0))
+        + 0.15 * math.log1p(m.get("num_comments", 0))
+    ),
+    "github-repos": lambda m: (
+        0.70 * math.log1p(m.get("stars", 0)) + 0.30 * math.log1p(m.get("forks", 0))
+    ),
+    "stackoverflow": lambda m: (
+        0.50 * math.log1p(m.get("score", 0))
+        + 0.30 * math.log1p(m.get("answer_count", 0))
+        + 0.20 * float(m.get("is_answered", False))
+    ),
+    "twitter": lambda m: (
+        0.50 * math.log1p(m.get("likes", 0))
+        + 0.30 * math.log1p(m.get("reposts", 0))
+        + 0.20 * math.log1p(m.get("replies", 0))
+    ),
+}
+
+
+def score_results(results: list[dict], query: str) -> None:
+    """Add metadata['composite_score'] (0-100) to each result, then sort descending."""
+    try:
+        from lib.query_type import detect_query_type, get_source_penalty
+    except ImportError:
+        detect_query_type = None
+        get_source_penalty = None
+
+    query_type = detect_query_type(query) if detect_query_type else "breaking_news"
+
+    normalize_engagement_scores(results)
+
+    for result in results:
+        relevance = semantic_score(query, result)
+        recency = freshness_score(result)
+        engagement = _clamp01(_coerce_float(result.get("engagement_score"), 0.5))
+        composite = (
+            RELEVANCE_WEIGHT * relevance
+            + RECENCY_WEIGHT * recency
+            + ENGAGEMENT_WEIGHT * engagement
+        )
+        score_100 = max(0, min(100, int(round(_clamp01(composite) * 100))))
+
+        # Apply query-type source penalty (e.g., web-ddgs penalized for opinion queries)
+        if get_source_penalty is not None:
+            penalty = get_source_penalty(query_type, result.get("source", ""))
+            score_100 = max(0, score_100 - int(penalty))
+
+        result.setdefault("metadata", {})["composite_score"] = score_100
+
+    # Clean up internal engagement_score from top-level result dict
+    for result in results:
+        result.pop("engagement_score", None)
+
+    results.sort(
+        key=lambda r: r.get("metadata", {}).get("composite_score", 0), reverse=True
+    )
+
+
+def semantic_score(query: str, result: dict) -> float:
+    query_tokens = {token.lower() for token in WORD_RE.findall(query or "")}
+    title = str(result.get("title", "") or "")
+    snippet = str(result.get("snippet", "") or "")
+    text_tokens = {token.lower() for token in WORD_RE.findall(f"{title} {snippet}")}
+    union = query_tokens | text_tokens
+    if not union:
+        return 0.0
+    return len(query_tokens & text_tokens) / len(union)
+
+
+def freshness_score(result: dict) -> float:
+    return _freshness_score_at(result, datetime.datetime.now(datetime.timezone.utc))
+
+
+def _top_comment_score(metadata: dict) -> int:
+    value = metadata.get("top_comment_score", 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def raw_engagement(source: str, metadata: dict) -> float:
+    platform = SOURCE_ALIASES.get((source or "").lower(), (source or "").lower())
+    formula = PLATFORM_FORMULAS.get(platform)
+    if formula is None:
+        return 0.0
+    return float(formula(metadata))
+
+
+def normalize_engagement_scores(results: list[dict]) -> None:
+    groups: dict[str, list[tuple[dict, float]]] = {}
+
+    for result in results:
+        source = str(result.get("source", "") or "")
+        metadata = _merged_metrics(result)
+        score = raw_engagement(source, metadata)
+        groups.setdefault(source, []).append((result, score))
+
+    for group in groups.values():
+        values = [score for _, score in group]
+        low = min(values)
+        high = max(values)
+
+        if low == high:
+            for result, _ in group:
+                result["engagement_score"] = 0.5
+            continue
+
+        scale = high - low
+        for result, score in group:
+            result["engagement_score"] = (score - low) / scale
+
+
+def _freshness_score_at(result: dict, now: datetime.datetime | None = None) -> float:
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    value = _get_date_value(result)
+    if not value:
+        return 0.5
+
+    parsed = _parse_iso_datetime(value)
+    if parsed is None:
+        return 0.5
+
+    age_days = (now.date() - parsed.astimezone(datetime.timezone.utc).date()).days
+    score = 1.0 - (age_days / 180.0)
+    return _clamp01(score)
+
+
+def _get_date_value(result: dict) -> str:
+    metadata = result.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    for name in DATE_FIELDS:
+        value = metadata.get(name)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _parse_iso_datetime(value: str) -> datetime.datetime | None:
+    text = value.strip()
+    if not text:
+        return None
+
+    try:
+        parsed = datetime.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def _merged_metrics(result: dict) -> dict:
+    merged: dict = {}
+    metadata = result.get("metadata")
+    if isinstance(metadata, dict):
+        merged.update(metadata)
+
+    for key, value in result.items():
+        if key == "metadata":
+            continue
+        merged.setdefault(key, value)
+
+    return merged
+
+
+def _coerce_float(value: object, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))

--- a/lib/search_runner.py
+++ b/lib/search_runner.py
@@ -445,10 +445,23 @@ def dedup_results(results: list[dict]) -> list[dict]:
         if not url:
             continue
         key = normalize_url(url)
-        if key not in seen or len(json.dumps(result.get("metadata", {}))) > len(
-            json.dumps(seen[key].get("metadata", {}))
-        ):
+        if key not in seen:
             seen[key] = result
+        else:
+            winner = seen[key]
+            loser = result
+            # Keep the result with richer metadata
+            if len(json.dumps(result.get("metadata", {}))) > len(
+                json.dumps(winner.get("metadata", {}))
+            ):
+                winner, loser = result, winner
+                seen[key] = winner
+            # Track which sources contributed this URL
+            loser_source = loser.get("source", "")
+            if loser_source:
+                winner.setdefault("metadata", {}).setdefault("seen_sources", []).append(
+                    loser_source
+                )
     return list(seen.values())
 
 
@@ -479,6 +492,23 @@ async def main(queries: list[dict]) -> None:
             continue
         all_results.extend(result)
     unique_results = dedup_results(all_results)
+
+    # Post-processing: score and cross-link
+    if unique_results:
+        try:
+            from lib.scoring import score_results
+
+            query_text = queries[0].get("query", "") if queries else ""
+            score_results(unique_results, query_text)
+        except Exception as exc:
+            print(f"[search_runner] scoring failed: {exc}", file=sys.stderr)
+        try:
+            from lib.convergence import cross_source_link
+
+            cross_source_link(unique_results)
+        except Exception as exc:
+            print(f"[search_runner] convergence failed: {exc}", file=sys.stderr)
+
     for result in unique_results:
         print(json.dumps(result, ensure_ascii=False))
 

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -1,0 +1,81 @@
+from lib.convergence import _jaccard, _tokenize, cross_source_link
+
+
+def _make_result(title, source):
+    return {
+        "url": f"https://example.com/{source}/{title.replace(' ', '-')}",
+        "title": title,
+        "snippet": "",
+        "source": source,
+        "metadata": {},
+    }
+
+
+def test_cross_source_link_different_sources():
+    results = [
+        _make_result("OpenAI launches AI agents platform", "reddit"),
+        _make_result("OpenAI launches new AI agents platform", "twitter"),
+    ]
+
+    cross_source_link(results)
+
+    assert results[0]["metadata"]["also_on"] == ["twitter"]
+    assert results[1]["metadata"]["also_on"] == ["reddit"]
+
+
+def test_cross_source_link_same_source_skipped():
+    results = [
+        _make_result("OpenAI launches AI agents platform", "reddit"),
+        _make_result("OpenAI launches new AI agents platform", "reddit"),
+    ]
+
+    cross_source_link(results)
+
+    assert "also_on" not in results[0]["metadata"]
+    assert "also_on" not in results[1]["metadata"]
+
+
+def test_cross_source_link_below_threshold():
+    results = [
+        _make_result("OpenAI launches AI agents platform", "reddit"),
+        _make_result("Best sourdough bread recipe", "twitter"),
+    ]
+
+    cross_source_link(results)
+
+    assert "also_on" not in results[0]["metadata"]
+    assert "also_on" not in results[1]["metadata"]
+
+
+def test_cross_source_link_empty_input():
+    results = []
+
+    cross_source_link(results)
+
+    assert results == []
+
+
+def test_jaccard_identical():
+    tokens = _tokenize("OpenAI launches AI agents platform")
+
+    assert _jaccard(tokens, tokens) == 1.0
+
+
+def test_jaccard_disjoint():
+    tokens_a = _tokenize("OpenAI launches AI agents platform")
+    tokens_b = _tokenize("Best sourdough bread recipe")
+
+    assert _jaccard(tokens_a, tokens_b) == 0.0
+
+
+def test_also_on_sorted_and_deduped():
+    results = [
+        _make_result("OpenAI launches AI agents platform", "reddit"),
+        _make_result("OpenAI launches new AI agents platform", "youtube"),
+        _make_result("OpenAI launches AI agents platform today", "twitter"),
+        _make_result("OpenAI launches AI agents platform update", "twitter"),
+    ]
+
+    cross_source_link(results)
+
+    assert results[0]["metadata"]["also_on"] == ["twitter", "youtube"]

--- a/tests/test_query_type.py
+++ b/tests/test_query_type.py
@@ -1,0 +1,59 @@
+from lib.query_type import (
+    detect_query_type,
+    get_source_penalty,
+    get_tiebreaker,
+    is_source_in_tier,
+)
+
+
+def test_detect_comparison():
+    assert detect_query_type("React vs Vue") == "comparison"
+
+
+def test_detect_how_to():
+    assert detect_query_type("how to deploy kubernetes") == "how_to"
+
+
+def test_detect_product():
+    assert detect_query_type("best alternative to Slack") == "product"
+
+
+def test_detect_opinion():
+    assert detect_query_type("is Claude worth it") == "opinion"
+
+
+def test_detect_prediction():
+    assert detect_query_type("election forecast 2028") == "prediction"
+
+
+def test_detect_concept():
+    assert detect_query_type("what is transformer architecture") == "concept"
+
+
+def test_detect_default_breaking_news():
+    assert detect_query_type("AI agents") == "breaking_news"
+
+
+def test_priority_comparison_over_opinion():
+    assert detect_query_type("is React better than Vue") == "comparison"
+
+
+def test_get_source_penalty_web_ddgs():
+    assert get_source_penalty("product", "web-ddgs") == 15.0
+
+
+def test_get_source_penalty_non_web():
+    assert get_source_penalty("product", "reddit") == 0.0
+
+
+def test_get_tiebreaker_known():
+    assert get_tiebreaker("comparison", "hn") == 1
+
+
+def test_get_tiebreaker_unknown():
+    assert get_tiebreaker("comparison", "unknown-source") == 99
+
+
+def test_is_source_in_tier():
+    assert is_source_in_tier("opinion", "reddit") is True
+    assert is_source_in_tier("opinion", "some-random-source") is False

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,130 @@
+import datetime
+
+import pytest
+
+from lib.scoring import (
+    freshness_score,
+    normalize_engagement_scores,
+    raw_engagement,
+    score_results,
+    semantic_score,
+)
+
+
+def _make_result(source="reddit", title="Test", snippet="test snippet", score=0, **meta):
+    return {
+        "url": f"https://example.com/{id(meta)}",
+        "title": title,
+        "snippet": snippet,
+        "source": source,
+        "query": "test",
+        "metadata": {"score": score, **meta},
+    }
+
+
+def test_score_results_adds_composite_score():
+    results = [_make_result(title="AI agents", snippet="latest AI agents news")]
+
+    score_results(results, "AI agents")
+
+    assert "composite_score" in results[0]["metadata"]
+
+
+def test_composite_score_range():
+    today = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    results = [
+        _make_result(title="AI agents", score=100, published_at=today),
+        _make_result(title="cooking recipes", score=0, published_at="2020-01-01T00:00:00+00:00"),
+    ]
+
+    score_results(results, "AI agents")
+
+    for result in results:
+        composite_score = result["metadata"]["composite_score"]
+        assert isinstance(composite_score, int)
+        assert 0 <= composite_score <= 100
+
+
+def test_results_sorted_by_score():
+    today = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    old_date = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=200)).isoformat()
+    results = [
+        _make_result(title="cooking recipes", score=1, published_at=old_date),
+        _make_result(title="AI agents", score=100, published_at=today),
+        _make_result(title="AI agents", score=10, published_at=old_date),
+    ]
+
+    score_results(results, "AI agents")
+
+    scores = [result["metadata"]["composite_score"] for result in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_semantic_score_exact_match():
+    result = _make_result(title="AI agents framework", snippet="")
+
+    score = semantic_score("AI agents", result)
+
+    assert score > 0.5
+
+
+def test_semantic_score_no_overlap():
+    result = _make_result(title="cooking recipes", snippet="")
+
+    assert semantic_score("AI agents", result) == 0.0
+
+
+def test_freshness_score_recent():
+    result = _make_result(
+        published_at=datetime.datetime.now(datetime.timezone.utc).isoformat()
+    )
+
+    score = freshness_score(result)
+
+    assert score == pytest.approx(1.0, abs=0.01)
+
+
+def test_freshness_score_old():
+    result = _make_result(
+        published_at=(
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=200)
+        ).isoformat()
+    )
+
+    assert freshness_score(result) == 0.0
+
+
+def test_freshness_score_missing_date():
+    result = _make_result()
+
+    assert freshness_score(result) == 0.5
+
+
+def test_normalize_engagement_single_item():
+    results = [_make_result(source="reddit", score=42)]
+
+    normalize_engagement_scores(results)
+
+    assert results[0]["engagement_score"] == 0.5
+
+
+def test_normalize_engagement_range():
+    results = [
+        _make_result(source="reddit", score=1, num_comments=0),
+        _make_result(source="reddit", score=100, num_comments=50),
+    ]
+
+    normalize_engagement_scores(results)
+
+    assert results[0]["engagement_score"] == pytest.approx(0.0)
+    assert results[1]["engagement_score"] == pytest.approx(1.0)
+
+
+def test_raw_engagement_reddit():
+    value = raw_engagement(
+        "reddit",
+        {"score": 100, "num_comments": 50, "upvote_ratio": 0.9, "top_comment_score": 10},
+    )
+
+    assert isinstance(value, float)
+    assert value > 0.0

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -11,7 +11,9 @@ from lib.scoring import (
 )
 
 
-def _make_result(source="reddit", title="Test", snippet="test snippet", score=0, **meta):
+def _make_result(
+    source="reddit", title="Test", snippet="test snippet", score=0, **meta
+):
     return {
         "url": f"https://example.com/{id(meta)}",
         "title": title,
@@ -34,7 +36,9 @@ def test_composite_score_range():
     today = datetime.datetime.now(datetime.timezone.utc).isoformat()
     results = [
         _make_result(title="AI agents", score=100, published_at=today),
-        _make_result(title="cooking recipes", score=0, published_at="2020-01-01T00:00:00+00:00"),
+        _make_result(
+            title="cooking recipes", score=0, published_at="2020-01-01T00:00:00+00:00"
+        ),
     ]
 
     score_results(results, "AI agents")
@@ -47,7 +51,9 @@ def test_composite_score_range():
 
 def test_results_sorted_by_score():
     today = datetime.datetime.now(datetime.timezone.utc).isoformat()
-    old_date = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=200)).isoformat()
+    old_date = (
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=200)
+    ).isoformat()
     results = [
         _make_result(title="cooking recipes", score=1, published_at=old_date),
         _make_result(title="AI agents", score=100, published_at=today),
@@ -123,7 +129,12 @@ def test_normalize_engagement_range():
 def test_raw_engagement_reddit():
     value = raw_engagement(
         "reddit",
-        {"score": 100, "num_comments": 50, "upvote_ratio": 0.9, "top_comment_score": 10},
+        {
+            "score": 100,
+            "num_comments": 50,
+            "upvote_ratio": 0.9,
+            "top_comment_score": 10,
+        },
     )
 
     assert isinstance(value, float)


### PR DESCRIPTION
## Summary

- **Per-platform engagement scoring**: Composite score (0-100) combining relevance (0.45), recency (0.25), and engagement (0.30). Platform-specific formulas for Reddit, HN, YouTube, GitHub, StackOverflow, Twitter using log1p compression with batch min-max normalization.
- **Cross-source convergence detection**: Word-token Jaccard similarity (threshold 0.40) between titles from different sources. Adds `metadata["also_on"]` annotations for cross-platform topic matches.
- **Query-type classifier**: Regex-based 7-type detection (comparison, how_to, product, opinion, prediction, concept, breaking_news). Source tier tables, websearch penalty by type, tiebreaker ordering.
- **Pipeline integration**: Scoring and convergence run after dedup in search_runner.py. `dedup_results()` now tracks `seen_sources` when merging duplicate URLs.

## New files

| File | Purpose |
|------|---------|
| `lib/query_type.py` | Query type classification + source routing tables |
| `lib/scoring.py` | Engagement formulas + composite scoring |
| `lib/convergence.py` | Cross-source Jaccard title linking |

## Test plan

- [x] 13 tests for query_type (7-type classification, priority, penalties, tiebreakers)
- [x] 11 tests for scoring (composite range, sorting, semantic/freshness/engagement)
- [x] 7 tests for convergence (same-source exclusion, threshold, dedup)
- [x] Full suite: 435 passed
- [x] Integration test: `search_runner.py` outputs `composite_score` in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)