### PR TITLE
docs: add Mintlify documentation site

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.05.3"
+    "version": "2026.04.05.4"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.05.3",
+      "version": "2026.04.05.4",
       "author": {
         "name": "0xmariowu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.05.3",
+  "version": "2026.04.05.4",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.05.4
+
 ## 2026.04.05.3
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 </p>
 
 <p align="center">
+  <a href="https://autosearch.mintlify.app">Documentation</a> &bull;
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#what-makes-it-different">What Makes It Different</a> &bull;
   <a href="#self-evolution">Self-Evolution</a> &bull;

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,0 +1,78 @@
+---
+title: Architecture
+description: How AutoSearch works internally — the 6-block pipeline, AVO evolution, and directory layout.
+---
+
+## Pipeline
+
+Every research session runs through a 6-block pipeline:
+
+```
+You: /autosearch "topic"
+ |
+ v
+[1] Claude recalls what it already knows -> maps 9 knowledge dimensions
+ |
+[2] Identifies gaps -> generates queries ONLY for what Claude doesn't know
+ |
+[3] Searches 32+ channels in parallel (10-30 seconds)
+ |
+[4] LLM evaluates each result for relevance, filters noise
+ |
+[5] Synthesizes report with two-stage citation lock
+ |
+[6] Checks quality rubrics -> evolves strategy -> commits improvements
+```
+
+Each block has a time limit (5/5/5/8/3/3 minutes) to prevent hangs.
+
+## Self-evolution (AVO)
+
+AutoSearch implements the AVO (Agent Variation Operator) pattern:
+
+- **P_t = `state/`** — lineage: worklog, patterns, evolution history, outcomes
+- **K = `skills/`** — capability set (50+ skills)
+- **f = `judge.py`** — fixed scoring function (never modified by evolution)
+
+After each session:
+1. `judge.py` scores results on 7 dimensions
+2. If the score improved, the strategy changes are committed
+3. If the score regressed, changes are reverted
+4. Reusable patterns are saved to `state/patterns.jsonl`
+
+The safety mechanism: the evaluator is fixed and cannot be modified by evolution. Only search strategy evolves — not the scoring.
+
+## Model routing
+
+| Task | Model | Why |
+|---|---|---|
+| Classification, scoring, rubrics | Haiku | Fast, cheap, sufficient |
+| Synthesis, reasoning, evolution | Sonnet | Better judgment |
+| Claims compression | Haiku | Batch processing |
+
+## Directory layout
+
+```
+autosearch/
+  .claude-plugin/     Plugin manifest (version, metadata)
+  commands/           /autosearch entry point + setup
+  agents/             Claude Code agent definitions
+  skills/             50+ skills (pipeline, synthesis, evaluation, evolution)
+  channels/           32+ channel plugins (SKILL.md + search.py each)
+    _engines/         Shared backends (baidu, ddgs)
+  lib/                search_runner.py, judge.py (fixed evaluator)
+  state/              Append-only learning data
+  scripts/            Setup, install, version management
+  tests/              pytest test suite (279 tests)
+  evidence/           Search results (per-session)
+  delivery/           Generated reports
+  docs/               This documentation site
+```
+
+## Immutable files
+
+These files cannot be modified during normal operation:
+
+- `PROTOCOL.md` — agent operating protocol
+- `lib/judge.py` — scoring function
+- Meta-skills: `create-skill`, `observe-user`, `extract-knowledge`, `interact-user`, `discover-environment`

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,0 +1,138 @@
+---
+title: Changelog
+description: All changes to AutoSearch, organized by release.
+---
+
+## 2026.04.05.3
+
+### Changes
+
+- Reddit comment insights — top comments with scores, authors, and excerpts for highest-scoring results
+- X/Twitter search with full engagement data — cookie-based GraphQL search with likes, reposts, replies
+- Two-phase search — Phase 1 extracts entities (subreddits, handles, authors), Phase 2 does targeted follow-ups
+- HN channel now includes `num_comments` in metadata
+- Claims pipeline carries engagement scores and cross-platform signals through to synthesis
+- Reranking boosts cross-source convergent items as stronger evidence
+- Channel selection considers query type (how-to, comparison, opinion, etc.)
+
+### Fixes
+
+- CI author check no longer fails on merge commits from `actions/checkout`
+
+## 2026.04.05.2
+
+### Changes
+
+- Per-platform engagement scoring with composite scores (relevance + recency + engagement)
+- Cross-source convergence detection with "also on" annotations
+- Search query type classification for smarter source prioritization
+
+## 2026.04.05.1
+
+### Changes
+
+- HuggingFace channel — search models and datasets by downloads
+- Papers with Code channel — trending AI papers via HuggingFace Daily Papers
+- 34 search channels total (was 32)
+- Cleaned up 18 orphan skills (1,828 lines removed)
+
+## 2026.04.04.9
+
+### Changes
+
+- CI hygiene workflow — checks author identity, codenames, personal paths, container pins
+- Git history fully rewritten — removed all PII from 270 commits
+
+### Fixes
+
+- Removed literal PII from .gitleaks.toml detection rules
+- Cleaned up 10 stale remote branches
+
+## 2026.04.04.8
+
+### Changes
+
+- Lazy-load channel plugins on first query for faster startup
+- Added isort and bugbear rules to ruff linter
+- Pyright now checks the correct directories
+
+### Fixes
+
+- Pinned semgrep container image to SHA digest
+- Fixed shell injection risk in release.yml
+- Added .dockerignore to prevent secret leakage into Docker builds
+- HTML-escaped title in report assembly to prevent XSS
+- Added `set -euo pipefail` to run_search.sh
+
+## 2026.04.04.7
+
+### Changes
+
+- Engine-level health tracking — dependent channels suspend together on engine failure
+- Transient failures auto-retry once before giving up
+- Channel health data persists immediately after every success/failure
+
+## 2026.04.04.6
+
+### Fixes
+
+- Search failures correctly distinguished from empty results
+
+## 2026.04.04.5
+
+### Fixes
+
+- Chinese channels no longer get suspended by English-session zero-yield
+
+## 2026.04.04.4
+
+### Changes
+
+- Pre-release test suite with `./scripts/release-test.sh`
+- 6 user scenarios (Quick/Standard/Deep x EN/ZH) with Docker support
+
+## 2026.04.04.3
+
+### Fixes
+
+- Claims compression enforced to prevent Block 4 hangs at 120+ results
+- All 6 pipeline blocks now have time limits
+
+## 2026.04.04.2
+
+### Changes
+
+- Haiku-compressed claims before synthesis
+- Targeted gap-fill queries from coverage analysis
+- Research context persistence across sessions
+
+## 2026.04.04.1
+
+### Changes
+
+- Delivery format choice: Markdown, Rich HTML, or Slides
+- Language auto-detection — Chinese topics get Chinese output
+- 6-block orchestrated pipeline with real-time progress
+- 9 to 279 tests
+
+## 2026.4.3
+
+### Changes
+
+- Plugin release — install via `claude plugin marketplace add 0xmariowu/autosearch`
+- 32 search channels with convention-based loader
+- Chinese channels via Baidu Kaifa Developer Search
+- Two-stage citation lock
+- Model routing: Haiku for batch, Sonnet for synthesis
+- Benchmark: AutoSearch 92% vs Native Claude 72%
+
+## 2026.4.1
+
+### Changes
+
+- Rubric AVO — auto-generate rubrics, score delivery, evolve skills
+- Pipeline baseline: 0.880 pass rate on initial benchmark
+
+## Pre-plugin history
+
+V1 and V2.0 prototype development (2026-03-23 to 2026-03-28). See git history for details.

--- a/docs/channels.mdx
+++ b/docs/channels.mdx
@@ -1,0 +1,98 @@
+---
+title: Channels
+description: All 32+ search channels — dedicated connectors for code, academic, community, Chinese, video, and business platforms.
+---
+
+AutoSearch has 32+ dedicated search channels. Each channel has its own connector — not just web search with `site:` filters.
+
+No API keys required for any built-in channel.
+
+## Code
+
+| Channel | What it searches |
+|---|---|
+| `github-repos` | Repository discovery by stars, activity, topic |
+| `github-issues` | Bug reports, feature requests, pain points |
+| `github-code` | Code search for implementations and patterns |
+| `npm-pypi` | Package registry search for libraries and SDKs |
+| `stackoverflow` | Programming Q&A with community-validated solutions |
+
+## Academic
+
+| Channel | What it searches |
+|---|---|
+| `arxiv` | Pre-prints and latest research papers |
+| `semantic-scholar` | Academic papers with citation data |
+| `google-scholar` | Comprehensive academic search with citation counts |
+| `citation-graph` | Follow-up work and references from known papers |
+| `papers-with-code` | Papers with associated code implementations |
+| `openreview` | Conference papers from ICLR, NeurIPS, ICML |
+| `conference-talks` | ML/AI conference presentations and workshops |
+
+## Community
+
+| Channel | What it searches |
+|---|---|
+| `reddit` | Community opinions, user experiences, comparisons |
+| `hn` | Hacker News tech discussions and startup signals |
+| `twitter` | Social signals with engagement data |
+| `devto` | Practitioner blog posts and tutorials |
+
+## Chinese platforms
+
+12 dedicated Chinese channels — no other research tool covers the Chinese internet like this.
+
+| Channel | What it searches |
+|---|---|
+| `zhihu` | Chinese Q&A (like Quora) — deep technical discussions |
+| `bilibili` | Chinese video — tech tutorials, conference recordings |
+| `csdn` | Chinese developer tutorials and code examples |
+| `juejin` | Chinese frontend/backend technical articles |
+| `36kr` | Chinese tech business news and startup coverage |
+| `wechat` | WeChat Official Accounts — long-form industry analysis |
+| `weibo` | Chinese social media reactions and trending topics |
+| `xiaohongshu` | User experience reports and product reviews |
+| `douyin` | Short-form video — viral tech demos |
+| `xiaoyuzhou` | Chinese podcasts — interviews and expert conversations |
+| `xueqiu` | Chinese investment analysis and stock discussions |
+| `infoq-cn` | Chinese enterprise tech practices |
+
+## Video
+
+| Channel | What it searches |
+|---|---|
+| `youtube` | Tutorials, tech talks, product demos with transcripts |
+| `bilibili` | Chinese tech videos (also listed under Chinese) |
+| `conference-talks` | Conference keynotes and workshop presentations |
+
+## Business
+
+| Channel | What it searches |
+|---|---|
+| `producthunt` | New product launches and startup discovery |
+| `crunchbase` | Startup funding data and company profiles |
+| `g2` | Software reviews from verified business users |
+| `linkedin` | Professional perspectives and industry signals |
+
+## General
+
+| Channel | What it searches |
+|---|---|
+| `web-ddgs` | Broad web coverage via DuckDuckGo |
+| `rss` | Structured feeds — blogs, news, release notifications |
+
+## Optional premium channels
+
+These require API keys but provide enhanced capabilities:
+
+| Channel | Key needed | What it adds |
+|---|---|---|
+| Exa | `EXA_API_KEY` | Semantic web search with paraphrase matching |
+| Tavily | `TAVILY_API_KEY` | Research-oriented search with structured results |
+| HuggingFace | None (public API) | Model and dataset discovery |
+
+## Adding a channel
+
+See the [Contributing guide](/contributing) for how to add a new channel. Each channel is a directory with:
+- `SKILL.md` — channel definition and search strategy
+- `search.py` — async search function returning `[{url, title, snippet}]`

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,0 +1,61 @@
+---
+title: Contributing
+description: How to set up the development environment, add channels, and submit pull requests.
+---
+
+## Development setup
+
+```bash
+git clone https://github.com/0xmariowu/Autosearch.git
+cd Autosearch
+
+# Create venv and install deps
+bash scripts/setup.sh
+
+# Activate hooks
+npx husky
+
+# Run tests
+PYTHONPATH=. .venv/bin/python3 -m pytest tests/ -x -q -m "not network"
+
+# Lint
+ruff check . && ruff format --check .
+```
+
+## Adding a channel
+
+1. Create `channels/{name}/SKILL.md` — follow `channels/web-ddgs/SKILL.md` as template
+2. Create `channels/{name}/search.py` — export `async def search(query: str, max_results: int) -> list[dict]`
+3. Each result must have `url`, `title`, `snippet` keys
+4. Run `PYTHONPATH=. .venv/bin/python3 -m pytest tests/test_channels_smoke.py -x` to verify
+
+## PR rules
+
+- One logical change per commit
+- Source code first, tests second, docs third
+- `ruff check && ruff format --check` must pass
+- `pytest -x -q -m "not network"` must pass
+- PR stays under 5 commits
+- Feature commits need corresponding test commits
+- Bump version with `scripts/bump-version.sh` if source files changed
+
+## Commit convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add new channel
+fix: correct search result dedup
+test: add channel contract tests
+chore: update dependencies
+docs: improve README
+```
+
+Use `scripts/committer "type: message" file1 file2` to commit.
+
+## What we won't accept
+
+- PRs that only refactor without fixing a bug or adding a feature
+- PRs that remove channels (channels are a competitive advantage)
+- PRs that modify `PROTOCOL.md`, `lib/judge.py`, or meta-skills without prior discussion
+- PRs with secrets, API keys, or personal paths

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "maple",
+  "name": "AutoSearch",
+  "colors": {
+    "primary": "#16A34A",
+    "light": "#22C55E",
+    "dark": "#15803D"
+  },
+  "favicon": "/favicon.svg",
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/0xmariowu/Autosearch"
+      }
+    ]
+  },
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": ["introduction", "quickstart", "contributing"]
+          },
+          {
+            "group": "How It Works",
+            "pages": ["architecture", "protocol", "principles"]
+          },
+          {
+            "group": "Reference",
+            "pages": ["channels", "skills", "security", "changelog"]
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/0xmariowu/Autosearch"
+    }
+  }
+}

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y="80" font-size="80">🔍</text>
+</svg>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,49 @@
+---
+title: Introduction
+description: Research that gets smarter every time you use it. 32+ search channels, self-evolving queries, cited reports.
+---
+
+# AutoSearch
+
+Research that gets smarter every time you use it.
+
+32+ search channels. Self-evolving queries. Cited reports. Zero API keys required.
+
+## What is AutoSearch?
+
+AutoSearch is a Claude Code plugin that automates multi-platform research. Instead of manually searching Google, then Reddit, then GitHub, then arXiv, then Chinese platforms — AutoSearch does it all in parallel and delivers a cited report.
+
+The key difference from other search tools: **AutoSearch learns**. After each session, it records which queries found relevant results and which returned nothing. Next time, it skips what failed and doubles down on what worked.
+
+## How it compares
+
+| | AutoSearch | Perplexity | Native Claude |
+|---|---|---|---|
+| **Search channels** | 32+ dedicated connectors | ~3 web engines | 1 (WebSearch) |
+| **Chinese sources** | 12 native platforms | 0 | 0 |
+| **Academic sources** | 6 dedicated connectors | 1 | 0 |
+| **Gets smarter over time** | Yes | No | No |
+| **Every result cited** | Yes (two-stage citation lock) | Yes (URL-level) | No |
+| **Reports** | Markdown / Rich HTML / Slides | Web page | Plain text |
+| **Cost** | Free (Claude Code plugin) | $20/month | Free |
+
+## Quick demo
+
+```bash
+/autosearch "compare vector databases for RAG applications"
+```
+
+AutoSearch asks two questions — how deep and what format — then searches, evaluates, and delivers:
+
+```
+[Phase 1/6] Prepare  — 25 rubrics, 47 items recalled, 15 queries planned
+[Phase 2/6] Search   — 62 results from 12 channels
+[Phase 3/6] Evaluate — 54 relevant, 3 gap queries
+[Phase 4/6] Deliver  — report ready (38 citations)
+[Phase 5/6] Quality  — 23/25 rubrics passed
+[Phase 6/6] Evolve   — 4 patterns saved
+```
+
+## The key insight
+
+Claude already knows 60-70% of most research topics from training data. AutoSearch doesn't waste time re-searching what Claude already knows. It maps gaps first, then searches specifically for fresh data, community voice, Chinese sources, and niche repositories that Claude's training missed.

--- a/docs/principles.mdx
+++ b/docs/principles.mdx
@@ -1,0 +1,83 @@
+---
+title: Evidence Principles
+description: What AutoSearch trusts and why — the evidence evaluation framework behind every research decision.
+---
+
+## Core rule
+
+**Only trust evidence. Only trust recent evidence.**
+
+- For tool/framework/model selection: evidence must be from **2025-06-01 or later**
+- For methodology/principles/patterns: no time limit, but must verify it still holds
+- "I heard" / "people say" / "it's common knowledge" = not evidence
+
+## Three evidence channels
+
+### Channel 1: Papers and articles
+
+Published analysis with methodology and data.
+
+| Tier | Source | Weight |
+|---|---|---|
+| **A — Authoritative** | Top venues (NeurIPS, ICML, ACL) + official publications from Anthropic, OpenAI, Google DeepMind | Primary evidence |
+| **B — Credible** | Lesser-known papers, established tech blogs (Simon Willison, Lilian Weng, Chip Huyen) | Supporting evidence |
+| **C — Supplementary** | Unknown authors, personal blogs, Medium posts | Supplement only |
+
+### Channel 2: Tool chains
+
+Open-source tools, libraries, frameworks on GitHub, HuggingFace, npm, PyPI.
+
+| Tier | Signal | Weight |
+|---|---|---|
+| **A — Established** | 1K+ stars + active maintenance + real issues addressed | Primary evidence |
+| **B — Emerging** | 100-1K stars, OR backed by known org | Supporting evidence |
+| **C — Experimental** | <100 stars, solo maintainer | Supplement only |
+
+### Channel 3: User feedback
+
+Community discussions, complaints, success stories.
+
+| Tier | Source | Weight |
+|---|---|---|
+| **A — Detailed** | Specific experience with reproducible details, engagement > 50 | Primary evidence |
+| **B — Corroborated** | Multiple independent users reporting the same thing | Supporting evidence |
+| **C — Anecdotal** | Single user, no details, low engagement | Supplement only |
+
+## Reliability formula
+
+```
+Reliability = Channel_Count x Evidence_Quality
+
+Channel count:
+  1 channel  -> supplement only
+  2 channels -> credible (act with caution)
+  3 channels -> high confidence (act on this)
+
+Evidence quality (per channel):
+  A-tier -> weight 3
+  B-tier -> weight 2
+  C-tier -> weight 1
+
+Score = sum of weights across channels
+  >= 7 -> strong evidence
+  4-6  -> moderate evidence
+  1-3  -> weak evidence
+```
+
+## Anti-patterns
+
+| Trap | Why it fails |
+|---|---|
+| **Appeal to popularity** | 10K GitHub stars does not equal best solution |
+| **Appeal to recency** | "Just released" does not equal better |
+| **Appeal to authority** | "Google uses X" does not mean X is right for you |
+| **Survivorship bias** | Success stories ignore all the failures |
+| **Single-source trust** | One blog post does not equal truth |
+| **Outdated evidence** | A 2024 benchmark is wrong for 2026 models |
+
+## When evidence is absent
+
+1. Acknowledge the gap explicitly
+2. Check existing knowledge bases for prior art under a different name
+3. If nothing: propose a small-scale test (pilot with 50 cases, not 5000)
+4. Never fill an evidence gap with AI speculation — label hypotheses as hypotheses

--- a/docs/protocol.mdx
+++ b/docs/protocol.mdx
@@ -1,0 +1,57 @@
+---
+title: Operating Protocol
+description: The executable operating instructions that govern AutoSearch's behavior as a self-evolving research agent.
+---
+
+## Identity
+
+AutoSearch is a self-evolving research agent implementing the AVO (Agent Variation Operator) pattern. It uses Claude's training knowledge as a real source alongside searched evidence.
+
+## Skills system
+
+Every `.md` file in `skills/` is a skill with a `name` and `description` in YAML frontmatter. The agent reads the description first to decide when a skill applies, and reads the full skill before executing any capability it governs.
+
+Five meta-skills are immutable: `create-skill`, `observe-user`, `extract-knowledge`, `interact-user`, `discover-environment`.
+
+## Startup sequence
+
+1. Read `state/worklog.jsonl` — check for incomplete sessions
+2. If the last entry is `search_run` with no later `reflection`, resume from that generation's evidence
+3. Read `state/patterns.jsonl` to load accumulated learning
+4. Run `discover-environment` — scan available tools, models, runtimes, API keys
+5. Run `observe-user` — read user context from conversation and project
+
+## The loop
+
+Each iteration is one variation step implementing `Vary(P_t) = Agent(P_t, K, f)`:
+
+- Choose actions from state, evidence, constraints, and opportunity
+- Search with platform skills when search is the best move
+- Evaluate results with `llm-evaluate` when relevance judgment is needed
+- Use own knowledge through `use-own-knowledge` when it adds value
+- Run `judge.py` at least once in every variation step
+
+## Scoring
+
+```bash
+python3 judge.py <evidence-file> [--target N]
+```
+
+Scores against 7 dimensions: `quantity`, `diversity`, `relevance`, `freshness`, `efficiency`, `latency`, `adoption`.
+
+## Evolution rules
+
+- If the new score beats the previous best → keep and commit changes
+- If the new score doesn't beat → discard and revert changes
+- State files (`worklog`, `patterns`, `evolution`, `outcomes`) are append-only and never reverted
+- `anti-cheat` runs before accepting results to prevent score gaming
+
+## Self-supervision
+
+- 3 consecutive flat generations (max score <= min score * 1.01) → redirect strategy
+- 3 consecutive reverts → try a fundamentally different approach
+- If truly stuck → deliver the best honest result with an explanation of what remains uncertain
+
+## Delivery
+
+Deliver when any stopping condition is met: score reaches threshold, budget exhausted, or stuck with no progress. Run `synthesize-knowledge` before final delivery to produce a conceptual framework organized by concept, not by platform.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,50 @@
+---
+title: Quick Start
+description: Install AutoSearch and run your first research query in under a minute.
+---
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/autosearch/main/scripts/install.sh | bash
+```
+
+Or install via the Claude Code plugin system:
+
+```bash
+claude plugin marketplace add 0xmariowu/autosearch
+```
+
+## Use
+
+```bash
+/autosearch "your research topic"
+```
+
+AutoSearch will ask you:
+1. **Depth** — quick, standard, or deep
+2. **Format** — markdown, rich HTML, or slides
+
+Then it searches, evaluates, and delivers a cited report.
+
+## Update
+
+```bash
+claude plugin update autosearch@autosearch
+```
+
+Or re-run the install script. To enable auto-updates: `/plugin` > Marketplaces > autosearch > Enable auto-update.
+
+## Optional: API keys
+
+AutoSearch works with zero API keys. All 32+ channels use free public APIs or scraping.
+
+For enhanced semantic search, you can optionally add:
+
+| Key | What it enables |
+|---|---|
+| `EXA_API_KEY` | Exa semantic web search |
+| `TAVILY_API_KEY` | Tavily research-oriented search |
+| `YOUTUBE_INNERTUBE_KEY` | YouTube transcript extraction |
+
+Set them in your environment or `.env` file.

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -1,0 +1,19 @@
+---
+title: Security
+description: How to report security vulnerabilities in AutoSearch.
+---
+
+## Reporting a vulnerability
+
+If you find a security issue, please email **security@0xmariowu.dev** instead of opening a public issue.
+
+We will respond within 48 hours.
+
+## Scope
+
+Security concerns include:
+
+- Authentication or authorization bypass
+- Data exposure or leakage
+- Command injection or code execution
+- API key or secret exposure in logs or artifacts

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -1,0 +1,82 @@
+---
+title: Skills
+description: The 50+ evolvable skills that make up AutoSearch's capability set.
+---
+
+AutoSearch's behavior is defined by skills — markdown files in `skills/` that the agent reads and follows at runtime. Skills are the "K" in the AVO equation `Vary(P_t) = Agent(P_t, K, f)`.
+
+## How skills work
+
+Each skill is a `.md` file with:
+- YAML frontmatter: `name` and `description` (first sentence = when to use)
+- Free-form body: instructions the agent follows
+
+Skills can be modified by the evolution loop — if a change improves the judge score, it gets committed. If it regresses, it gets reverted.
+
+## Pipeline skills
+
+| Skill | Purpose |
+|---|---|
+| `pipeline-flow` | Orchestrates the 7-phase pipeline |
+| `research-mode` | Choose speed/balanced/deep from user context |
+| `decompose-task` | Break complex questions into sub-questions |
+| `gene-query` | Generate diverse queries from entity/pain/object genes |
+| `select-channels` | Pick 5-10 most relevant channels per topic |
+
+## Knowledge skills
+
+| Skill | Purpose |
+|---|---|
+| `systematic-recall` | Extract everything Claude knows before searching |
+| `use-own-knowledge` | Contribute training knowledge as a source |
+| `knowledge-map` | Save/load structured knowledge maps across sessions |
+| `extract-knowledge` | Pull reusable knowledge from high-quality results |
+
+## Evaluation skills
+
+| Skill | Purpose |
+|---|---|
+| `llm-evaluate` | Semantic relevance judgment on search results |
+| `rerank-evidence` | Rank results by importance for synthesis |
+| `normalize-results` | Standardize results into canonical schema |
+| `extract-dates` | Extract publication dates from all available signals |
+| `generate-rubrics` | Define binary rubrics for quality evaluation |
+| `check-rubrics` | Evaluate each rubric as pass/fail with evidence |
+
+## Synthesis skills
+
+| Skill | Purpose |
+|---|---|
+| `assemble-context` | Select, deduplicate, compress evidence for synthesis |
+| `synthesize-knowledge` | Turn evidence into conceptual frameworks |
+| `evaluate-delivery` | Self-check delivery quality before presenting |
+
+## Evolution skills
+
+| Skill | Purpose |
+|---|---|
+| `auto-evolve` | Run one AVO evolution step |
+| `anti-cheat` | Reject novelty collapse and score gaming |
+| `outcome-tracker` | Learn which queries produced used results |
+| `provider-health` | Track platform health and skip cooling-down sources |
+
+## Meta-skills (immutable)
+
+These five skills cannot be modified by evolution:
+
+| Skill | Purpose |
+|---|---|
+| `create-skill` | Create new skills when a capability is missing |
+| `observe-user` | Learn user preferences and project context |
+| `extract-knowledge` | Pull reusable knowledge from results |
+| `interact-user` | Handle user dialogue and feedback |
+| `discover-environment` | Scan available tools, models, and API keys |
+
+## Utility skills
+
+| Skill | Purpose |
+|---|---|
+| `fetch-webpage` | Full content extraction from URLs |
+| `follow-links` | Follow outlinks from curated collections |
+| `search-author-track` | Discover a researcher's full body of work |
+| `search-citation-graph` | Follow citation chains from known papers |


### PR DESCRIPTION
## Summary

- Added `docs/` directory with Mintlify configuration (`docs.json`) and 10 MDX pages
- Pages: introduction, quickstart, architecture, protocol, evidence principles, channels reference, skills reference, contributing guide, security policy, changelog
- Navigation: Getting Started / How It Works / Reference tabs
- Added documentation link to README nav bar
- Theme: maple with green accent (#16A34A)

## Test plan

- [ ] Verify Mintlify deploys successfully after merge
- [ ] Check all 10 pages render correctly
- [ ] Verify navigation structure matches docs.json
- [ ] Confirm GitHub link in navbar works

🤖 Generated with [Claude Code](https://claude.com/claude-code)