### PR TITLE
feat: carry engagement and convergence signals to Block 4

### DIFF
--- a/skills/llm-evaluate/SKILL.md
+++ b/skills/llm-evaluate/SKILL.md
@@ -159,7 +159,7 @@ After evaluation, produce a compressed claims file: `evidence/{session_id}-claim
 
 For each relevant result (llm_relevant=true), distill one structured claim:
 ```json
-{"url": "https://...", "claim": "Qdrant outperforms Pinecone on filtered search by 3x at 1M vectors", "source": "github", "dimension": "performance-benchmarks"}
+{"url": "https://...", "claim": "Qdrant outperforms Pinecone on filtered search by 3x at 1M vectors", "source": "github", "dimension": "performance-benchmarks", "engagement_score": 78, "also_on": ["reddit", "hn"], "top_comment": "Senior engineer here: we migrated and saw 3x improvement..."}
 ```
 
 Rules:
@@ -167,6 +167,11 @@ Rules:
 - The claim must capture the single most important finding from that result
 - Include the dimension it covers (maps to the 9 recall dimensions)
 - This file is what Block 4 reads instead of raw results — keep it dense and useful
+
+Signal carry-forward rules (optional fields — include when available):
+- `engagement_score`: carry when `metadata.composite_score >= 50`
+- `also_on`: carry when `metadata.also_on` has at least 1 entry — cross-platform signals are the strongest evidence
+- `top_comment`: carry `metadata.top_comments[0].excerpt` when present (Reddit only) — first-person experience from comments adds depth that titles and snippets cannot
 
 # Quality Bar
 

--- a/skills/rerank-evidence/SKILL.md
+++ b/skills/rerank-evidence/SKILL.md
@@ -49,6 +49,9 @@ But foundational works (STaR, Reflexion, Voyager) should rank high regardless of
 A result from an underrepresented platform or content type gets a boost.
 If the bundle is 80% GitHub repos, a blog post or paper should rank higher than another repo.
 
+## 6. Cross-Source Convergence
+A result that appears across multiple platforms (`also_on` field non-empty) is stronger evidence than a single-source finding. Treat convergent items one tier higher than equivalent single-source items. The same story confirmed by Reddit, HN, and Twitter is likely canonical and should rank near the top.
+
 # How To Rank
 
 You are Claude. You can read all the results and judge their relative importance.

--- a/skills/select-channels/SKILL.md
+++ b/skills/select-channels/SKILL.md
@@ -49,6 +49,22 @@ Log every exclusion: `excluded: {channel} — language mismatch ({channel_langua
 | Business intelligence | crunchbase, 36kr, linkedin, xueqiu, twitter |
 | Emerging/recent | producthunt, github-repos, twitter, hn |
 
+## Rule 2b: Query type adjustment
+
+`lib/query_type.py` classifies the topic into one of 7 types. Use the query type to boost or deprioritize channels:
+
+| Query type | Boost these | Deprioritize |
+|-----------|------------|-------------|
+| how_to | youtube, stackoverflow, reddit | arxiv, crunchbase |
+| comparison | reddit, hn, youtube | producthunt |
+| opinion | reddit, twitter, hn | arxiv, google-scholar |
+| prediction | twitter, reddit | stackoverflow, arxiv |
+| product | reddit, twitter, producthunt | arxiv |
+| concept | hn, reddit, arxiv, web-ddgs | producthunt |
+| breaking_news | twitter, reddit, web-ddgs, hn | arxiv |
+
+This is a soft signal — don't exclude deprioritized channels entirely, just rank them lower in the selection.
+
 ## Rule 3: Fill gaps from knowledge map
 
 For each GAP dimension in the knowledge map, add the channel most likely to fill it:


### PR DESCRIPTION
## Summary

Skill modifications to pass scoring, convergence, and enrichment signals through the claims pipeline to Block 4 synthesis.

- **llm-evaluate**: Carry `engagement_score`, `also_on`, and `top_comment` into claims file
- **rerank-evidence**: Add cross-source convergence as ranking criterion #6
- **select-channels**: Add query-type boost/deprioritize table (Rule 2b)

## Test plan

- [x] Skill compliance tests pass (170 tests)
- [x] Full suite: 435 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)