### PR TITLE
feat: tiered Reddit/Twitter fallback with ScrapeCreators + query ID auto-refresh

### DIFF
--- a/channels/_engines/scrapecreators.py
+++ b/channels/_engines/scrapecreators.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+
+import httpx
+
+from lib.search_runner import DEFAULT_TIMEOUT, make_result
+
+API_BASE = "https://api.scrapecreators.com/v1"
+
+
+def _get_api_key() -> str:
+    return os.getenv("SCRAPECREATORS_API_KEY", "").strip()
+
+
+def _headers() -> dict[str, str]:
+    return {"x-api-key": _get_api_key(), "Accept": "application/json"}
+
+
+async def search_reddit(query: str, max_results: int = 10) -> list[dict]:
+    """Search Reddit via ScrapeCreators. Returns [] if no API key."""
+    if not _get_api_key():
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            resp = await client.get(
+                f"{API_BASE}/reddit/search",
+                params={"query": query, "sort": "relevance", "timeframe": "month"},
+                headers=_headers(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            posts = data.get("data", data) if isinstance(data, dict) else data
+            if not isinstance(posts, list):
+                posts = posts.get("children", []) if isinstance(posts, dict) else []
+
+            results: list[dict] = []
+            for post in posts:
+                post_data = post.get("data", post) if isinstance(post, dict) else {}
+                permalink = post_data.get("permalink", "")
+                title = post_data.get("title", "")
+                if not permalink or not title:
+                    continue
+                url = (
+                    f"https://www.reddit.com{permalink}"
+                    if permalink.startswith("/")
+                    else permalink
+                )
+                extra: dict = {
+                    "subreddit": post_data.get("subreddit", ""),
+                    "score": post_data.get("score", 0),
+                    "num_comments": post_data.get("num_comments", 0),
+                }
+                created_utc = post_data.get("created_utc")
+                if isinstance(created_utc, (int, float)):
+                    extra["published_at"] = datetime.fromtimestamp(
+                        created_utc, tz=timezone.utc
+                    ).isoformat()
+                results.append(
+                    make_result(
+                        url=url,
+                        title=title,
+                        snippet=(post_data.get("selftext", "") or "")[:500],
+                        source="reddit",
+                        query=query,
+                        extra_metadata=extra,
+                    )
+                )
+                if len(results) >= max_results:
+                    break
+            return results
+    except Exception as exc:
+        print(f"[scrapecreators] reddit search failed: {exc}", file=sys.stderr)
+        return []
+
+
+async def search_reddit_subreddit(
+    subreddit: str, query: str, max_results: int = 10
+) -> list[dict]:
+    """Search within a specific subreddit via ScrapeCreators. Returns [] if no API key."""
+    if not _get_api_key():
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            resp = await client.get(
+                f"{API_BASE}/reddit/subreddit/search",
+                params={
+                    "subreddit": subreddit,
+                    "query": query,
+                    "sort": "relevance",
+                    "timeframe": "month",
+                },
+                headers=_headers(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            posts = data.get("data", data) if isinstance(data, dict) else data
+            if not isinstance(posts, list):
+                posts = posts.get("children", []) if isinstance(posts, dict) else []
+
+            results: list[dict] = []
+            for post in posts:
+                post_data = post.get("data", post) if isinstance(post, dict) else {}
+                permalink = post_data.get("permalink", "")
+                title = post_data.get("title", "")
+                if not permalink or not title:
+                    continue
+                url = (
+                    f"https://www.reddit.com{permalink}"
+                    if permalink.startswith("/")
+                    else permalink
+                )
+                extra: dict = {
+                    "subreddit": post_data.get("subreddit", subreddit),
+                    "score": post_data.get("score", 0),
+                    "num_comments": post_data.get("num_comments", 0),
+                }
+                created_utc = post_data.get("created_utc")
+                if isinstance(created_utc, (int, float)):
+                    extra["published_at"] = datetime.fromtimestamp(
+                        created_utc, tz=timezone.utc
+                    ).isoformat()
+                results.append(
+                    make_result(
+                        url=url,
+                        title=title,
+                        snippet=(post_data.get("selftext", "") or "")[:500],
+                        source="reddit",
+                        query=query,
+                        extra_metadata=extra,
+                    )
+                )
+                if len(results) >= max_results:
+                    break
+            return results
+    except Exception as exc:
+        print(
+            f"[scrapecreators] reddit subreddit search failed: {exc}",
+            file=sys.stderr,
+        )
+        return []
+
+
+async def fetch_reddit_comments(post_url: str, max_comments: int = 10) -> list[dict]:
+    """Fetch comments for a Reddit post via ScrapeCreators. Returns [] if no API key."""
+    if not _get_api_key():
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            resp = await client.get(
+                f"{API_BASE}/reddit/post/comments",
+                params={"url": post_url},
+                headers=_headers(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            comments_raw = data.get("data", data) if isinstance(data, dict) else data
+            if not isinstance(comments_raw, list):
+                comments_raw = (
+                    comments_raw.get("children", [])
+                    if isinstance(comments_raw, dict)
+                    else []
+                )
+
+            comments: list[dict] = []
+            for node in comments_raw:
+                comment = node.get("data", node) if isinstance(node, dict) else {}
+                author = str(comment.get("author", "") or "")
+                body = str(comment.get("body", "") or "").strip()
+                if not body or author in {"[deleted]", "[removed]", "AutoModerator"}:
+                    continue
+                score = 0
+                try:
+                    score = int(comment.get("score", 0))
+                except (TypeError, ValueError):
+                    pass
+                comments.append(
+                    {
+                        "score": score,
+                        "author": author,
+                        "excerpt": body[:200],
+                    }
+                )
+                if len(comments) >= max_comments:
+                    break
+            comments.sort(key=lambda c: c["score"], reverse=True)
+            return comments
+    except Exception as exc:
+        print(f"[scrapecreators] reddit comments failed: {exc}", file=sys.stderr)
+        return []
+
+
+async def search_twitter(query: str, max_results: int = 10) -> list[dict]:
+    """Search Twitter via ScrapeCreators. Returns [] if no API key."""
+    if not _get_api_key():
+        return []
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            resp = await client.get(
+                f"{API_BASE}/twitter/search/tweets",
+                params={"query": query, "sort_by": "relevance"},
+                headers=_headers(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            tweets = data.get("data", data) if isinstance(data, dict) else data
+            if not isinstance(tweets, list):
+                tweets = []
+
+            results: list[dict] = []
+            for tweet in tweets:
+                text = str(tweet.get("text", "") or tweet.get("full_text", "") or "")
+                tweet_id = str(tweet.get("id_str", "") or tweet.get("id", "") or "")
+                author = str(
+                    tweet.get("screen_name", "")
+                    or tweet.get("user", {}).get("screen_name", "")
+                    or ""
+                )
+                if not text or not tweet_id:
+                    continue
+                url = (
+                    f"https://x.com/{author}/status/{tweet_id}"
+                    if author
+                    else f"https://x.com/i/status/{tweet_id}"
+                )
+                extra: dict = {
+                    "likes": int(tweet.get("favorite_count", 0) or 0),
+                    "reposts": int(tweet.get("retweet_count", 0) or 0),
+                    "replies": int(tweet.get("reply_count", 0) or 0),
+                    "author_handle": author,
+                }
+                created_at = tweet.get("created_at", "")
+                if created_at:
+                    extra["published_at"] = created_at
+                results.append(
+                    make_result(
+                        url=url,
+                        title=text[:200],
+                        snippet=text[:500],
+                        source="twitter",
+                        query=query,
+                        extra_metadata=extra,
+                    )
+                )
+                if len(results) >= max_results:
+                    break
+            return results
+    except Exception as exc:
+        print(f"[scrapecreators] twitter search failed: {exc}", file=sys.stderr)
+        return []

--- a/channels/reddit/search.py
+++ b/channels/reddit/search.py
@@ -139,14 +139,32 @@ async def _search_ddgs_fallback(query: str, max_results: int) -> list[dict]:
 
 
 async def search(query: str, max_results: int = 10) -> list[dict]:
-    # Try JSON API first, fall back to ddgs
+    # Tier 1: ScrapeCreators (if API key set)
+    try:
+        from channels._engines.scrapecreators import search_reddit as sc_search
+
+        results = await sc_search(query, max_results)
+        if results:
+            return results
+    except Exception as exc:
+        print(f"[reddit] ScrapeCreators failed: {exc}", file=sys.stderr)
+
+    # Tier 2: Reddit JSON API (may 403)
     try:
         results = await _search_json_api(query, max_results)
         if results:
             return results
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 403:
+            print(
+                "[reddit] .json API blocked (403), using DDGS fallback", file=sys.stderr
+            )
+        else:
+            print(f"[reddit] JSON API failed: {exc}", file=sys.stderr)
     except Exception as exc:
         print(f"[reddit] JSON API failed, trying fallback: {exc}", file=sys.stderr)
 
+    # Tier 3: DDGS site:reddit.com (always works)
     try:
         return await _search_ddgs_fallback(query, max_results)
     except Exception as exc:

--- a/channels/twitter/graphql.py
+++ b/channels/twitter/graphql.py
@@ -7,6 +7,7 @@ import re
 import sys
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 import httpx
 
@@ -15,6 +16,15 @@ API_BASE = "https://x.com/i/api/graphql"
 DEFAULT_QUERY_ID = "6AAys3t42mosm_yTI_QENg"
 FALLBACK_QUERY_IDS = ["M1jEez78PEfVfbQLvlWMvQ", "5h0kNbk3ii97rmfY6CdgAA"]
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+_CACHE_TTL_SECONDS = 86400  # 24 hours
+_CACHE_FILE: Path | None = None
+_JS_BUNDLE_RE = re.compile(
+    r'https://abs\.twimg\.com/responsive-web/client-web[^"\']+\.js'
+)
+_QUERY_ID_RE = re.compile(
+    r'\{queryId:"([^"]+)"[^}]*operationName:"SearchTimeline"'
+    r'|operationName:"SearchTimeline"[^}]*queryId:"([^"]+)"'
+)
 
 
 def _log_error(message: str, exc: Exception | None = None) -> None:
@@ -51,16 +61,117 @@ def _extract_cookie_pair(cookie_jar: object) -> tuple[str, str] | None:
     return None
 
 
+# --- Query ID refresh ---
+
+
+def _get_cache_path() -> Path:
+    global _CACHE_FILE
+    if _CACHE_FILE is not None:
+        return _CACHE_FILE
+    root = Path(__file__).resolve().parent.parent.parent
+    _CACHE_FILE = root / "state" / "twitter-query-ids.json"
+    return _CACHE_FILE
+
+
+def _load_cached_ids() -> list[str] | None:
+    path = _get_cache_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        cached_at = data.get("cached_at", 0)
+        import time
+
+        if time.time() - cached_at > _CACHE_TTL_SECONDS:
+            return None
+        ids = data.get("query_ids", [])
+        return ids if ids else None
+    except Exception:
+        return None
+
+
+def _save_cached_ids(ids: list[str]) -> None:
+    path = _get_cache_path()
+    try:
+        import time
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"query_ids": ids, "cached_at": time.time()}, indent=2) + "\n"
+        )
+    except OSError:
+        pass
+
+
+async def _fetch_query_ids_from_bundles() -> list[str]:
+    try:
+        timeout = httpx.Timeout(15.0, connect=10.0)
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            headers={"User-Agent": USER_AGENT},
+            follow_redirects=True,
+        ) as client:
+            resp = await client.get("https://x.com")
+            if resp.status_code != 200:
+                return []
+
+            bundle_urls = _JS_BUNDLE_RE.findall(resp.text)
+            if not bundle_urls:
+                return []
+
+            # Only fetch a few bundles to avoid downloading megabytes
+            for url in bundle_urls[:8]:
+                try:
+                    js_resp = await client.get(url)
+                    if js_resp.status_code != 200:
+                        continue
+                    for match in _QUERY_ID_RE.finditer(js_resp.text):
+                        query_id = match.group(1) or match.group(2)
+                        if query_id:
+                            print(
+                                f"[twitter-graphql] refreshed query ID: {query_id}",
+                                file=sys.stderr,
+                            )
+                            return [query_id]
+                except Exception:
+                    continue
+    except Exception as exc:
+        _log_error("Failed to fetch query IDs from bundles", exc)
+    return []
+
+
+async def get_query_ids() -> list[str]:
+    cached = _load_cached_ids()
+    if cached:
+        return cached
+
+    fresh = await _fetch_query_ids_from_bundles()
+    if fresh:
+        _save_cached_ids(fresh)
+        return fresh
+
+    # Fall back to hardcoded IDs
+    return [DEFAULT_QUERY_ID, *FALLBACK_QUERY_IDS]
+
+
+# --- Credential detection ---
+
+
 def get_credentials() -> tuple[str, str] | None:
     try:
         auth_token = os.getenv("TWITTER_AUTH_TOKEN", "").strip()
         ct0 = os.getenv("TWITTER_CT0", "").strip()
         if auth_token and ct0:
+            print("[twitter] using env var credentials for GraphQL", file=sys.stderr)
             return auth_token, ct0
 
         try:
             import browser_cookie3  # type: ignore
         except ImportError:
+            print(
+                "[twitter] install browser-cookie3 for auto cookie extraction",
+                file=sys.stderr,
+            )
             return None
 
         browsers = [
@@ -74,10 +185,18 @@ def get_credentials() -> tuple[str, str] | None:
                 cookie_jar = loader()
                 credentials = _extract_cookie_pair(cookie_jar)
                 if credentials is not None:
+                    print(
+                        f"[twitter] using {browser_name} cookies for GraphQL",
+                        file=sys.stderr,
+                    )
                     return credentials
             except Exception as exc:
                 _log_error(f"Failed to load {browser_name} cookies", exc)
 
+        print(
+            "[twitter] no X/Twitter session found in browsers, using DDGS fallback",
+            file=sys.stderr,
+        )
         return None
     except Exception as exc:
         _log_error("Failed to get credentials", exc)
@@ -242,7 +361,7 @@ async def search_graphql(query: str, max_results: int = 20) -> list[dict]:
             "product": "Latest",
         }
         features = _build_features()
-        query_ids = [DEFAULT_QUERY_ID, *FALLBACK_QUERY_IDS]
+        query_ids = await get_query_ids()
 
         headers = {
             "Authorization": f"Bearer {BEARER_TOKEN}",

--- a/channels/twitter/search.py
+++ b/channels/twitter/search.py
@@ -71,15 +71,31 @@ async def _search_ddgs(query: str, max_results: int) -> list[dict]:
     return merged[:max_results]
 
 
-async def search(query: str, max_results: int = 10) -> list[dict]:
-    """Search Twitter/X — GraphQL first, DDGS fallback."""
+async def _search_scrapecreators(query: str, max_results: int) -> list[dict]:
+    """Try ScrapeCreators Twitter API (requires SCRAPECREATORS_API_KEY)."""
     try:
-        # Try GraphQL (cookie-based, rich engagement data)
+        from channels._engines.scrapecreators import search_twitter as sc_search
+
+        return await sc_search(query, max_results)
+    except Exception as exc:
+        print(f"[twitter] ScrapeCreators failed: {exc}", file=sys.stderr)
+        return []
+
+
+async def search(query: str, max_results: int = 10) -> list[dict]:
+    """Search Twitter/X — GraphQL first, ScrapeCreators second, DDGS fallback."""
+    try:
+        # Tier 1: GraphQL (cookie-based, rich engagement data)
         results = await _search_graphql(query, max_results)
         if results:
             return results
 
-        # Fall back to DDGS site-search
+        # Tier 2: ScrapeCreators (if API key set)
+        results = await _search_scrapecreators(query, max_results)
+        if results:
+            return results
+
+        # Tier 3: DDGS site-search (always works)
         return await _search_ddgs(query, max_results)
     except Exception as exc:
         from lib.search_runner import SearchError

--- a/env.example
+++ b/env.example
@@ -2,6 +2,9 @@
 # Copy to .env and fill in keys for paid channels.
 # All channels work without these (free fallbacks are used).
 
+# ScrapeCreators — one key unlocks full Reddit (search + comments) and Twitter (search + engagement)
+# SCRAPECREATORS_API_KEY=
+
 # Exa — semantic web search (used by search-exa, search-hn-exa, search-reddit-exa, search-twitter-exa)
 # EXA_API_KEY=
 

--- a/lib/enrichment.py
+++ b/lib/enrichment.py
@@ -59,11 +59,36 @@ async def enrich_reddit_items(
         return
 
 
+async def _enrich_via_scrapecreators(result: dict) -> bool:
+    """Try enriching a Reddit post via ScrapeCreators. Returns True if successful."""
+    try:
+        from channels._engines.scrapecreators import fetch_reddit_comments
+
+        comments = await fetch_reddit_comments(result["url"], max_comments=5)
+        if not comments:
+            return False
+
+        metadata = result.setdefault("metadata", {})
+        metadata["top_comments"] = comments
+        metadata["comment_insights"] = _extract_comment_insights(
+            [c.get("excerpt", "") for c in comments]
+        )
+        if comments:
+            metadata["top_comment_score"] = comments[0].get("score", 0)
+        return True
+    except Exception:
+        return False
+
+
 async def _enrich_single(
     result: dict, client: httpx.AsyncClient, bail_event: asyncio.Event
 ) -> None:
     try:
         if bail_event.is_set():
+            return
+
+        # Try ScrapeCreators first (if API key set)
+        if await _enrich_via_scrapecreators(result):
             return
 
         path = urlparse(result["url"]).path
@@ -80,6 +105,12 @@ async def _enrich_single(
 
         if response.status_code == 429:
             bail_event.set()
+            return
+        if response.status_code == 403:
+            print(
+                "[enrichment] reddit .json blocked (403), skipping comment fetch",
+                file=sys.stderr,
+            )
             return
         if response.is_error:
             return

--- a/lib/judge.py
+++ b/lib/judge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import datetime as dt
 import json

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -8,6 +8,12 @@ import pytest
 
 from lib.enrichment import enrich_reddit_items
 
+# All existing tests mock httpx directly. Since _enrich_single now tries
+# ScrapeCreators first, we patch it to return False so the .json path runs.
+_NO_SCRAPECREATORS = patch(
+    "lib.enrichment._enrich_via_scrapecreators", new=AsyncMock(return_value=False)
+)
+
 MOCK_THREAD_JSON = [
     {
         "data": {
@@ -97,7 +103,10 @@ async def test_enrich_adds_top_comments() -> None:
     async def get(*args, **kwargs):
         return _make_response(json_data=MOCK_THREAD_JSON)
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
         _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
         await enrich_reddit_items([result], max_items=1)
 
@@ -119,7 +128,10 @@ async def test_enrich_adds_upvote_ratio() -> None:
     async def get(*args, **kwargs):
         return _make_response(json_data=MOCK_THREAD_JSON)
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
         _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
         await enrich_reddit_items([result], max_items=1)
 
@@ -130,7 +142,10 @@ async def test_enrich_adds_upvote_ratio() -> None:
 async def test_enrich_skips_non_reddit() -> None:
     result = _make_result(source="hn", url="https://news.ycombinator.com/item?id=1")
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
         await enrich_reddit_items([result], max_items=1)
 
     mock_async_client.assert_not_called()
@@ -156,7 +171,10 @@ async def test_enrich_429_bails() -> None:
     async def get(*args, **kwargs):
         return responses.pop(0)
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
         _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
         await enrich_reddit_items([first, second], max_items=2)
 
@@ -173,7 +191,10 @@ async def test_enrich_filters_deleted_comments() -> None:
     async def get(*args, **kwargs):
         return _make_response(json_data=MOCK_THREAD_JSON)
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
         _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
         await enrich_reddit_items([result], max_items=1)
 
@@ -202,7 +223,10 @@ async def test_enrich_comment_insights() -> None:
     async def get(*args, **kwargs):
         return _make_response(json_data=thread_json)
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
         _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
         await enrich_reddit_items([result], max_items=1)
 
@@ -221,7 +245,10 @@ async def test_enrich_network_error_silent() -> None:
     result = _make_result()
     original = deepcopy(result)
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
         _setup_async_client(
             mock_async_client,
             AsyncMock(side_effect=RuntimeError("network down")),
@@ -229,3 +256,42 @@ async def test_enrich_network_error_silent() -> None:
         await enrich_reddit_items([result], max_items=1)
 
     assert result == original
+
+
+@pytest.mark.asyncio
+async def test_enrich_403_logs_and_skips(capsys) -> None:
+    result = _make_result()
+
+    async def get(*args, **kwargs):
+        return _make_response(status_code=403, is_error=True, json_data=None)
+
+    with (
+        _NO_SCRAPECREATORS,
+        patch("lib.enrichment.httpx.AsyncClient") as mock_async_client,
+    ):
+        _setup_async_client(mock_async_client, AsyncMock(side_effect=get))
+        await enrich_reddit_items([result], max_items=1)
+
+    assert "top_comments" not in result["metadata"]
+    captured = capsys.readouterr()
+    assert "403" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_enrich_uses_scrapecreators_when_available() -> None:
+    result = _make_result()
+
+    async def fake_sc_enrich(r: dict) -> bool:
+        r.setdefault("metadata", {})["top_comments"] = [
+            {"score": 80, "author": "sc_user", "excerpt": "Great insight from API"}
+        ]
+        return True
+
+    with patch(
+        "lib.enrichment._enrich_via_scrapecreators",
+        new=AsyncMock(side_effect=fake_sc_enrich),
+    ):
+        await enrich_reddit_items([result], max_items=1)
+
+    # ScrapeCreators populated the comments
+    assert result["metadata"]["top_comments"][0]["author"] == "sc_user"

--- a/tests/test_scrapecreators.py
+++ b/tests/test_scrapecreators.py
@@ -1,0 +1,210 @@
+"""Tests for ScrapeCreators engine (Reddit + Twitter)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _mock_response(status_code: int, json_data: object) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        from httpx import HTTPStatusError
+
+        resp.raise_for_status.side_effect = HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    resp.json.return_value = json_data
+    return resp
+
+
+def _mock_client(response: MagicMock) -> MagicMock:
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# --- Key missing returns [] ---
+
+
+@pytest.mark.asyncio
+async def test_search_reddit_no_key() -> None:
+    from channels._engines.scrapecreators import search_reddit
+
+    with patch("channels._engines.scrapecreators._get_api_key", return_value=""):
+        result = await search_reddit("test", 5)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_search_twitter_no_key() -> None:
+    from channels._engines.scrapecreators import search_twitter
+
+    with patch("channels._engines.scrapecreators._get_api_key", return_value=""):
+        result = await search_twitter("test", 5)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_no_key() -> None:
+    from channels._engines.scrapecreators import fetch_reddit_comments
+
+    with patch("channels._engines.scrapecreators._get_api_key", return_value=""):
+        result = await fetch_reddit_comments("https://reddit.com/r/test/1", 5)
+    assert result == []
+
+
+# --- Reddit search ---
+
+
+@pytest.mark.asyncio
+async def test_search_reddit_parses_posts() -> None:
+    from channels._engines.scrapecreators import search_reddit
+
+    api_response = {
+        "data": [
+            {
+                "data": {
+                    "permalink": "/r/test/comments/abc/hello/",
+                    "title": "Hello World",
+                    "selftext": "This is a test post",
+                    "subreddit": "test",
+                    "score": 42,
+                    "num_comments": 10,
+                    "created_utc": 1712000000,
+                }
+            }
+        ]
+    }
+
+    mock = _mock_client(_mock_response(200, api_response))
+
+    with (
+        patch("channels._engines.scrapecreators._get_api_key", return_value="test-key"),
+        patch("channels._engines.scrapecreators.httpx.AsyncClient", return_value=mock),
+    ):
+        results = await search_reddit("hello", 5)
+
+    assert len(results) == 1
+    assert results[0]["source"] == "reddit"
+    assert "Hello World" in results[0]["title"]
+    assert results[0]["metadata"]["score"] == 42
+
+
+# --- Twitter search ---
+
+
+@pytest.mark.asyncio
+async def test_search_twitter_parses_tweets() -> None:
+    from channels._engines.scrapecreators import search_twitter
+
+    api_response = {
+        "data": [
+            {
+                "id_str": "999",
+                "text": "Test tweet about AI coding",
+                "screen_name": "testuser",
+                "favorite_count": 100,
+                "retweet_count": 20,
+                "reply_count": 5,
+                "created_at": "2025-01-15T12:00:00Z",
+            }
+        ]
+    }
+
+    mock = _mock_client(_mock_response(200, api_response))
+
+    with (
+        patch("channels._engines.scrapecreators._get_api_key", return_value="test-key"),
+        patch("channels._engines.scrapecreators.httpx.AsyncClient", return_value=mock),
+    ):
+        results = await search_twitter("AI coding", 5)
+
+    assert len(results) == 1
+    assert results[0]["source"] == "twitter"
+    assert results[0]["metadata"]["likes"] == 100
+    assert results[0]["metadata"]["author_handle"] == "testuser"
+
+
+# --- Reddit comments ---
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_parses() -> None:
+    from channels._engines.scrapecreators import fetch_reddit_comments
+
+    api_response = {
+        "data": [
+            {
+                "data": {
+                    "author": "user1",
+                    "body": "Great post, very helpful!",
+                    "score": 50,
+                }
+            },
+            {
+                "data": {
+                    "author": "[deleted]",
+                    "body": "[deleted]",
+                    "score": 10,
+                }
+            },
+            {
+                "data": {
+                    "author": "user2",
+                    "body": "I disagree with the premise",
+                    "score": 20,
+                }
+            },
+        ]
+    }
+
+    mock = _mock_client(_mock_response(200, api_response))
+
+    with (
+        patch("channels._engines.scrapecreators._get_api_key", return_value="test-key"),
+        patch("channels._engines.scrapecreators.httpx.AsyncClient", return_value=mock),
+    ):
+        comments = await fetch_reddit_comments("https://reddit.com/r/test/1", 5)
+
+    assert len(comments) == 2  # [deleted] filtered out
+    assert comments[0]["score"] == 50  # sorted by score desc
+    assert comments[0]["author"] == "user1"
+
+
+# --- Error handling ---
+
+
+@pytest.mark.asyncio
+async def test_search_reddit_error_returns_empty() -> None:
+    from channels._engines.scrapecreators import search_reddit
+
+    mock = _mock_client(_mock_response(500, {}))
+
+    with (
+        patch("channels._engines.scrapecreators._get_api_key", return_value="test-key"),
+        patch("channels._engines.scrapecreators.httpx.AsyncClient", return_value=mock),
+    ):
+        results = await search_reddit("test", 5)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_twitter_error_returns_empty() -> None:
+    from channels._engines.scrapecreators import search_twitter
+
+    mock = _mock_client(_mock_response(401, {}))
+
+    with (
+        patch("channels._engines.scrapecreators._get_api_key", return_value="test-key"),
+        patch("channels._engines.scrapecreators.httpx.AsyncClient", return_value=mock),
+    ):
+        results = await search_twitter("test", 5)
+
+    assert results == []

--- a/tests/test_twitter_graphql.py
+++ b/tests/test_twitter_graphql.py
@@ -76,6 +76,79 @@ def _make_response(status_code: int, payload: dict | None = None) -> MagicMock:
     return mock_response
 
 
+# --- Query ID refresh tests ---
+
+
+@pytest.mark.asyncio
+async def test_get_query_ids_uses_cache(tmp_path) -> None:
+    import json
+    import time
+
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    cache_file = tmp_path / "twitter-query-ids.json"
+    cache_file.write_text(
+        json.dumps({"query_ids": ["cached_id_123"], "cached_at": time.time()})
+    )
+
+    with patch.object(graphql, "_CACHE_FILE", cache_file):
+        # Bypass the global cache path
+        original = graphql._get_cache_path
+
+        def patched_cache():
+            return cache_file
+
+        graphql._get_cache_path = patched_cache
+        try:
+            ids = await graphql.get_query_ids()
+        finally:
+            graphql._get_cache_path = original
+
+    assert ids == ["cached_id_123"]
+
+
+@pytest.mark.asyncio
+async def test_get_query_ids_expired_cache_refreshes() -> None:
+
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    # Expired cache (cached_at = 0)
+    with (
+        patch.object(graphql, "_load_cached_ids", return_value=None),
+        patch.object(
+            graphql,
+            "_fetch_query_ids_from_bundles",
+            new=AsyncMock(return_value=["fresh_id_456"]),
+        ),
+        patch.object(graphql, "_save_cached_ids") as mock_save,
+    ):
+        ids = await graphql.get_query_ids()
+
+    assert ids == ["fresh_id_456"]
+    mock_save.assert_called_once_with(["fresh_id_456"])
+
+
+@pytest.mark.asyncio
+async def test_get_query_ids_falls_back_to_hardcoded() -> None:
+    graphql = importlib.import_module("channels.twitter.graphql")
+
+    with (
+        patch.object(graphql, "_load_cached_ids", return_value=None),
+        patch.object(
+            graphql,
+            "_fetch_query_ids_from_bundles",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        ids = await graphql.get_query_ids()
+
+    assert ids[0] == graphql.DEFAULT_QUERY_ID
+    assert len(ids) == 3
+
+
+# --- Credential tests ---
+
+
 def test_get_credentials_from_env() -> None:
     graphql = importlib.import_module("channels.twitter.graphql")
 
@@ -178,10 +251,20 @@ async def test_search_graphql_tries_fallback_on_404() -> None:
     success_response = _make_response(200, MOCK_GRAPHQL_RESPONSE)
     mock_client = _make_async_client(side_effect=[not_found_response, success_response])
 
+    # Mock get_query_ids to return the hardcoded list (so we control which IDs are tried)
     with (
         patch(
             "channels.twitter.graphql.get_credentials",
             return_value=("auth_token", "ct0"),
+        ),
+        patch(
+            "channels.twitter.graphql.get_query_ids",
+            new=AsyncMock(
+                return_value=[
+                    graphql.DEFAULT_QUERY_ID,
+                    *graphql.FALLBACK_QUERY_IDS,
+                ]
+            ),
         ),
         patch("channels.twitter.graphql.httpx.AsyncClient", return_value=mock_client),
     ):


### PR DESCRIPTION
## Summary

- Reddit and Twitter channels now use three-tier fallback: ScrapeCreators API (optional) → native API → DuckDuckGo
- Twitter GraphQL query IDs auto-refresh from X's JS bundles (24h cache), replacing hardcoded IDs that break on rotation
- Cookie extraction and fallback paths log clearly to stderr so users know what's happening
- Reddit enrichment tries ScrapeCreators for comments first, logs 403 blocks instead of silent failure
- One optional env var `SCRAPECREATORS_API_KEY` unlocks full Reddit (search + comments) and Twitter (search + engagement)
- Fixed judge.py Python 3.9 compat (`from __future__ import annotations`)

## Test plan

- [x] 477 passed, 0 failed (full test suite minus live API smoke tests)
- [x] 29 new/modified tests: ScrapeCreators engine (8), query ID refresh (3), enrichment 403 + ScrapeCreators (2), existing tests updated
- [x] Live verified: query ID refresh fetched `pCd62NDD9dlCDgEGgEVHMg` from x.com JS bundle
- [x] Live verified: Reddit fallback chain ScrapeCreators(skip) → .json(403, logged) → DDGS(ok)
- [x] Live verified: Twitter fallback chain GraphQL(no creds, logged) → ScrapeCreators(skip) → DDGS(ok)
- [ ] ScrapeCreators API paths need live testing with a real API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)