### PR TITLE
feat: two-phase search with entity extraction

### DIFF
--- a/channels/reddit/search.py
+++ b/channels/reddit/search.py
@@ -69,6 +69,68 @@ async def _search_json_api(query: str, max_results: int) -> list[dict]:
         return results
 
 
+async def search_subreddit(
+    subreddit: str, query: str, max_results: int = 5
+) -> list[dict]:
+    """Search within a specific subreddit. Returns [] on failure (never raises)."""
+    try:
+        async with httpx.AsyncClient(
+            timeout=DEFAULT_TIMEOUT,
+            headers={"User-Agent": USER_AGENT},
+        ) as client:
+            response = await client.get(
+                f"https://www.reddit.com/r/{subreddit}/search.json",
+                params={
+                    "q": query,
+                    "restrict_sr": "on",
+                    "sort": "relevance",
+                    "limit": min(25, max_results),
+                },
+            )
+            if response.status_code in (403, 404):
+                return []
+            response.raise_for_status()
+            payload = response.json()
+            data = payload.get("data")
+            if not isinstance(data, dict):
+                return []
+
+            results: list[dict] = []
+            for post in data.get("children", []):
+                post_data = post.get("data", {})
+                permalink = post_data.get("permalink", "")
+                title = post_data.get("title", "")
+                if not permalink or not title:
+                    continue
+                result_url = urljoin(BASE_URL, permalink)
+                content = (post_data.get("selftext", "") or "")[:500]
+                extra_metadata: dict = {
+                    "subreddit": post_data.get("subreddit", ""),
+                    "score": post_data.get("score", 0),
+                    "num_comments": post_data.get("num_comments", 0),
+                }
+                created_utc = post_data.get("created_utc")
+                if isinstance(created_utc, (int, float)):
+                    extra_metadata["published_at"] = datetime.fromtimestamp(
+                        created_utc, tz=timezone.utc
+                    ).isoformat()
+                results.append(
+                    make_result(
+                        url=result_url,
+                        title=title,
+                        snippet=content,
+                        source="reddit",
+                        query=query,
+                        extra_metadata=extra_metadata,
+                    )
+                )
+                if len(results) >= max_results:
+                    break
+            return results
+    except Exception:
+        return []
+
+
 async def _search_ddgs_fallback(query: str, max_results: int) -> list[dict]:
     """Fallback: search Reddit via DuckDuckGo site: filter."""
     from channels._engines.ddgs import search_ddgs_site

--- a/lib/entity_extract.py
+++ b/lib/entity_extract.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+MAX_ENTITIES = 5
+ACADEMIC_SOURCES = {"arxiv", "semantic-scholar", "google-scholar"}
+GENERIC_HANDLES = {
+    "amazon",
+    "apple",
+    "github",
+    "google",
+    "meta",
+    "microsoft",
+    "openai",
+    "reddit",
+    "twitter",
+    "x",
+    "youtube",
+}
+HANDLE_RE = re.compile(r"@(\w{1,15})")
+NAME_PART = r"(?:[A-Z][A-Za-z'`-]+|[A-Z]\.)"
+AUTHOR_NAME = rf"{NAME_PART}(?:\s+{NAME_PART}){{1,3}}"
+AUTHOR_LIST_PATTERNS = [
+    re.compile(
+        rf"\b(?:authors?|by)\s*:?\s*((?:{AUTHOR_NAME})(?:\s*(?:,|and)\s*{AUTHOR_NAME})+)"
+    ),
+    re.compile(rf"\b((?:{AUTHOR_NAME})(?:\s*(?:,|and)\s*{AUTHOR_NAME})+)"),
+]
+SINGLE_AUTHOR_PATTERN = re.compile(rf"\bby\s+({AUTHOR_NAME})\b")
+
+
+def _top_items(counter: Counter[str], limit: int = MAX_ENTITIES) -> list[str]:
+    return [
+        item
+        for item, _count in sorted(counter.items(), key=lambda pair: (-pair[1], pair[0]))[
+            :limit
+        ]
+    ]
+
+
+def extract_subreddits(results: list[dict]) -> list[str]:
+    counts: Counter[str] = Counter()
+
+    for result in results:
+        if result.get("source") != "reddit":
+            continue
+        metadata = result.get("metadata") or {}
+        subreddit = str(metadata.get("subreddit") or "").strip()
+        subreddit = subreddit.removeprefix("r/").strip()
+        if subreddit:
+            counts[subreddit.lower()] += 1
+
+    return _top_items(counts)
+
+
+def _normalize_handle(handle: str) -> str:
+    return handle.lstrip("@").strip().lower()
+
+
+def extract_x_handles(results: list[dict]) -> list[str]:
+    counts: Counter[str] = Counter()
+
+    for result in results:
+        if result.get("source") != "twitter":
+            continue
+
+        text = " ".join(
+            part for part in (result.get("title", ""), result.get("snippet", "")) if part
+        )
+        for handle in HANDLE_RE.findall(text):
+            normalized = _normalize_handle(handle)
+            if normalized and normalized not in GENERIC_HANDLES:
+                counts[normalized] += 1
+
+        metadata = result.get("metadata") or {}
+        author_handle = _normalize_handle(str(metadata.get("author_handle") or ""))
+        if author_handle and author_handle not in GENERIC_HANDLES:
+            counts[author_handle] += 1
+
+    return _top_items(counts)
+
+
+def _normalize_author(name: str) -> str:
+    return re.sub(r"\s+", " ", name.strip(" ,.;:"))
+
+
+def _extract_author_names(text: str) -> list[str]:
+    authors: list[str] = []
+
+    for pattern in AUTHOR_LIST_PATTERNS:
+        for match in pattern.findall(text):
+            parts = re.split(r"\s*(?:,|and)\s*", match)
+            authors.extend(_normalize_author(part) for part in parts if part.strip())
+
+    for match in SINGLE_AUTHOR_PATTERN.findall(text):
+        authors.append(_normalize_author(match))
+
+    return [author for author in authors if author]
+
+
+def extract_authors(results: list[dict]) -> list[str]:
+    counts: Counter[str] = Counter()
+
+    for result in results:
+        if result.get("source") not in ACADEMIC_SOURCES:
+            continue
+
+        metadata = result.get("metadata") or {}
+        text = " ".join(
+            part
+            for part in (
+                result.get("title", ""),
+                result.get("snippet", ""),
+                str(metadata.get("authors") or ""),
+            )
+            if part
+        )
+        for author in _extract_author_names(text):
+            counts[author] += 1
+
+    return _top_items(counts)
+
+
+def extract_entities(results: list[dict]) -> dict[str, list[str]]:
+    return {
+        "subreddits": extract_subreddits(results),
+        "x_handles": extract_x_handles(results),
+        "authors": extract_authors(results),
+    }

--- a/lib/entity_extract.py
+++ b/lib/entity_extract.py
@@ -33,9 +33,9 @@ SINGLE_AUTHOR_PATTERN = re.compile(rf"\bby\s+({AUTHOR_NAME})\b")
 def _top_items(counter: Counter[str], limit: int = MAX_ENTITIES) -> list[str]:
     return [
         item
-        for item, _count in sorted(counter.items(), key=lambda pair: (-pair[1], pair[0]))[
-            :limit
-        ]
+        for item, _count in sorted(
+            counter.items(), key=lambda pair: (-pair[1], pair[0])
+        )[:limit]
     ]
 
 
@@ -66,7 +66,9 @@ def extract_x_handles(results: list[dict]) -> list[str]:
             continue
 
         text = " ".join(
-            part for part in (result.get("title", ""), result.get("snippet", "")) if part
+            part
+            for part in (result.get("title", ""), result.get("snippet", ""))
+            if part
         )
         for handle in HANDLE_RE.findall(text):
             normalized = _normalize_handle(handle)

--- a/lib/phase2.py
+++ b/lib/phase2.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from lib.search_runner import dedup_results
+
+
+async def _search_subreddit(
+    subreddit: str, original_query: str, max_per_entity: int
+) -> list[dict]:
+    from channels.reddit.search import search_subreddit
+
+    return await search_subreddit(subreddit, original_query, max_per_entity)
+
+
+async def _search_x_handle(
+    handle: str, original_query: str, max_per_entity: int
+) -> list[dict]:
+    from channels.twitter.search import search as twitter_search
+
+    query = f"from:{handle} {original_query}"
+    return await twitter_search(query, max_per_entity)
+
+
+async def run_phase2(
+    entities: dict[str, list[str]], original_query: str, max_per_entity: int = 5
+) -> list[dict]:
+    try:
+        tasks = [
+            _search_subreddit(subreddit, original_query, max_per_entity)
+            for subreddit in (entities.get("subreddits") or [])
+        ]
+        tasks.extend(
+            _search_x_handle(handle, original_query, max_per_entity)
+            for handle in (entities.get("x_handles") or [])
+        )
+
+        if not tasks:
+            return []
+
+        gathered = await asyncio.gather(*tasks, return_exceptions=True)
+
+        results: list[dict] = []
+        for item in gathered:
+            if isinstance(item, Exception):
+                continue
+            results.extend(item)
+
+        return dedup_results(results)
+    except Exception as exc:
+        print(f"[phase2] {exc}", file=sys.stderr)
+        return []

--- a/tests/test_entity_extract.py
+++ b/tests/test_entity_extract.py
@@ -1,0 +1,129 @@
+from lib.entity_extract import extract_entities
+
+
+def test_extract_subreddits():
+    results = [
+        {
+            "url": "https://reddit.com/1",
+            "title": "One",
+            "snippet": "Alpha",
+            "source": "reddit",
+            "query": "agents",
+            "metadata": {"subreddit": "Python"},
+        },
+        {
+            "url": "https://reddit.com/2",
+            "title": "Two",
+            "snippet": "Beta",
+            "source": "reddit",
+            "query": "agents",
+            "metadata": {"subreddit": "Python"},
+        },
+        {
+            "url": "https://reddit.com/3",
+            "title": "Three",
+            "snippet": "Gamma",
+            "source": "reddit",
+            "query": "agents",
+            "metadata": {"subreddit": "MachineLearning"},
+        },
+    ]
+
+    entities = extract_entities(results)
+
+    assert entities["subreddits"] == ["python", "machinelearning"]
+
+
+def test_extract_subreddits_top5():
+    results = []
+    for index in range(6):
+        for repeat in range(index + 1):
+            results.append(
+                {
+                    "url": f"https://reddit.com/{index}/{repeat}",
+                    "title": f"Post {index}",
+                    "snippet": "Text",
+                    "source": "reddit",
+                    "query": "agents",
+                    "metadata": {"subreddit": f"sub{index}"},
+                }
+            )
+
+    entities = extract_entities(results)
+
+    assert entities["subreddits"] == ["sub5", "sub4", "sub3", "sub2", "sub1"]
+
+
+def test_extract_x_handles():
+    results = [
+        {
+            "url": "https://x.com/1",
+            "title": "@alice on agents",
+            "snippet": "RT @bob and @alice",
+            "source": "twitter",
+            "query": "agents",
+            "metadata": {"author_handle": "@carol"},
+        },
+        {
+            "url": "https://x.com/2",
+            "title": "@alice shipping updates",
+            "snippet": "Conversation with @bob",
+            "source": "twitter",
+            "query": "agents",
+            "metadata": {},
+        },
+    ]
+
+    entities = extract_entities(results)
+
+    assert entities["x_handles"] == ["alice", "bob", "carol"]
+
+
+def test_extract_x_handles_filters_generic():
+    results = [
+        {
+            "url": "https://x.com/1",
+            "title": "@openai meets @google",
+            "snippet": "@builder shares notes",
+            "source": "twitter",
+            "query": "agents",
+            "metadata": {"author_handle": "@OpenAI"},
+        }
+    ]
+
+    entities = extract_entities(results)
+
+    assert entities["x_handles"] == ["builder"]
+
+
+def test_extract_authors():
+    results = [
+        {
+            "url": "https://arxiv.org/abs/1",
+            "title": "Paper title",
+            "snippet": "Jane Doe, John Smith, Alice Brown. New findings in agents.",
+            "source": "arxiv",
+            "query": "agents",
+            "metadata": {},
+        },
+        {
+            "url": "https://scholar.google.com/2",
+            "title": "Another paper",
+            "snippet": "by Jane Doe",
+            "source": "google-scholar",
+            "query": "agents",
+            "metadata": {},
+        },
+    ]
+
+    entities = extract_entities(results)
+
+    assert entities["authors"] == ["Jane Doe", "Alice Brown", "John Smith"]
+
+
+def test_extract_empty_results():
+    assert extract_entities([]) == {
+        "subreddits": [],
+        "x_handles": [],
+        "authors": [],
+    }

--- a/tests/test_phase2.py
+++ b/tests/test_phase2.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch
+
+import pytest
+
+from lib.phase2 import run_phase2
+
+
+def _result(url: str, source: str) -> dict:
+    return {
+        "url": url,
+        "title": "Title",
+        "snippet": "Snippet",
+        "source": source,
+        "query": "agents",
+        "metadata": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_phase2_with_subreddits() -> None:
+    calls: list[tuple[str, str, int]] = []
+
+    async def fake_search_subreddit(subreddit, query, max_results):
+        calls.append((subreddit, query, max_results))
+        return [_result(f"https://reddit.com/r/{subreddit}", "reddit")]
+
+    with patch(
+        "lib.phase2._search_subreddit",
+        new=fake_search_subreddit,
+    ):
+        results = await run_phase2(
+            {
+                "subreddits": ["python", "machinelearning"],
+                "x_handles": [],
+                "authors": [],
+            },
+            "agent frameworks",
+            max_per_entity=3,
+        )
+
+    assert calls == [
+        ("python", "agent frameworks", 3),
+        ("machinelearning", "agent frameworks", 3),
+    ]
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_phase2_deduplicates() -> None:
+    async def fake_sub(sub, q, n):
+        return [_result("https://example.com/shared", "reddit")]
+
+    async def fake_handle(handle, q, n):
+        return [_result("https://example.com/shared", "twitter")]
+
+    with (
+        patch("lib.phase2._search_subreddit", new=fake_sub),
+        patch("lib.phase2._search_x_handle", new=fake_handle),
+    ):
+        results = await run_phase2(
+            {"subreddits": ["python"], "x_handles": ["alice"], "authors": []},
+            "agent frameworks",
+        )
+
+    assert len(results) == 1
+    assert results[0]["url"] == "https://example.com/shared"
+
+
+@pytest.mark.asyncio
+async def test_run_phase2_empty_entities() -> None:
+    results = await run_phase2(
+        {"subreddits": [], "x_handles": [], "authors": []},
+        "agent frameworks",
+    )
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_run_phase2_handles_errors() -> None:
+    async def fake_sub_error(sub, q, n):
+        raise RuntimeError("boom")
+
+    async def fake_handle_ok(handle, q, n):
+        return [_result("https://x.com/alice/status/1", "twitter")]
+
+    with (
+        patch("lib.phase2._search_subreddit", new=fake_sub_error),
+        patch("lib.phase2._search_x_handle", new=fake_handle_ok),
+    ):
+        results = await run_phase2(
+            {"subreddits": ["python"], "x_handles": ["alice"], "authors": []},
+            "agent frameworks",
+        )
+
+    assert len(results) == 1


### PR DESCRIPTION
## Summary

- **Entity extraction**: Extract subreddits, X handles, and academic authors from Phase 1 results by frequency. Filters generic handles (openai, google, etc.). Top 5 per type.
- **Subreddit search**: New `search_subreddit()` in Reddit channel searches within a specific subreddit via `restrict_sr=on`
- **Phase 2 orchestration**: `run_phase2()` runs targeted searches for extracted entities concurrently, deduplicates results. Caller-opt-in only.

## New files

| File | Purpose |
|------|---------|
| `lib/entity_extract.py` | Entity extraction from search results |
| `lib/phase2.py` | Phase 2 targeted search orchestration |

## Test plan

- [x] 6 entity extraction tests (subreddits, handles, authors, filtering)
- [x] 4 phase2 tests (dispatch, dedup, empty, error handling)
- [x] Full suite: 447 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)