### PR TITLE
feat: X/Twitter GraphQL cookie-based search

### DIFF
--- a/channels/twitter/SKILL.md
+++ b/channels/twitter/SKILL.md
@@ -3,7 +3,7 @@ name: twitter
 description: "Finds public Twitter/X posts, threads, and announcement-style updates indexed from the platform."
 categories: [social, tech-discussion]
 platform: x.com
-api_key_required: false
+api_key_required: false  # Enhanced with cookie auth: set TWITTER_AUTH_TOKEN + TWITTER_CT0, or have X logged in via browser
 aliases: [x]
 ---
 
@@ -26,3 +26,5 @@ It is weak for long-form explanation, historical retrieval, and stable reference
 ## Quality signals
 
 Engagement count helps, especially when paired with a relevant account. Verified or clearly authoritative accounts, linked primary sources, and multi-post threads are usually better signals than isolated low-engagement posts.
+
+When cookie authentication is available (via env vars or browser), results include likes, reposts, replies, and author handles. Without auth, results come from DuckDuckGo site-search with no engagement data.

--- a/channels/twitter/graphql.py
+++ b/channels/twitter/graphql.py
@@ -10,11 +10,11 @@ from datetime import datetime, timezone
 
 import httpx
 
-BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
-API_BASE = 'https://x.com/i/api/graphql'
-DEFAULT_QUERY_ID = '6AAys3t42mosm_yTI_QENg'
-FALLBACK_QUERY_IDS = ['M1jEez78PEfVfbQLvlWMvQ', '5h0kNbk3ii97rmfY6CdgAA']
-USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
+BEARER_TOKEN = "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
+API_BASE = "https://x.com/i/api/graphql"
+DEFAULT_QUERY_ID = "6AAys3t42mosm_yTI_QENg"
+FALLBACK_QUERY_IDS = ["M1jEez78PEfVfbQLvlWMvQ", "5h0kNbk3ii97rmfY6CdgAA"]
+USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
 
 
 def _log_error(message: str, exc: Exception | None = None) -> None:
@@ -167,12 +167,16 @@ def _parse_tweets(response_json: dict) -> list[dict]:
                         )
                         user_legacy = user_result.get("legacy", {})
 
-                        if not isinstance(legacy, dict) or not isinstance(user_legacy, dict):
+                        if not isinstance(legacy, dict) or not isinstance(
+                            user_legacy, dict
+                        ):
                             continue
 
                         rest_id = str(result.get("rest_id", "") or "").strip()
                         full_text = str(legacy.get("full_text", "") or "")
-                        author_handle = str(user_legacy.get("screen_name", "") or "").strip()
+                        author_handle = str(
+                            user_legacy.get("screen_name", "") or ""
+                        ).strip()
                         author_handle = re.sub(r"^@", "", author_handle)
                         author_handle = re.sub(r"[^A-Za-z0-9_]", "", author_handle)
 

--- a/channels/twitter/graphql.py
+++ b/channels/twitter/graphql.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import sys
+import uuid
+from datetime import datetime, timezone
+
+import httpx
+
+BEARER_TOKEN = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
+API_BASE = 'https://x.com/i/api/graphql'
+DEFAULT_QUERY_ID = '6AAys3t42mosm_yTI_QENg'
+FALLBACK_QUERY_IDS = ['M1jEez78PEfVfbQLvlWMvQ', '5h0kNbk3ii97rmfY6CdgAA']
+USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36'
+
+
+def _log_error(message: str, exc: Exception | None = None) -> None:
+    if exc is None:
+        print(f"[twitter-graphql] {message}", file=sys.stderr)
+        return
+    print(f"[twitter-graphql] {message}: {exc}", file=sys.stderr)
+
+
+def _extract_cookie_pair(cookie_jar: object) -> tuple[str, str] | None:
+    try:
+        allowed_domains = {".twitter.com", "twitter.com", ".x.com", "x.com"}
+        auth_token = ""
+        ct0 = ""
+
+        for cookie in cookie_jar:
+            domain = (getattr(cookie, "domain", "") or "").lower()
+            if domain not in allowed_domains:
+                continue
+
+            name = getattr(cookie, "name", "")
+            value = getattr(cookie, "value", "")
+
+            if name == "auth_token" and value:
+                auth_token = value
+            elif name == "ct0" and value:
+                ct0 = value
+
+            if auth_token and ct0:
+                return auth_token, ct0
+    except Exception as exc:
+        _log_error("Failed to extract cookies", exc)
+
+    return None
+
+
+def get_credentials() -> tuple[str, str] | None:
+    try:
+        auth_token = os.getenv("TWITTER_AUTH_TOKEN", "").strip()
+        ct0 = os.getenv("TWITTER_CT0", "").strip()
+        if auth_token and ct0:
+            return auth_token, ct0
+
+        try:
+            import browser_cookie3  # type: ignore
+        except ImportError:
+            return None
+
+        browsers = [
+            ("Safari", browser_cookie3.safari),
+            ("Chrome", browser_cookie3.chrome),
+            ("Firefox", browser_cookie3.firefox),
+        ]
+
+        for browser_name, loader in browsers:
+            try:
+                cookie_jar = loader()
+                credentials = _extract_cookie_pair(cookie_jar)
+                if credentials is not None:
+                    return credentials
+            except Exception as exc:
+                _log_error(f"Failed to load {browser_name} cookies", exc)
+
+        return None
+    except Exception as exc:
+        _log_error("Failed to get credentials", exc)
+        return None
+
+
+def _build_features() -> dict:
+    try:
+        return {
+            "responsive_web_graphql_exclude_directive_enabled": True,
+            "verified_phone_label_enabled": False,
+            "responsive_web_graphql_timeline_navigation_enabled": True,
+            "responsive_web_graphql_skip_user_profile_image_extensions_enabled": False,
+            "creator_subscriptions_tweet_preview_api_enabled": True,
+            "rweb_tipjar_consumption_enabled": True,
+            "freedom_of_speech_not_reach_fetch_enabled": True,
+            "standardized_nudges_misinfo": True,
+            "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": True,
+            "longform_notetweets_inline_media_enabled": True,
+            "longform_notetweets_rich_text_read_enabled": True,
+            "responsive_web_enhance_cards_enabled": False,
+            "tweetypie_unmention_optimization_enabled": True,
+            "responsive_web_edit_tweet_api_enabled": True,
+            "view_counts_everywhere_api_enabled": True,
+            "articles_preview_enabled": True,
+            "responsive_web_twitter_article_tweet_consumption_enabled": True,
+            "tweet_awards_web_tipping_enabled": False,
+            "rweb_video_timestamps_enabled": True,
+            "c9s_tweet_anatomy_moderator_badge_enabled": True,
+            "communities_web_enable_tweet_community_results_fetch": True,
+            "interactive_text_enabled": True,
+            "responsive_web_text_conversations_enabled": False,
+        }
+    except Exception as exc:
+        _log_error("Failed to build features", exc)
+        return {}
+
+
+def _parse_tweets(response_json: dict) -> list[dict]:
+    try:
+        instructions = (
+            response_json.get("data", {})
+            .get("search_by_raw_query", {})
+            .get("search_timeline", {})
+            .get("timeline", {})
+            .get("instructions", [])
+        )
+        if not isinstance(instructions, list):
+            return []
+
+        tweets: list[dict] = []
+
+        for instruction in instructions:
+            try:
+                if instruction.get("type") != "TimelineAddEntries":
+                    continue
+
+                entries = instruction.get("entries", [])
+                if not isinstance(entries, list):
+                    continue
+
+                for entry in entries:
+                    try:
+                        entry_id = entry.get("entryId", "")
+                        if not re.match(r"^tweet-", entry_id):
+                            continue
+
+                        result = (
+                            entry.get("content", {})
+                            .get("itemContent", {})
+                            .get("tweet_results", {})
+                            .get("result", {})
+                        )
+                        if not isinstance(result, dict):
+                            continue
+
+                        if result.get("__typename") == "TweetWithVisibilityResults":
+                            result = result.get("tweet", {})
+                            if not isinstance(result, dict):
+                                continue
+
+                        legacy = result.get("legacy", {})
+                        user_result = (
+                            result.get("core", {})
+                            .get("user_results", {})
+                            .get("result", {})
+                        )
+                        user_legacy = user_result.get("legacy", {})
+
+                        if not isinstance(legacy, dict) or not isinstance(user_legacy, dict):
+                            continue
+
+                        rest_id = str(result.get("rest_id", "") or "").strip()
+                        full_text = str(legacy.get("full_text", "") or "")
+                        author_handle = str(user_legacy.get("screen_name", "") or "").strip()
+                        author_handle = re.sub(r"^@", "", author_handle)
+                        author_handle = re.sub(r"[^A-Za-z0-9_]", "", author_handle)
+
+                        if not rest_id or not full_text or not author_handle:
+                            continue
+
+                        created_at_raw = str(legacy.get("created_at", "") or "").strip()
+                        if not created_at_raw:
+                            continue
+
+                        try:
+                            created_dt = datetime.strptime(
+                                created_at_raw, "%a %b %d %H:%M:%S %z %Y"
+                            )
+                            created_at_iso = (
+                                created_dt.astimezone(timezone.utc)
+                                .isoformat()
+                                .replace("+00:00", "Z")
+                            )
+                        except Exception as exc:
+                            _log_error("Failed to parse tweet timestamp", exc)
+                            continue
+
+                        _quotes = int(legacy.get("quote_count", 0) or 0)
+
+                        tweets.append(
+                            {
+                                "text": full_text,
+                                "url": f"https://x.com/{author_handle}/status/{rest_id}",
+                                "author_handle": author_handle,
+                                "likes": int(legacy.get("favorite_count", 0) or 0),
+                                "reposts": int(legacy.get("retweet_count", 0) or 0),
+                                "replies": int(legacy.get("reply_count", 0) or 0),
+                                "created_at": created_at_iso,
+                            }
+                        )
+                    except Exception as exc:
+                        _log_error("Failed to parse tweet entry", exc)
+                        continue
+            except Exception as exc:
+                _log_error("Failed to parse timeline instruction", exc)
+                continue
+
+        return tweets
+    except Exception as exc:
+        _log_error("Failed to parse GraphQL response", exc)
+        return []
+
+
+async def search_graphql(query: str, max_results: int = 20) -> list[dict]:
+    try:
+        credentials = get_credentials()
+        if credentials is None:
+            return []
+
+        auth_token, ct0 = credentials
+        await asyncio.sleep(0)
+
+        variables = {
+            "rawQuery": query,
+            "count": min(max_results, 20),
+            "querySource": "typed_query",
+            "product": "Latest",
+        }
+        features = _build_features()
+        query_ids = [DEFAULT_QUERY_ID, *FALLBACK_QUERY_IDS]
+
+        headers = {
+            "Authorization": f"Bearer {BEARER_TOKEN}",
+            "X-Csrf-Token": ct0,
+            "Cookie": f"auth_token={auth_token}; ct0={ct0}",
+            "User-Agent": USER_AGENT,
+            "X-Twitter-Auth-Type": "OAuth2Session",
+            "X-Twitter-Active-User": "yes",
+            "origin": "https://x.com",
+            "referer": "https://x.com/",
+            "X-Client-Transaction-Id": uuid.uuid4().hex,
+        }
+
+        timeout = httpx.Timeout(20.0, connect=10.0)
+
+        async with httpx.AsyncClient(headers=headers, timeout=timeout) as client:
+            for index, query_id in enumerate(query_ids):
+                try:
+                    url = f"{API_BASE}/{query_id}/SearchTimeline"
+                    response = await client.get(
+                        url,
+                        params={
+                            "variables": json.dumps(variables, separators=(",", ":")),
+                            "features": json.dumps(features, separators=(",", ":")),
+                        },
+                    )
+
+                    if response.status_code == 404 and index < len(query_ids) - 1:
+                        await asyncio.sleep(0)
+                        continue
+
+                    if response.status_code != 200:
+                        _log_error(
+                            f"SearchTimeline request failed with status {response.status_code}"
+                        )
+                        return []
+
+                    try:
+                        response_json = response.json()
+                    except Exception as exc:
+                        _log_error("Failed to decode GraphQL response JSON", exc)
+                        return []
+
+                    parsed = _parse_tweets(response_json)
+                    if not parsed:
+                        return []
+                    return parsed[:max_results]
+                except Exception as exc:
+                    _log_error("GraphQL request failed", exc)
+                    return []
+
+        return []
+    except Exception as exc:
+        _log_error("search_graphql failed", exc)
+        return []

--- a/channels/twitter/search.py
+++ b/channels/twitter/search.py
@@ -1,41 +1,86 @@
 from __future__ import annotations
 
+import sys
+
 from channels._engines.ddgs import search_ddgs_web
+from lib.search_runner import make_result
+
+
+async def _search_graphql(query: str, max_results: int) -> list[dict]:
+    """Try GraphQL SearchTimeline (requires browser cookies or env vars)."""
+    try:
+        from channels.twitter.graphql import search_graphql
+
+        tweets = await search_graphql(query, max_results)
+        if not tweets:
+            return []
+
+        results: list[dict] = []
+        for tweet in tweets:
+            results.append(
+                make_result(
+                    url=tweet.get("url", ""),
+                    title=tweet.get("text", "")[:200],
+                    snippet=tweet.get("text", "")[:500],
+                    source="twitter",
+                    query=query,
+                    extra_metadata={
+                        "likes": tweet.get("likes", 0),
+                        "reposts": tweet.get("reposts", 0),
+                        "replies": tweet.get("replies", 0),
+                        "author_handle": tweet.get("author_handle", ""),
+                        "published_at": tweet.get("created_at", ""),
+                    },
+                )
+            )
+            if len(results) >= max_results:
+                break
+        return results
+    except Exception as exc:
+        print(f"[twitter] GraphQL failed: {exc}", file=sys.stderr)
+        return []
+
+
+async def _search_ddgs(query: str, max_results: int) -> list[dict]:
+    """Search Twitter/X via DuckDuckGo site-search (no auth needed)."""
+    half = max(3, (max_results + 1) // 2)
+
+    twitter_results = await search_ddgs_web(
+        f"site:twitter.com {query}", half, source="twitter"
+    )
+    x_results = await search_ddgs_web(f"site:x.com {query}", half, source="twitter")
+
+    # Merge and dedup by URL stem (twitter.com/user/status/ID == x.com/user/status/ID)
+    seen: set[str] = set()
+    merged: list[dict] = []
+
+    for r in twitter_results + x_results:
+        url = r.get("url", "")
+        key = url
+        if "/status/" in url:
+            key = url.split("/status/")[-1].split("?")[0]
+
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(r)
+
+        if len(merged) >= max_results:
+            break
+
+    return merged[:max_results]
 
 
 async def search(query: str, max_results: int = 10) -> list[dict]:
-    """Search Twitter/X via DuckDuckGo, querying both domains."""
+    """Search Twitter/X — GraphQL first, DDGS fallback."""
     try:
-        # Search both twitter.com and x.com for maximum coverage
-        half = max(3, (max_results + 1) // 2)
+        # Try GraphQL (cookie-based, rich engagement data)
+        results = await _search_graphql(query, max_results)
+        if results:
+            return results
 
-        twitter_results = await search_ddgs_web(
-            f"site:twitter.com {query}", half, source="twitter"
-        )
-        x_results = await search_ddgs_web(f"site:x.com {query}", half, source="twitter")
-
-        # Merge and dedup by URL stem (twitter.com/user/status/ID == x.com/user/status/ID)
-        seen: set[str] = set()
-        merged: list[dict] = []
-
-        for r in twitter_results + x_results:
-            # Extract status ID for dedup
-            url = r.get("url", "")
-            # Normalize: extract /status/XXXXX part
-            key = url
-            if "/status/" in url:
-                key = url.split("/status/")[-1].split("?")[0]
-
-            if key in seen:
-                continue
-            seen.add(key)
-            merged.append(r)
-
-            if len(merged) >= max_results:
-                break
-
-        return merged[:max_results]
-
+        # Fall back to DDGS site-search
+        return await _search_ddgs(query, max_results)
     except Exception as exc:
         from lib.search_runner import SearchError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+browser-cookie3>=0.19.1  # optional: Twitter cookie extraction from browsers
 ddgs>=9.12.0
 httpx>=0.27.0
 lxml>=5.0

--- a/tests/test_twitter_graphql.py
+++ b/tests/test_twitter_graphql.py
@@ -1,0 +1,234 @@
+"""Tests for Twitter GraphQL search and channel fallback behavior."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+MOCK_GRAPHQL_RESPONSE = {
+    "data": {
+        "search_by_raw_query": {
+            "search_timeline": {
+                "timeline": {
+                    "instructions": [
+                        {
+                            "type": "TimelineAddEntries",
+                            "entries": [
+                                {
+                                    "entryId": "tweet-123456",
+                                    "content": {
+                                        "itemContent": {
+                                            "tweet_results": {
+                                                "result": {
+                                                    "rest_id": "123456",
+                                                    "legacy": {
+                                                        "full_text": "Test tweet about AI",
+                                                        "favorite_count": 42,
+                                                        "retweet_count": 10,
+                                                        "reply_count": 5,
+                                                        "quote_count": 2,
+                                                        "created_at": "Wed Jan 15 14:30:00 +0000 2025",
+                                                    },
+                                                    "core": {
+                                                        "user_results": {
+                                                            "result": {
+                                                                "legacy": {
+                                                                    "screen_name": "testuser"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+
+
+def _make_async_client(
+    *, response: MagicMock | None = None, side_effect: object | None = None
+) -> AsyncMock:
+    mock_client = AsyncMock()
+    if side_effect is not None:
+        mock_client.get = AsyncMock(side_effect=side_effect)
+    else:
+        mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _make_response(status_code: int, payload: dict | None = None) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.json.return_value = payload or {}
+    return mock_response
+
+
+def test_get_credentials_from_env() -> None:
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    def getenv_side_effect(key: str, default: str = "") -> str:
+        values = {
+            "TWITTER_AUTH_TOKEN": "auth_token",
+            "TWITTER_CT0": "ct0",
+        }
+        return values.get(key, default)
+
+    with patch("channels.twitter.graphql.os.getenv", side_effect=getenv_side_effect):
+        assert graphql.get_credentials() == ("auth_token", "ct0")
+
+
+def test_get_credentials_returns_none_when_missing() -> None:
+    graphql = importlib.import_module("channels.twitter.graphql")
+    original_import = builtins.__import__
+
+    def import_side_effect(
+        name: str,
+        globals: dict | None = None,
+        locals: dict | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "browser_cookie3":
+            raise ImportError("browser_cookie3 unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch("channels.twitter.graphql.os.getenv", return_value=""), patch(
+        "builtins.__import__", side_effect=import_side_effect
+    ):
+        assert graphql.get_credentials() is None
+
+
+@pytest.mark.asyncio
+async def test_search_graphql_parses_tweets() -> None:
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    mock_response = _make_response(200, MOCK_GRAPHQL_RESPONSE)
+    mock_client = _make_async_client(response=mock_response)
+
+    with patch(
+        "channels.twitter.graphql.get_credentials",
+        return_value=("auth_token", "ct0"),
+    ), patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client):
+        tweets = await graphql.search_graphql("AI", max_results=10)
+
+    assert len(tweets) == 1
+    tweet = tweets[0]
+    assert tweet["url"] == "https://x.com/testuser/status/123456"
+    assert tweet["text"] == "Test tweet about AI"
+    assert tweet["author_handle"] == "testuser"
+    assert tweet["likes"] == 42
+    assert tweet["reposts"] == 10
+    assert tweet["replies"] == 5
+
+
+@pytest.mark.asyncio
+async def test_search_graphql_returns_empty_on_error() -> None:
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    mock_client = _make_async_client(side_effect=Exception("connection refused"))
+
+    with patch(
+        "channels.twitter.graphql.get_credentials",
+        return_value=("auth_token", "ct0"),
+    ), patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client):
+        tweets = await graphql.search_graphql("AI", max_results=10)
+
+    assert tweets == []
+
+
+@pytest.mark.asyncio
+async def test_search_graphql_returns_empty_without_creds() -> None:
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    with patch("channels.twitter.graphql.get_credentials", return_value=None), patch(
+        "channels.twitter.graphql.httpx.AsyncClient"
+    ) as mock_async_client:
+        tweets = await graphql.search_graphql("AI", max_results=10)
+
+    assert tweets == []
+    mock_async_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_graphql_tries_fallback_on_404() -> None:
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    not_found_response = _make_response(404)
+    success_response = _make_response(200, MOCK_GRAPHQL_RESPONSE)
+    mock_client = _make_async_client(
+        side_effect=[not_found_response, success_response]
+    )
+
+    with patch(
+        "channels.twitter.graphql.get_credentials",
+        return_value=("auth_token", "ct0"),
+    ), patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client):
+        tweets = await graphql.search_graphql("AI", max_results=10)
+
+    assert len(tweets) == 1
+    assert mock_client.get.await_count == 2
+    first_url = mock_client.get.call_args_list[0].args[0]
+    second_url = mock_client.get.call_args_list[1].args[0]
+    assert graphql.DEFAULT_QUERY_ID in first_url
+    assert graphql.FALLBACK_QUERY_IDS[0] in second_url
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_ddgs() -> None:
+    twitter_search = importlib.import_module("channels.twitter.search")
+    ddgs_results = [
+        {
+            "url": "https://x.com/testuser/status/123456",
+            "title": "DDGS result",
+            "snippet": "Fallback result",
+        }
+    ]
+
+    with patch(
+        "channels.twitter.search._search_graphql", new=AsyncMock(return_value=[])
+    ) as mock_graphql, patch(
+        "channels.twitter.search._search_ddgs",
+        new=AsyncMock(return_value=ddgs_results),
+    ) as mock_ddgs:
+        results = await twitter_search.search("AI", max_results=5)
+
+    assert results == ddgs_results
+    mock_graphql.assert_awaited_once_with("AI", 5)
+    mock_ddgs.assert_awaited_once_with("AI", 5)
+
+
+@pytest.mark.asyncio
+async def test_search_uses_graphql_when_available() -> None:
+    twitter_search = importlib.import_module("channels.twitter.search")
+    graphql_results = [
+        {
+            "url": "https://x.com/testuser/status/123456",
+            "title": "GraphQL result",
+            "snippet": "Primary result",
+        }
+    ]
+
+    with patch(
+        "channels.twitter.search._search_graphql",
+        new=AsyncMock(return_value=graphql_results),
+    ) as mock_graphql, patch(
+        "channels.twitter.search._search_ddgs", new=AsyncMock(return_value=[])
+    ) as mock_ddgs:
+        results = await twitter_search.search("AI", max_results=5)
+
+    assert results == graphql_results
+    mock_graphql.assert_awaited_once_with("AI", 5)
+    mock_ddgs.assert_not_awaited()

--- a/tests/test_twitter_graphql.py
+++ b/tests/test_twitter_graphql.py
@@ -105,8 +105,9 @@ def test_get_credentials_returns_none_when_missing() -> None:
             raise ImportError("browser_cookie3 unavailable")
         return original_import(name, globals, locals, fromlist, level)
 
-    with patch("channels.twitter.graphql.os.getenv", return_value=""), patch(
-        "builtins.__import__", side_effect=import_side_effect
+    with (
+        patch("channels.twitter.graphql.os.getenv", return_value=""),
+        patch("builtins.__import__", side_effect=import_side_effect),
     ):
         assert graphql.get_credentials() is None
 
@@ -118,10 +119,13 @@ async def test_search_graphql_parses_tweets() -> None:
     mock_response = _make_response(200, MOCK_GRAPHQL_RESPONSE)
     mock_client = _make_async_client(response=mock_response)
 
-    with patch(
-        "channels.twitter.graphql.get_credentials",
-        return_value=("auth_token", "ct0"),
-    ), patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch(
+            "channels.twitter.graphql.get_credentials",
+            return_value=("auth_token", "ct0"),
+        ),
+        patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client),
+    ):
         tweets = await graphql.search_graphql("AI", max_results=10)
 
     assert len(tweets) == 1
@@ -140,10 +144,13 @@ async def test_search_graphql_returns_empty_on_error() -> None:
 
     mock_client = _make_async_client(side_effect=Exception("connection refused"))
 
-    with patch(
-        "channels.twitter.graphql.get_credentials",
-        return_value=("auth_token", "ct0"),
-    ), patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch(
+            "channels.twitter.graphql.get_credentials",
+            return_value=("auth_token", "ct0"),
+        ),
+        patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client),
+    ):
         tweets = await graphql.search_graphql("AI", max_results=10)
 
     assert tweets == []
@@ -153,9 +160,10 @@ async def test_search_graphql_returns_empty_on_error() -> None:
 async def test_search_graphql_returns_empty_without_creds() -> None:
     graphql = importlib.import_module("channels.twitter.graphql")
 
-    with patch("channels.twitter.graphql.get_credentials", return_value=None), patch(
-        "channels.twitter.graphql.httpx.AsyncClient"
-    ) as mock_async_client:
+    with (
+        patch("channels.twitter.graphql.get_credentials", return_value=None),
+        patch("channels.twitter.graphql.httpx.AsyncClient") as mock_async_client,
+    ):
         tweets = await graphql.search_graphql("AI", max_results=10)
 
     assert tweets == []
@@ -168,14 +176,15 @@ async def test_search_graphql_tries_fallback_on_404() -> None:
 
     not_found_response = _make_response(404)
     success_response = _make_response(200, MOCK_GRAPHQL_RESPONSE)
-    mock_client = _make_async_client(
-        side_effect=[not_found_response, success_response]
-    )
+    mock_client = _make_async_client(side_effect=[not_found_response, success_response])
 
-    with patch(
-        "channels.twitter.graphql.get_credentials",
-        return_value=("auth_token", "ct0"),
-    ), patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch(
+            "channels.twitter.graphql.get_credentials",
+            return_value=("auth_token", "ct0"),
+        ),
+        patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client),
+    ):
         tweets = await graphql.search_graphql("AI", max_results=10)
 
     assert len(tweets) == 1
@@ -197,12 +206,15 @@ async def test_search_falls_back_to_ddgs() -> None:
         }
     ]
 
-    with patch(
-        "channels.twitter.search._search_graphql", new=AsyncMock(return_value=[])
-    ) as mock_graphql, patch(
-        "channels.twitter.search._search_ddgs",
-        new=AsyncMock(return_value=ddgs_results),
-    ) as mock_ddgs:
+    with (
+        patch(
+            "channels.twitter.search._search_graphql", new=AsyncMock(return_value=[])
+        ) as mock_graphql,
+        patch(
+            "channels.twitter.search._search_ddgs",
+            new=AsyncMock(return_value=ddgs_results),
+        ) as mock_ddgs,
+    ):
         results = await twitter_search.search("AI", max_results=5)
 
     assert results == ddgs_results
@@ -221,12 +233,15 @@ async def test_search_uses_graphql_when_available() -> None:
         }
     ]
 
-    with patch(
-        "channels.twitter.search._search_graphql",
-        new=AsyncMock(return_value=graphql_results),
-    ) as mock_graphql, patch(
-        "channels.twitter.search._search_ddgs", new=AsyncMock(return_value=[])
-    ) as mock_ddgs:
+    with (
+        patch(
+            "channels.twitter.search._search_graphql",
+            new=AsyncMock(return_value=graphql_results),
+        ) as mock_graphql,
+        patch(
+            "channels.twitter.search._search_ddgs", new=AsyncMock(return_value=[])
+        ) as mock_ddgs,
+    ):
         results = await twitter_search.search("AI", max_results=5)
 
     assert results == graphql_results


### PR DESCRIPTION
## Summary

- **GraphQL client**: Python async client for X's internal GraphQL SearchTimeline API using browser cookies
  - Credential priority: env vars (`TWITTER_AUTH_TOKEN` + `TWITTER_CT0`) → Safari → Chrome → Firefox
  - Returns full tweet data: text, likes, reposts, replies, author handle, created_at
  - QueryID fallback rotation on 404
  - Never raises SearchError (protects shared DDGS engine group)
- **Twitter channel refactor**: GraphQL first, DDGS fallback when no credentials available
- **browser-cookie3**: Added as optional dependency (ImportError guarded)

## New files

| File | Purpose |
|------|---------|
| `channels/twitter/graphql.py` | GraphQL SearchTimeline client |

## Test plan

- [x] 8 tests (credential env/browser, GraphQL parsing, 404 fallback, DDGS fallback, no SearchError)
- [x] Full suite: 443 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)