### PR TITLE
feat: Reddit comment enrichment + HN metadata fix

### DIFF
--- a/channels/hn/search.py
+++ b/channels/hn/search.py
@@ -23,6 +23,8 @@ async def search(query: str, max_results: int = 10) -> list[dict]:
                     metadata["created_utc"] = h["created_at"]
                 if h.get("points"):
                     metadata["points"] = h["points"]
+                if h.get("num_comments") is not None:
+                    metadata["num_comments"] = h["num_comments"]
                 url = (
                     h.get("url")
                     or f"https://news.ycombinator.com/item?id={h.get('objectID', '')}"

--- a/lib/enrichment.py
+++ b/lib/enrichment.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+
+import httpx
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+)
+_COMMENT_FILLERS = ("I ", "You ", "This.", "Same", "Agreed", "Lol", "lol")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+async def enrich_reddit_items(
+    results: list[dict], max_items: int = 3, timeout_total: float = 5.0
+) -> None:
+    try:
+        reddit_results = [
+            result for result in results if result.get("source") == "reddit"
+        ]
+        reddit_results.sort(
+            key=lambda item: item.get("metadata", {}).get("composite_score", 0),
+            reverse=True,
+        )
+        selected_results = reddit_results[:max_items]
+        if not selected_results:
+            return
+
+        bail_event = asyncio.Event()
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            tasks = [
+                asyncio.create_task(_enrich_single(result, client, bail_event))
+                for result in selected_results
+            ]
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*tasks, return_exceptions=True),
+                    timeout=timeout_total,
+                )
+            except asyncio.TimeoutError:
+                print(
+                    f"[enrichment] timeout after {timeout_total}s",
+                    file=sys.stderr,
+                )
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                try:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                except Exception:
+                    pass
+    except Exception as exc:
+        print(f"[enrichment] {exc}", file=sys.stderr)
+        return
+
+
+async def _enrich_single(
+    result: dict, client: httpx.AsyncClient, bail_event: asyncio.Event
+) -> None:
+    try:
+        if bail_event.is_set():
+            return
+
+        path = urlparse(result["url"]).path
+        if not path:
+            return
+
+        try:
+            response = await client.get(
+                f"https://www.reddit.com{path}.json?raw_json=1",
+                headers={"User-Agent": USER_AGENT},
+            )
+        except Exception:
+            return
+
+        if response.status_code == 429:
+            bail_event.set()
+            return
+        if response.is_error:
+            return
+
+        try:
+            data = response.json()
+        except Exception:
+            return
+
+        if not isinstance(data, list) or len(data) < 2:
+            return
+
+        try:
+            post = data[0]["data"]["children"][0]["data"]
+            comment_nodes = data[1]["data"]["children"]
+        except Exception:
+            return
+
+        upvote_ratio_value = post.get("upvote_ratio", 0.0)
+        try:
+            upvote_ratio = float(upvote_ratio_value)
+        except (TypeError, ValueError):
+            upvote_ratio = 0.0
+
+        eligible_comments: list[tuple[int, dict[str, int | str], str]] = []
+        for node in comment_nodes:
+            if not isinstance(node, dict) or node.get("kind") != "t1":
+                continue
+
+            comment = node.get("data", {})
+            if not isinstance(comment, dict):
+                continue
+
+            author = str(comment.get("author", "") or "")
+            body = str(comment.get("body", "") or "")
+            if author in {"[deleted]", "[removed]"}:
+                continue
+
+            stripped_body = body.strip()
+            if stripped_body in {"[deleted]", "[removed]"}:
+                continue
+
+            try:
+                score = int(comment.get("score", 0))
+            except (TypeError, ValueError):
+                continue
+            if score < 1:
+                continue
+
+            created_utc = comment.get("created_utc")
+            if not isinstance(created_utc, (int, float)):
+                continue
+
+            eligible_comments.append(
+                (
+                    score,
+                    {
+                        "score": score,
+                        "author": author,
+                        "excerpt": stripped_body[:200],
+                        "date": datetime.fromtimestamp(
+                            created_utc, tz=timezone.utc
+                        ).isoformat(),
+                    },
+                    stripped_body,
+                )
+            )
+
+        eligible_comments.sort(key=lambda item: item[0], reverse=True)
+        eligible_comments = eligible_comments[:5]
+        top_comments = [item[1] for item in eligible_comments]
+        comment_insights = _extract_comment_insights(
+            [item[2] for item in eligible_comments]
+        )
+        metadata = result.setdefault("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+            result["metadata"] = metadata
+
+        metadata["upvote_ratio"] = upvote_ratio
+        metadata["top_comments"] = top_comments
+        metadata["comment_insights"] = comment_insights
+    except Exception as exc:
+        print(f"[enrichment] {exc}", file=sys.stderr)
+        return
+
+
+def _extract_comment_insights(comment_bodies: list[str]) -> list[str]:
+    insights: list[str] = []
+    seen: set[str] = set()
+
+    for body in comment_bodies:
+        text = body.strip()
+        if not text:
+            continue
+
+        for sentence in _SENTENCE_SPLIT_RE.split(text):
+            cleaned = sentence.strip()
+            if len(cleaned) <= 30:
+                continue
+            if cleaned.startswith(_COMMENT_FILLERS):
+                continue
+            if cleaned in seen:
+                continue
+
+            seen.add(cleaned)
+            insights.append(cleaned)
+            if len(insights) >= 3:
+                return insights
+
+    return insights

--- a/lib/search_runner.py
+++ b/lib/search_runner.py
@@ -508,6 +508,12 @@ async def main(queries: list[dict]) -> None:
             cross_source_link(unique_results)
         except Exception as exc:
             print(f"[search_runner] convergence failed: {exc}", file=sys.stderr)
+        try:
+            from lib.enrichment import enrich_reddit_items
+
+            await enrich_reddit_items(unique_results)
+        except Exception as exc:
+            print(f"[search_runner] enrichment failed: {exc}", file=sys.stderr)
 
     for result in unique_results:
         print(json.dumps(result, ensure_ascii=False))

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -8,7 +8,6 @@ import pytest
 
 from lib.enrichment import enrich_reddit_items
 
-
 MOCK_THREAD_JSON = [
     {
         "data": {

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.enrichment import enrich_reddit_items
+
+
+MOCK_THREAD_JSON = [
+    {
+        "data": {
+            "children": [
+                {
+                    "data": {
+                        "upvote_ratio": 0.95,
+                        "title": "Test Post",
+                        "selftext": "Test content",
+                        "score": 100,
+                        "num_comments": 5,
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "data": {
+            "children": [
+                {
+                    "kind": "t1",
+                    "data": {
+                        "author": "testuser",
+                        "body": "This is a really great and detailed comment about the topic at hand which should be long enough for insights.",
+                        "score": 50,
+                        "created_utc": 1712000000,
+                        "permalink": "/r/test/comments/abc/test_post/def",
+                    },
+                },
+                {
+                    "kind": "t1",
+                    "data": {
+                        "author": "[deleted]",
+                        "body": "[deleted]",
+                        "score": 30,
+                        "created_utc": 1712000000,
+                        "permalink": "/r/test/comments/abc/test_post/ghi",
+                    },
+                },
+            ]
+        }
+    },
+]
+
+
+def _make_result(
+    *,
+    source: str = "reddit",
+    url: str = "https://www.reddit.com/r/test/comments/abc/test_post/",
+    composite_score: float = 0,
+) -> dict:
+    return {
+        "url": url,
+        "title": "Test result",
+        "snippet": "Snippet",
+        "source": source,
+        "query": "test query",
+        "metadata": {"composite_score": composite_score},
+    }
+
+
+def _make_response(
+    *,
+    status_code: int = 200,
+    is_error: bool = False,
+    json_data: object | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.is_error = is_error
+    response.json = MagicMock(return_value=json_data)
+    return response
+
+
+def _setup_async_client(mock_async_client: MagicMock, get_impl: AsyncMock) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.get = get_impl
+    mock_async_client.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_async_client.return_value.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_enrich_adds_top_comments() -> None:
+    result = _make_result()
+
+    async def get(*args, **kwargs):
+        return _make_response(json_data=MOCK_THREAD_JSON)
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
+        await enrich_reddit_items([result], max_items=1)
+
+    top_comments = result["metadata"]["top_comments"]
+    assert isinstance(top_comments, list)
+    assert len(top_comments) == 1
+    assert top_comments[0] == {
+        "score": 50,
+        "author": "testuser",
+        "excerpt": "This is a really great and detailed comment about the topic at hand which should be long enough for insights.",
+        "date": datetime.fromtimestamp(1712000000, tz=timezone.utc).isoformat(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_enrich_adds_upvote_ratio() -> None:
+    result = _make_result()
+
+    async def get(*args, **kwargs):
+        return _make_response(json_data=MOCK_THREAD_JSON)
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
+        await enrich_reddit_items([result], max_items=1)
+
+    assert result["metadata"]["upvote_ratio"] == 0.95
+
+
+@pytest.mark.asyncio
+async def test_enrich_skips_non_reddit() -> None:
+    result = _make_result(source="hn", url="https://news.ycombinator.com/item?id=1")
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        await enrich_reddit_items([result], max_items=1)
+
+    mock_async_client.assert_not_called()
+    assert result["metadata"] == {"composite_score": 0}
+
+
+@pytest.mark.asyncio
+async def test_enrich_429_bails() -> None:
+    first = _make_result(
+        url="https://www.reddit.com/r/test/comments/abc/top_post/",
+        composite_score=10,
+    )
+    second = _make_result(
+        url="https://www.reddit.com/r/test/comments/def/second_post/",
+        composite_score=5,
+    )
+
+    responses = [
+        _make_response(status_code=429, is_error=True, json_data=None),
+        _make_response(json_data=MOCK_THREAD_JSON),
+    ]
+
+    async def get(*args, **kwargs):
+        return responses.pop(0)
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
+        await enrich_reddit_items([first, second], max_items=2)
+
+    assert "upvote_ratio" not in first["metadata"]
+    assert "top_comments" not in first["metadata"]
+    assert "upvote_ratio" not in second["metadata"]
+    assert "top_comments" not in second["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_filters_deleted_comments() -> None:
+    result = _make_result()
+
+    async def get(*args, **kwargs):
+        return _make_response(json_data=MOCK_THREAD_JSON)
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
+        await enrich_reddit_items([result], max_items=1)
+
+    top_comments = result["metadata"]["top_comments"]
+    assert len(top_comments) == 1
+    assert [comment["author"] for comment in top_comments] == ["testuser"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_comment_insights() -> None:
+    result = _make_result()
+    thread_json = deepcopy(MOCK_THREAD_JSON)
+    thread_json[1]["data"]["children"].append(
+        {
+            "kind": "t1",
+            "data": {
+                "author": "anotheruser",
+                "body": "One strong practical takeaway is that the implementation should keep the error handling simple and explicit for maintainability.",
+                "score": 40,
+                "created_utc": 1712000100,
+                "permalink": "/r/test/comments/abc/test_post/jkl",
+            },
+        }
+    )
+
+    async def get(*args, **kwargs):
+        return _make_response(json_data=thread_json)
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
+        await enrich_reddit_items([result], max_items=1)
+
+    insights = result["metadata"]["comment_insights"]
+    assert 1 <= len(insights) <= 3
+    assert all(isinstance(insight, str) and len(insight) > 30 for insight in insights)
+
+
+@pytest.mark.asyncio
+async def test_enrich_empty_results() -> None:
+    await enrich_reddit_items([], max_items=3)
+
+
+@pytest.mark.asyncio
+async def test_enrich_network_error_silent() -> None:
+    result = _make_result()
+    original = deepcopy(result)
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        _setup_async_client(
+            mock_async_client,
+            AsyncMock(side_effect=RuntimeError("network down")),
+        )
+        await enrich_reddit_items([result], max_items=1)
+
+    assert result == original


### PR DESCRIPTION
## Summary

- **HN fix**: Add `num_comments` to HN channel metadata (was only in snippet text, not machine-parseable)
- **Reddit enrichment**: After search, fetch top 5 comments for highest-scoring Reddit results via `reddit.com/{path}.json`
  - Adds `upvote_ratio`, `top_comments` (score/author/excerpt/date), `comment_insights` to metadata
  - 429 bail-out cancels remaining fetches immediately
  - Integrated into search_runner.py pipeline after scoring/convergence

## New files

| File | Purpose |
|------|---------|
| `lib/enrichment.py` | Async Reddit comment enrichment with 429 fail-fast |

## Test plan

- [x] 8 enrichment tests (mock httpx, 429 bail, deleted comment filtering, network error silence)
- [x] Full suite: 444 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)