### PR TITLE
feat: content processing pipeline — BM25 filter, enrichment, two-tier claims

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.05.4"
+    "version": "2026.04.05.5"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.05.4",
+      "version": "2026.04.05.5",
       "author": {
         "name": "0xmariowu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.05.4",
+  "version": "2026.04.05.5",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.05.5
+
+### Changes
+
+- You can now get deeply processed research content — top results are fetched in full via Jina Reader, filtered to query-relevant paragraphs with BM25, and stored as extracted content
+- You can now get richer evidence in reports — claims from deep-processed results include verbatim evidence quotes and specific data points, not just one-sentence summaries
+- Content processing pipeline replicated from crawl4ai: BM25 paragraph filtering, HTML noise pruning, sliding window chunking, citation formatting, 3-tier anti-bot detection
+- Results are re-scored after content enrichment using full-content relevance (more accurate than snippet-based scoring)
+- HN channel now uses story_text for Ask HN / Show HN posts (was showing only points/comments)
+- arXiv abstracts are no longer truncated at 300 characters
+- Snippet cap increased from 500 to 1500 characters for richer Block 3 evaluation
+
+---
+
 ## 2026.04.05.4
 
 ## 2026.04.05.3

--- a/channels/arxiv/search.py
+++ b/channels/arxiv/search.py
@@ -39,7 +39,7 @@ async def search(query: str, max_results: int = 10) -> list[dict]:
                 )
                 url = id_el.text.strip() if id_el.text else ""
                 snippet = (
-                    summary_el.text.strip()[:300]
+                    summary_el.text.strip().replace("\n", " ")
                     if summary_el is not None and summary_el.text
                     else ""
                 )

--- a/channels/hn/search.py
+++ b/channels/hn/search.py
@@ -29,11 +29,18 @@ async def search(query: str, max_results: int = 10) -> list[dict]:
                     h.get("url")
                     or f"https://news.ycombinator.com/item?id={h.get('objectID', '')}"
                 )
+                # Prefer story_text (Ask HN / Show HN posts have it)
+                snippet = h.get("story_text") or ""
+                if not snippet:
+                    snippet = (
+                        f"Points: {h.get('points', 0)}"
+                        f" | Comments: {h.get('num_comments', 0)}"
+                    )
                 results.append(
                     make_result(
                         url=url,
                         title=h.get("title", ""),
-                        snippet=f"Points: {h.get('points', 0)} | Comments: {h.get('num_comments', 0)}",
+                        snippet=snippet,
                         source="hn",
                         query=query,
                         extra_metadata=metadata,

--- a/lib/content_processing.py
+++ b/lib/content_processing.py
@@ -1,0 +1,713 @@
+from __future__ import annotations
+
+import math
+import re
+
+import lxml.html
+from rank_bm25 import BM25Okapi
+from snowballstemmer import stemmer
+
+LINK_PATTERN = re.compile(
+    r'!?\[((?:[^\[\]]|\[(?:[^\[\]]|\[[^\]]*\])*\])*)\]\(((?:[^()\s]|\([^()]*\))*)(?:\s+"([^"]*)")?\)'
+)
+
+STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "he",
+    "in",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "that",
+    "the",
+    "to",
+    "was",
+    "were",
+    "will",
+    "with",
+    "i",
+    "you",
+    "she",
+    "we",
+    "they",
+    "me",
+    "him",
+    "her",
+    "us",
+    "them",
+    "my",
+    "your",
+    "his",
+    "our",
+    "their",
+    "mine",
+    "yours",
+    "hers",
+    "ours",
+    "theirs",
+    "myself",
+    "yourself",
+    "himself",
+    "herself",
+    "itself",
+    "ourselves",
+    "themselves",
+    "am",
+    "been",
+    "being",
+    "have",
+    "had",
+    "having",
+    "do",
+    "does",
+    "did",
+    "doing",
+    "about",
+    "above",
+    "across",
+    "after",
+    "against",
+    "along",
+    "among",
+    "around",
+    "before",
+    "behind",
+    "below",
+    "beneath",
+    "beside",
+    "between",
+    "beyond",
+    "down",
+    "during",
+    "except",
+    "inside",
+    "into",
+    "near",
+    "off",
+    "out",
+    "outside",
+    "over",
+    "past",
+    "through",
+    "toward",
+    "under",
+    "underneath",
+    "until",
+    "up",
+    "upon",
+    "within",
+    "but",
+    "or",
+    "nor",
+    "yet",
+    "so",
+    "although",
+    "because",
+    "since",
+    "unless",
+    "this",
+    "these",
+    "those",
+    "what",
+    "which",
+    "who",
+    "whom",
+    "whose",
+    "when",
+    "where",
+    "why",
+    "how",
+    "all",
+    "any",
+    "both",
+    "each",
+    "few",
+    "more",
+    "most",
+    "other",
+    "some",
+    "such",
+    "can",
+    "cannot",
+    "can't",
+    "could",
+    "couldn't",
+    "may",
+    "might",
+    "must",
+    "mustn't",
+    "shall",
+    "should",
+    "shouldn't",
+    "won't",
+    "would",
+    "wouldn't",
+    "not",
+    "n't",
+    "no",
+    "none",
+}
+
+_NOISE = {
+    "ccp",
+    "up",
+    "↑",
+    "▲",
+    "⬆️",
+    "a",
+    "an",
+    "at",
+    "by",
+    "in",
+    "of",
+    "on",
+    "to",
+    "the",
+}
+
+_PARAGRAPH_WEIGHTS = {
+    "h1": 5.0,
+    "h2": 4.0,
+    "h3": 3.0,
+    "h4": 2.0,
+    "blockquote": 2.0,
+    "code": 2.0,
+    "content": 1.0,
+}
+
+_PRUNING_REMOVE_TAGS = {
+    "script",
+    "style",
+    "nav",
+    "footer",
+    "header",
+    "aside",
+    "form",
+    "iframe",
+    "noscript",
+}
+
+_PRUNING_TAG_WEIGHTS = {
+    "div": 0.5,
+    "p": 1.0,
+    "article": 1.5,
+    "section": 1.0,
+    "span": 0.3,
+    "li": 0.5,
+    "ul": 0.5,
+    "ol": 0.5,
+    "h1": 1.2,
+    "h2": 1.1,
+    "h3": 1.0,
+    "h4": 0.9,
+    "h5": 0.8,
+    "h6": 0.7,
+}
+
+_NEGATIVE_PATTERNS = re.compile(
+    r"nav|footer|header|sidebar|ads|comment|promo|advert|social|share", re.I
+)
+
+_TIER1_PATTERNS = [
+    (
+        re.compile(r"Reference\s*#\s*[\d]+\.[0-9a-f]+\.\d+\.[0-9a-f]+", re.IGNORECASE),
+        "Akamai block (Reference #)",
+    ),
+    (
+        re.compile(r"Pardon\s+Our\s+Interruption", re.IGNORECASE),
+        "Akamai challenge (Pardon Our Interruption)",
+    ),
+    (
+        re.compile(r"challenge-form.*?__cf_chl_f_tk=", re.IGNORECASE | re.DOTALL),
+        "Cloudflare challenge form",
+    ),
+    (
+        re.compile(r'<span\s+class="cf-error-code">\d{4}</span>', re.IGNORECASE),
+        "Cloudflare firewall block",
+    ),
+    (
+        re.compile(r"/cdn-cgi/challenge-platform/\S+orchestrate", re.IGNORECASE),
+        "Cloudflare JS challenge",
+    ),
+    (
+        re.compile(r"window\._pxAppId\s*=", re.IGNORECASE),
+        "PerimeterX block",
+    ),
+    (
+        re.compile(r"captcha\.px-cdn\.net", re.IGNORECASE),
+        "PerimeterX captcha",
+    ),
+    (
+        re.compile(r"captcha-delivery\.com", re.IGNORECASE),
+        "DataDome captcha",
+    ),
+    (
+        re.compile(r"_Incapsula_Resource", re.IGNORECASE),
+        "Imperva/Incapsula block",
+    ),
+    (
+        re.compile(r"Incapsula\s+incident\s+ID", re.IGNORECASE),
+        "Imperva/Incapsula incident",
+    ),
+    (
+        re.compile(r"Sucuri\s+WebSite\s+Firewall", re.IGNORECASE),
+        "Sucuri firewall block",
+    ),
+    (
+        re.compile(r"KPSDK\.scriptStart\s*=\s*KPSDK\.now\(\)", re.IGNORECASE),
+        "Kasada challenge",
+    ),
+    (
+        re.compile(r"blocked\s+by\s+network\s+security", re.IGNORECASE),
+        "Network security block",
+    ),
+]
+
+_TIER2_PATTERNS = [
+    (
+        re.compile(r"Access\s+Denied", re.IGNORECASE),
+        "Access Denied on short page",
+    ),
+    (
+        re.compile(r"Checking\s+your\s+browser", re.IGNORECASE),
+        "Cloudflare browser check",
+    ),
+    (
+        re.compile(r"<title>\s*Just\s+a\s+moment", re.IGNORECASE),
+        "Cloudflare interstitial",
+    ),
+    (
+        re.compile(r'class=["\']g-recaptcha["\']', re.IGNORECASE),
+        "reCAPTCHA on block page",
+    ),
+    (
+        re.compile(r'class=["\']h-captcha["\']', re.IGNORECASE),
+        "hCaptcha on block page",
+    ),
+    (
+        re.compile(r"Access\s+to\s+This\s+Page\s+Has\s+Been\s+Blocked", re.IGNORECASE),
+        "PerimeterX block page",
+    ),
+    (
+        re.compile(r"blocked\s+by\s+security", re.IGNORECASE),
+        "Blocked by security",
+    ),
+    (
+        re.compile(r"Request\s+unsuccessful", re.IGNORECASE),
+        "Request unsuccessful (Imperva)",
+    ),
+]
+
+_TIER2_MAX_SIZE = 10000
+_STRUCTURAL_MAX_SIZE = 50000
+_CONTENT_ELEMENTS_RE = re.compile(
+    r"<(?:p|h[1-6]|article|section|li|td|a|pre)\b", re.IGNORECASE
+)
+_SCRIPT_TAG_RE = re.compile(r"<script\b", re.IGNORECASE)
+_STYLE_TAG_RE = re.compile(r"<style\b[\s\S]*?</style>", re.IGNORECASE)
+_SCRIPT_BLOCK_RE = re.compile(r"<script\b[\s\S]*?</script>", re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
+_BODY_RE = re.compile(r"<body\b", re.IGNORECASE)
+_BLOCK_PAGE_MAX_SIZE = 5000
+_EMPTY_CONTENT_THRESHOLD = 100
+
+
+def _classify_markdown_paragraph(paragraph: str) -> str:
+    if paragraph.startswith("#### "):
+        return "h4"
+    if paragraph.startswith("### "):
+        return "h3"
+    if paragraph.startswith("## "):
+        return "h2"
+    if paragraph.startswith("# "):
+        return "h1"
+    if paragraph.startswith("> "):
+        return "blockquote"
+    if paragraph.startswith("```"):
+        return "code"
+    return "content"
+
+
+def _stem_tokens(text: str, stemmer_instance) -> list[str]:
+    return [stemmer_instance.stemWord(word) for word in text.lower().split()]
+
+
+def _remove_node(node) -> None:
+    parent = node.getparent()
+    if parent is not None:
+        parent.remove(node)
+
+
+def _node_text(node) -> str:
+    return "".join(node.itertext()).strip()
+
+
+def _node_inner_html(node) -> str:
+    parts = []
+    if node.text:
+        parts.append(node.text)
+    for child in node:
+        parts.append(lxml.html.tostring(child, encoding="unicode"))
+    return "".join(parts)
+
+
+def _direct_link_text_length(node) -> int:
+    link_text_len = 0
+    for child in node:
+        if getattr(child, "tag", None) == "a" and len(child) == 0 and child.text:
+            link_text_len += len(child.text.strip())
+    return link_text_len
+
+
+def _compute_class_id_weight(node) -> float:
+    class_id_score = 0.0
+    classes = node.get("class")
+    if classes:
+        if _NEGATIVE_PATTERNS.match(classes):
+            class_id_score -= 0.5
+    element_id = node.get("id")
+    if element_id:
+        if _NEGATIVE_PATTERNS.match(element_id):
+            class_id_score -= 0.5
+    return class_id_score
+
+
+def _compute_pruning_score(node) -> float:
+    text_len = len(_node_text(node))
+    tag_len = len(_node_inner_html(node))
+    link_text_len = _direct_link_text_length(node)
+
+    score = 0.0
+    total_weight = 0.0
+
+    density = text_len / tag_len if tag_len > 0 else 0
+    score += 0.4 * density
+    total_weight += 0.4
+
+    density = 1 - (link_text_len / text_len if text_len > 0 else 0)
+    score += 0.2 * density
+    total_weight += 0.2
+
+    tag_score = _PRUNING_TAG_WEIGHTS.get(node.tag, 0.5)
+    score += 0.2 * tag_score
+    total_weight += 0.2
+
+    class_score = _compute_class_id_weight(node)
+    score += 0.1 * max(0, class_score)
+    total_weight += 0.1
+
+    score += 0.1 * math.log(text_len + 1)
+    total_weight += 0.1
+
+    return score / total_weight if total_weight > 0 else 0.0
+
+
+def _prune_tree(node, threshold: float) -> None:
+    if node is None or not isinstance(getattr(node, "tag", None), str):
+        return
+
+    if _compute_pruning_score(node) < threshold:
+        parent = node.getparent()
+        if parent is not None:
+            parent.remove(node)
+        else:
+            node.clear()
+            node.text = ""
+        return
+
+    children = [child for child in node if isinstance(getattr(child, "tag", None), str)]
+    for child in children:
+        _prune_tree(child, threshold)
+
+
+def _looks_like_data(html: str) -> bool:
+    stripped = html.strip()
+    if not stripped:
+        return False
+    if stripped[0] in ("{", "["):
+        return True
+    if stripped[:10].lower().startswith(("<html", "<!")):
+        if re.search(
+            r"<body[^>]*>\s*<pre[^>]*>\s*[{\[]", stripped[:500], re.IGNORECASE
+        ):
+            return True
+        return False
+    return stripped[0] == "<"
+
+
+def _structural_integrity_check(html: str) -> tuple[bool, str]:
+    html_len = len(html)
+    if html_len > _STRUCTURAL_MAX_SIZE or _looks_like_data(html):
+        return False, ""
+
+    signals = []
+
+    if not _BODY_RE.search(html):
+        return True, f"Structural: no <body> tag ({html_len} bytes)"
+
+    body_match = re.search(r"<body\b[^>]*>([\s\S]*)</body>", html, re.IGNORECASE)
+    body_content = body_match.group(1) if body_match else html
+    stripped = _SCRIPT_BLOCK_RE.sub("", body_content)
+    stripped = _STYLE_TAG_RE.sub("", stripped)
+    visible_text = _TAG_RE.sub("", stripped).strip()
+    visible_len = len(visible_text)
+    if visible_len < 50:
+        signals.append("minimal_text")
+
+    content_elements = len(_CONTENT_ELEMENTS_RE.findall(html))
+    if content_elements == 0:
+        signals.append("no_content_elements")
+
+    script_count = len(_SCRIPT_TAG_RE.findall(html))
+    if script_count > 0 and content_elements == 0 and visible_len < 100:
+        signals.append("script_heavy_shell")
+
+    signal_count = len(signals)
+    if signal_count >= 2:
+        return (
+            True,
+            f"Structural: {', '.join(signals)} ({html_len} bytes, {visible_len} chars visible)",
+        )
+
+    if signal_count == 1 and html_len < 5000:
+        return (
+            True,
+            f"Structural: {signals[0]} on small page ({html_len} bytes, {visible_len} chars visible)",
+        )
+
+    return False, ""
+
+
+def filter_relevant_paragraphs(
+    markdown: str,
+    query: str,
+    threshold: float = 1.0,
+    language: str = "english",
+) -> str:
+    if not markdown or not isinstance(markdown, str):
+        return ""
+    if not query or not isinstance(query, str):
+        return ""
+
+    paragraphs = [
+        paragraph for paragraph in markdown.split("\n\n") if paragraph.strip()
+    ]
+    if not paragraphs:
+        return ""
+
+    paragraph_types = [
+        _classify_markdown_paragraph(paragraph) for paragraph in paragraphs
+    ]
+    stemmer_instance = stemmer(language)
+
+    tokenized_corpus = [
+        _clean_tokens(_stem_tokens(paragraph, stemmer_instance))
+        for paragraph in paragraphs
+    ]
+    tokenized_query = _clean_tokens(_stem_tokens(query, stemmer_instance))
+
+    bm25 = BM25Okapi(tokenized_corpus)
+    scores = bm25.get_scores(tokenized_query)
+
+    adjusted_candidates = []
+    for index, (paragraph, paragraph_type, score) in enumerate(
+        zip(paragraphs, paragraph_types, scores, strict=True)
+    ):
+        adjusted_score = score * _PARAGRAPH_WEIGHTS.get(paragraph_type, 1.0)
+        adjusted_candidates.append((adjusted_score, index, paragraph))
+
+    selected_indices = {
+        index
+        for adjusted_score, index, _paragraph in adjusted_candidates
+        if adjusted_score >= threshold
+    }
+    minimum_keep = min(3, len(adjusted_candidates))
+    if len(selected_indices) < minimum_keep:
+        for _score, index, _paragraph in sorted(
+            adjusted_candidates, key=lambda item: item[0], reverse=True
+        )[:minimum_keep]:
+            selected_indices.add(index)
+
+    return "\n\n".join(
+        paragraph
+        for index, paragraph in enumerate(paragraphs)
+        if index in selected_indices
+    )
+
+
+def prune_html(html: str, threshold: float = 0.48) -> str:
+    if not html or not isinstance(html, str):
+        return ""
+
+    try:
+        root = lxml.html.fromstring(html)
+    except Exception:
+        try:
+            root = lxml.html.fromstring(f"<body>{html}</body>")
+        except Exception:
+            return ""
+
+    if not isinstance(getattr(root, "tag", None), str):
+        return ""
+
+    if root.tag.lower() == "html":
+        body = root.find(".//body")
+        if body is None:
+            return ""
+        tree_root = body
+    elif root.tag.lower() == "body":
+        tree_root = root
+    else:
+        try:
+            tree_root = lxml.html.fromstring(f"<body>{html}</body>")
+        except Exception:
+            return ""
+
+    for comment in tree_root.xpath(".//comment()"):
+        _remove_node(comment)
+
+    for tag in _PRUNING_REMOVE_TAGS:
+        for node in tree_root.findall(f".//{tag}"):
+            _remove_node(node)
+
+    _prune_tree(tree_root, threshold)
+    return lxml.html.tostring(tree_root, encoding="unicode", method="text")
+
+
+def chunk_with_overlap(
+    text: str, window_size: int = 2000, step: int = 1800
+) -> list[str]:
+    words = text.split()
+    chunks = []
+
+    if len(words) <= window_size:
+        return [text]
+
+    for i in range(0, len(words) - window_size + 1, step):
+        chunk = " ".join(words[i : i + window_size])
+        chunks.append(chunk)
+
+    if i + window_size < len(words):
+        chunks.append(" ".join(words[-window_size:]))
+
+    return chunks
+
+
+def convert_to_citations(markdown: str) -> tuple[str, str]:
+    """Convert [text](url) to text⟨N⟩ with reference section."""
+    link_map = {}
+    parts = []
+    last_end = 0
+    counter = 1
+
+    for match in LINK_PATTERN.finditer(markdown):
+        parts.append(markdown[last_end : match.start()])
+        text, url, title = match.groups()
+
+        if url not in link_map:
+            desc = []
+            if title:
+                desc.append(title)
+            if text and text != title:
+                desc.append(text)
+            link_map[url] = (counter, ": " + " - ".join(desc) if desc else "")
+            counter += 1
+
+        num = link_map[url][0]
+        parts.append(
+            f"{text}⟨{num}⟩"
+            if not match.group(0).startswith("!")
+            else f"![{text}⟨{num}⟩]"
+        )
+        last_end = match.end()
+
+    parts.append(markdown[last_end:])
+    converted_text = "".join(parts)
+
+    references = ["\n\n## References\n\n"]
+    references.extend(
+        f"⟨{num}⟩ {url}{desc}\n"
+        for url, (num, desc) in sorted(link_map.items(), key=lambda item: item[1][0])
+    )
+
+    return converted_text, "".join(references)
+
+
+def is_blocked(status_code: int | None, html: str) -> tuple[bool, str]:
+    html = html or ""
+    html_len = len(html)
+
+    if status_code == 429:
+        return True, "HTTP 429 Too Many Requests"
+
+    snippet = html[:15000]
+    if snippet:
+        for pattern, reason in _TIER1_PATTERNS:
+            if pattern.search(snippet):
+                return True, reason
+
+    if html_len > 15000:
+        stripped_for_t1 = _SCRIPT_BLOCK_RE.sub("", html[:500000])
+        stripped_for_t1 = _STYLE_TAG_RE.sub("", stripped_for_t1)
+        deep_snippet = stripped_for_t1[:30000]
+        for pattern, reason in _TIER1_PATTERNS:
+            if pattern.search(deep_snippet):
+                return True, reason
+
+    if status_code in (403, 503) and not _looks_like_data(html):
+        if html_len < _EMPTY_CONTENT_THRESHOLD:
+            return (
+                True,
+                f"HTTP {status_code} with near-empty response ({html_len} bytes)",
+            )
+        if html_len > _TIER2_MAX_SIZE:
+            stripped = _SCRIPT_BLOCK_RE.sub("", html[:500000])
+            stripped = _STYLE_TAG_RE.sub("", stripped)
+            check_snippet = stripped[:30000]
+        else:
+            check_snippet = snippet
+        for pattern, reason in _TIER2_PATTERNS:
+            if pattern.search(check_snippet):
+                return True, f"{reason} (HTTP {status_code}, {html_len} bytes)"
+        return True, f"HTTP {status_code} with HTML content ({html_len} bytes)"
+
+    if status_code and status_code >= 400 and html_len < _TIER2_MAX_SIZE:
+        for pattern, reason in _TIER2_PATTERNS:
+            if pattern.search(snippet):
+                return True, f"{reason} (HTTP {status_code}, {html_len} bytes)"
+
+    if status_code == 200:
+        stripped = html.strip()
+        if len(stripped) < _EMPTY_CONTENT_THRESHOLD and not _looks_like_data(html):
+            return True, f"Near-empty content ({len(stripped)} bytes) with HTTP 200"
+
+    blocked, reason = _structural_integrity_check(html)
+    if blocked:
+        return True, reason
+
+    return False, ""
+
+
+def _clean_tokens(tokens: list[str]) -> list[str]:
+    return [
+        token
+        for token in tokens
+        if len(token) > 2
+        and token not in _NOISE
+        and token not in STOP_WORDS
+        and not token.startswith("↑")
+        and not token.startswith("▲")
+        and not token.startswith("⬆")
+    ]

--- a/lib/enrichment.py
+++ b/lib/enrichment.py
@@ -223,6 +223,13 @@ async def enrich_content(
                     await asyncio.gather(*tasks, return_exceptions=True)
                 except Exception:
                     pass
+        # Re-score results now that we have richer content
+        try:
+            from lib.scoring import rescore_enriched
+
+            rescore_enriched(results, query)
+        except Exception as exc:
+            print(f"[content-enrichment] rescore failed: {exc}", file=sys.stderr)
     except Exception as exc:
         print(f"[content-enrichment] {exc}", file=sys.stderr)
 

--- a/lib/enrichment.py
+++ b/lib/enrichment.py
@@ -167,6 +167,160 @@ async def _enrich_single(
         return
 
 
+JINA_READER_PREFIX = "https://r.jina.ai/"
+_CONTENT_MAX_CHARS = 3000
+
+
+async def enrich_content(
+    results: list[dict],
+    query: str,
+    max_items: int = 10,
+    timeout_per: float = 15.0,
+    timeout_total: float = 60.0,
+) -> None:
+    """Fetch full content for top results, BM25-filter, store in metadata.
+
+    Runs after Reddit enrichment. Skips Reddit results (have their own
+    enrichment) and results that already have extracted_content.
+    Never raises — all errors logged to stderr.
+    """
+    try:
+        candidates = [
+            r
+            for r in results
+            if r.get("source") != "reddit"
+            and not r.get("metadata", {}).get("extracted_content")
+            and r.get("metadata", {}).get("composite_score", 0) >= 30
+        ]
+        candidates.sort(
+            key=lambda r: r.get("metadata", {}).get("composite_score", 0),
+            reverse=True,
+        )
+        selected = candidates[:max_items]
+        if not selected:
+            return
+
+        bail_event = asyncio.Event()
+        async with httpx.AsyncClient(timeout=timeout_per) as client:
+            tasks = [
+                asyncio.create_task(_fetch_and_process(r, query, client, bail_event))
+                for r in selected
+            ]
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*tasks, return_exceptions=True),
+                    timeout=timeout_total,
+                )
+            except asyncio.TimeoutError:
+                print(
+                    f"[content-enrichment] timeout after {timeout_total}s",
+                    file=sys.stderr,
+                )
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                try:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                except Exception:
+                    pass
+    except Exception as exc:
+        print(f"[content-enrichment] {exc}", file=sys.stderr)
+
+
+async def _fetch_and_process(
+    result: dict,
+    query: str,
+    client: httpx.AsyncClient,
+    bail_event: asyncio.Event,
+) -> None:
+    """Fetch full page via Jina Reader, BM25-filter, store in metadata."""
+    try:
+        if bail_event.is_set():
+            return
+
+        url = result.get("url", "")
+        if not url:
+            return
+
+        content = await _fetch_via_jina(url, client, bail_event)
+        if not content:
+            content = await _fetch_via_httpx(url, client, bail_event)
+        if not content or len(content.strip()) < 100:
+            return
+
+        # BM25 filter: keep only query-relevant paragraphs
+        from lib.content_processing import filter_relevant_paragraphs
+
+        filtered = filter_relevant_paragraphs(content, query)
+        if not filtered or len(filtered.strip()) < 50:
+            filtered = content[:_CONTENT_MAX_CHARS]
+
+        # Chunk if still too long
+        if len(filtered.split()) > 3000:
+            from lib.content_processing import chunk_with_overlap
+
+            chunks = chunk_with_overlap(filtered, window_size=2000, step=1800)
+            filtered = chunks[0] if chunks else filtered[:_CONTENT_MAX_CHARS]
+
+        # Truncate and store
+        result.setdefault("metadata", {})["extracted_content"] = filtered[
+            :_CONTENT_MAX_CHARS
+        ]
+    except Exception as exc:
+        print(f"[content-enrichment] {result.get('url', '?')}: {exc}", file=sys.stderr)
+
+
+async def _fetch_via_jina(
+    url: str, client: httpx.AsyncClient, bail_event: asyncio.Event
+) -> str:
+    """Fetch markdown via Jina Reader API."""
+    try:
+        if bail_event.is_set():
+            return ""
+        resp = await client.get(
+            f"{JINA_READER_PREFIX}{url}",
+            headers={
+                "Accept": "text/markdown",
+                "X-Return-Format": "markdown",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        if resp.status_code == 429:
+            bail_event.set()
+            return ""
+        if resp.is_error:
+            return ""
+        return resp.text
+    except Exception:
+        return ""
+
+
+async def _fetch_via_httpx(
+    url: str, client: httpx.AsyncClient, bail_event: asyncio.Event
+) -> str:
+    """Fallback: direct fetch + noise removal."""
+    try:
+        if bail_event.is_set():
+            return ""
+        resp = await client.get(url, headers={"User-Agent": USER_AGENT})
+        if resp.status_code == 429:
+            bail_event.set()
+            return ""
+        if resp.is_error:
+            return ""
+
+        html = resp.text
+        from lib.content_processing import is_blocked, prune_html
+
+        blocked, _reason = is_blocked(resp.status_code, html)
+        if blocked:
+            return ""
+
+        return prune_html(html)
+    except Exception:
+        return ""
+
+
 def _extract_comment_insights(comment_bodies: list[str]) -> list[str]:
     insights: list[str] = []
     seen: set[str] = set()

--- a/lib/scoring.py
+++ b/lib/scoring.py
@@ -86,6 +86,43 @@ def score_results(results: list[dict], query: str) -> None:
     )
 
 
+def rescore_enriched(results: list[dict], query: str) -> None:
+    """Update composite_score for results that have extracted_content.
+
+    After content enrichment, relevance based on full content is much
+    more accurate than snippet-based relevance. Re-score and re-sort.
+    """
+    changed = False
+    for result in results:
+        content = result.get("metadata", {}).get("extracted_content", "")
+        if not content:
+            continue
+        # Re-compute relevance on full content instead of snippet
+        query_tokens = {token.lower() for token in WORD_RE.findall(query or "")}
+        content_tokens = {token.lower() for token in WORD_RE.findall(content)}
+        union = query_tokens | content_tokens
+        content_relevance = (
+            len(query_tokens & content_tokens) / len(union) if union else 0.0
+        )
+
+        recency = freshness_score(result)
+        old_score = result.get("metadata", {}).get("composite_score", 50)
+        engagement_proxy = _clamp01(old_score / 100.0)
+
+        new_composite = (
+            0.60 * content_relevance + 0.20 * engagement_proxy + 0.20 * recency
+        )
+        new_score = max(0, min(100, int(round(_clamp01(new_composite) * 100))))
+        result["metadata"]["composite_score"] = new_score
+        changed = True
+
+    if changed:
+        results.sort(
+            key=lambda r: r.get("metadata", {}).get("composite_score", 0),
+            reverse=True,
+        )
+
+
 def semantic_score(query: str, result: dict) -> float:
     query_tokens = {token.lower() for token in WORD_RE.findall(query or "")}
     title = str(result.get("title", "") or "")

--- a/lib/search_runner.py
+++ b/lib/search_runner.py
@@ -322,7 +322,7 @@ def make_result(
     return {
         "url": normalize_url(url),
         "title": title.strip(),
-        "snippet": snippet.strip()[:500],
+        "snippet": snippet.strip()[:1500],
         "source": source,
         "query": query,
         "metadata": metadata,
@@ -514,6 +514,13 @@ async def main(queries: list[dict]) -> None:
             await enrich_reddit_items(unique_results)
         except Exception as exc:
             print(f"[search_runner] enrichment failed: {exc}", file=sys.stderr)
+        try:
+            from lib.enrichment import enrich_content
+
+            query_text = queries[0].get("query", "") if queries else ""
+            await enrich_content(unique_results, query_text)
+        except Exception as exc:
+            print(f"[search_runner] content enrichment failed: {exc}", file=sys.stderr)
 
     for result in unique_results:
         print(json.dumps(result, ensure_ascii=False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ browser-cookie3>=0.19.1  # optional: Twitter cookie extraction from browsers
 ddgs>=9.12.0
 httpx>=0.27.0
 lxml>=5.0
+rank-bm25>=0.2.2
+snowballstemmer>=2.2.0

--- a/skills/llm-evaluate/SKILL.md
+++ b/skills/llm-evaluate/SKILL.md
@@ -157,16 +157,45 @@ This gap_dimensions list is:
 
 After evaluation, produce a compressed claims file: `evidence/{session_id}-claims.jsonl`.
 
-For each relevant result (llm_relevant=true), distill one structured claim:
+## Two-tier claims
+
+Claims have two tiers depending on whether the result has deep-processed content.
+
+**Tier 1 — Results WITH `metadata.extracted_content`** (full page was fetched and BM25-filtered):
 ```json
-{"url": "https://...", "claim": "Qdrant outperforms Pinecone on filtered search by 3x at 1M vectors", "source": "github", "dimension": "performance-benchmarks", "engagement_score": 78, "also_on": ["reddit", "hn"], "top_comment": "Senior engineer here: we migrated and saw 3x improvement..."}
+{
+  "url": "https://...",
+  "claim": "Qdrant outperforms Pinecone on filtered vector search by 3.2x at 1M vectors",
+  "evidence": "VectorDBBench 2025: Qdrant 23,400 QPS vs Pinecone 7,300 QPS, p99 4.2ms vs 11.8ms",
+  "data_points": ["3.2x throughput", "40% lower p99 latency", "1M vector scale"],
+  "source": "github",
+  "dimension": "performance-benchmarks",
+  "engagement_score": 78,
+  "also_on": ["reddit", "hn"]
+}
+```
+
+**Tier 2 — Results WITHOUT `metadata.extracted_content`** (snippet only):
+```json
+{"url": "https://...", "claim": "Qdrant outperforms Pinecone on filtered search", "source": "github", "dimension": "performance-benchmarks"}
 ```
 
 Rules:
-- One claim per result, max one sentence
-- The claim must capture the single most important finding from that result
+- `claim`: main finding in one sentence — mandatory for all results
+- `evidence`: verbatim quote or specific data from `extracted_content`, max 200 chars — only for Tier 1
+- `data_points`: specific numbers, percentages, benchmarks extracted from content, max 5 items — only for Tier 1
 - Include the dimension it covers (maps to the 9 recall dimensions)
 - This file is what Block 4 reads instead of raw results — keep it dense and useful
+
+## Re-evaluation with extracted content
+
+When `metadata.extracted_content` is present, re-evaluate `llm_relevant` based on the full content, not just the snippet. Some results will flip:
+- Snippet looked relevant but full content is off-topic → flip to false
+- Snippet was vague but full content directly addresses the query → flip to true
+
+## Gap analysis with full content
+
+When assessing coverage gaps, consider `extracted_content` for what is actually covered in depth vs merely mentioned. A dimension with 3 results where all have thin snippets is still a gap. A dimension with 1 result with rich extracted_content may be sufficiently covered.
 
 Signal carry-forward rules (optional fields — include when available):
 - `engagement_score`: carry when `metadata.composite_score >= 50`

--- a/skills/synthesize-knowledge/SKILL.md
+++ b/skills/synthesize-knowledge/SKILL.md
@@ -117,7 +117,7 @@ Do not resolve the disagreement artificially — state what is genuinely uncerta
 Organize the delivery as typed blocks, not one monolithic document:
 
 1. **Executive framework** — the conceptual model (axes, dimensions, taxonomy)
-2. **Evidence tables** — organized by concept, with adoption signals (stars, citations, venue)
+2. **Evidence tables** — organized by concept, with adoption signals (stars, citations, venue). When claims include `evidence` or `data_points` fields, use the exact quotes and numbers in the table — do not paraphrase. These come from BM25-filtered full-page content and are more specific than snippet-based claims.
 3. **Design patterns** — recurring approaches identified across multiple projects
 4. **Risk analysis** — known limitations, failure modes, open problems
 5. **Gap declaration** — what the search did NOT find, what remains uncertain

--- a/tests/test_content_enrichment.py
+++ b/tests/test_content_enrichment.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.enrichment import JINA_READER_PREFIX, enrich_content
+
+
+def _make_result(
+    *,
+    url: str = "https://example.com/article",
+    source: str = "web",
+    composite_score: float = 50,
+) -> dict:
+    return {
+        "url": url,
+        "title": "Test result",
+        "snippet": "Snippet",
+        "source": source,
+        "query": "test query",
+        "metadata": {"composite_score": composite_score},
+    }
+
+
+def _make_response(
+    *,
+    status_code: int = 200,
+    is_error: bool = False,
+    text: str = "",
+) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.is_error = is_error
+    response.text = text
+    return response
+
+
+def _make_async_client(get_impl: AsyncMock) -> AsyncMock:
+    mock_client = AsyncMock()
+    mock_client.get = get_impl
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_stores_extracted() -> None:
+    result = _make_result()
+    mock_response = _make_response(
+        text=(
+            "# Title\n\n"
+            + ("Relevant paragraph about the topic. " * 6)
+            + "\n\n"
+            + ("Irrelevant footer text. " * 6)
+        )
+    )
+    mock_client = _make_async_client(AsyncMock(return_value=mock_response))
+
+    with (
+        patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client),
+        patch(
+            "lib.content_processing.filter_relevant_paragraphs",
+            return_value="Filtered topic paragraph. " * 4,
+        ),
+    ):
+        await enrich_content([result], "topic", max_items=1)
+
+    assert result["metadata"]["extracted_content"] == "Filtered topic paragraph. " * 4
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_skips_reddit() -> None:
+    result = _make_result(source="reddit", url="https://reddit.com/r/test/comments/1")
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        await enrich_content([result], "topic", max_items=1)
+
+    mock_async_client.assert_not_called()
+    assert "extracted_content" not in result["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_skips_low_score() -> None:
+    result = _make_result(composite_score=29)
+
+    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
+        await enrich_content([result], "topic", max_items=1)
+
+    mock_async_client.assert_not_called()
+    assert "extracted_content" not in result["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_bm25_filters() -> None:
+    result = _make_result()
+    original_text = (
+        "# Title\n\n"
+        + ("Relevant paragraph about the topic. " * 8)
+        + "\n\n"
+        + ("Irrelevant footer text. " * 12)
+    )
+    filtered_text = "Relevant paragraph about the topic. " * 4
+    mock_response = _make_response(text=original_text)
+    mock_client = _make_async_client(AsyncMock(return_value=mock_response))
+
+    with (
+        patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client),
+        patch("lib.content_processing.filter_relevant_paragraphs", return_value=filtered_text),
+    ):
+        await enrich_content([result], "topic", max_items=1)
+
+    assert result["metadata"]["extracted_content"] == filtered_text
+    assert len(result["metadata"]["extracted_content"]) < len(original_text)
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_fallback_httpx() -> None:
+    result = _make_result()
+    jina_error = _make_response(status_code=502, is_error=True, text="bad gateway")
+    direct_html = _make_response(
+        text=(
+            "<html><body><article>"
+            + ("Direct fallback content about the topic. " * 6)
+            + "</article></body></html>"
+        )
+    )
+    mock_client = _make_async_client(AsyncMock(side_effect=[jina_error, direct_html]))
+
+    with (
+        patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client),
+        patch("lib.content_processing.is_blocked", return_value=(False, "")),
+        patch(
+            "lib.content_processing.prune_html",
+            return_value="Direct fallback content about the topic. " * 6,
+        ),
+        patch(
+            "lib.content_processing.filter_relevant_paragraphs",
+            return_value="Direct fallback content about the topic. " * 4,
+        ),
+    ):
+        await enrich_content([result], "topic", max_items=1)
+
+    assert result["metadata"]["extracted_content"] == (
+        "Direct fallback content about the topic. " * 4
+    )
+    assert mock_client.get.await_count == 2
+    assert mock_client.get.await_args_list[0].args[0] == f"{JINA_READER_PREFIX}{result['url']}"
+    assert mock_client.get.await_args_list[1].args[0] == result["url"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_bail_on_429() -> None:
+    first = _make_result(url="https://example.com/first", composite_score=90)
+    second = _make_result(url="https://example.com/second", composite_score=80)
+    rate_limited = _make_response(status_code=429, is_error=True, text="")
+    mock_client = _make_async_client(AsyncMock(return_value=rate_limited))
+
+    async def gather_sequential(*aws, return_exceptions=False):
+        results = []
+        for awaitable in aws:
+            try:
+                results.append(await awaitable)
+            except Exception as exc:
+                if return_exceptions:
+                    results.append(exc)
+                else:
+                    raise
+        return results
+
+    with (
+        patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client),
+        patch("lib.enrichment.asyncio.create_task", side_effect=lambda coro: coro),
+        patch("lib.enrichment.asyncio.gather", side_effect=gather_sequential),
+    ):
+        await enrich_content([first, second], "topic", max_items=2)
+
+    assert mock_client.get.await_count == 1
+    assert "extracted_content" not in first["metadata"]
+    assert "extracted_content" not in second["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_empty_results() -> None:
+    await enrich_content([], "topic")
+
+
+@pytest.mark.asyncio
+async def test_enrich_content_truncates_to_3000() -> None:
+    result = _make_result()
+    mock_response = _make_response(text="Source text " * 20)
+    mock_client = _make_async_client(AsyncMock(return_value=mock_response))
+    long_filtered = "x" * 3500
+
+    with (
+        patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client),
+        patch("lib.content_processing.filter_relevant_paragraphs", return_value=long_filtered),
+    ):
+        await enrich_content([result], "topic", max_items=1)
+
+    assert len(result["metadata"]["extracted_content"]) == 3000
+    assert result["metadata"]["extracted_content"] == long_filtered[:3000]

--- a/tests/test_content_enrichment.py
+++ b/tests/test_content_enrichment.py
@@ -106,7 +106,10 @@ async def test_enrich_content_bm25_filters() -> None:
 
     with (
         patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client),
-        patch("lib.content_processing.filter_relevant_paragraphs", return_value=filtered_text),
+        patch(
+            "lib.content_processing.filter_relevant_paragraphs",
+            return_value=filtered_text,
+        ),
     ):
         await enrich_content([result], "topic", max_items=1)
 
@@ -145,7 +148,10 @@ async def test_enrich_content_fallback_httpx() -> None:
         "Direct fallback content about the topic. " * 4
     )
     assert mock_client.get.await_count == 2
-    assert mock_client.get.await_args_list[0].args[0] == f"{JINA_READER_PREFIX}{result['url']}"
+    assert (
+        mock_client.get.await_args_list[0].args[0]
+        == f"{JINA_READER_PREFIX}{result['url']}"
+    )
     assert mock_client.get.await_args_list[1].args[0] == result["url"]
 
 
@@ -194,7 +200,10 @@ async def test_enrich_content_truncates_to_3000() -> None:
 
     with (
         patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client),
-        patch("lib.content_processing.filter_relevant_paragraphs", return_value=long_filtered),
+        patch(
+            "lib.content_processing.filter_relevant_paragraphs",
+            return_value=long_filtered,
+        ),
     ):
         await enrich_content([result], "topic", max_items=1)
 

--- a/tests/test_content_processing.py
+++ b/tests/test_content_processing.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from lib.content_processing import (
+    chunk_with_overlap,
+    convert_to_citations,
+    filter_relevant_paragraphs,
+    is_blocked,
+    prune_html,
+)
+
+
+def test_filter_relevant_paragraphs_keeps_relevant() -> None:
+    markdown = (
+        "Solar battery storage improves grid resilience.\n\n"
+        "Celebrity gossip and entertainment rumors.\n\n"
+        "Renewable energy storage helps balance peak demand.\n\n"
+        "Sports scores from last night's game.\n\n"
+        "Battery systems make renewable power more reliable."
+    )
+    mock_bm25 = MagicMock()
+    mock_bm25.get_scores.return_value = [2.4, 0.1, 1.8, 0.0, 1.2]
+
+    with patch("lib.content_processing.BM25Okapi", return_value=mock_bm25):
+        filtered = filter_relevant_paragraphs(markdown, "renewable energy storage")
+
+    assert "Solar battery storage improves grid resilience." in filtered
+    assert "Renewable energy storage helps balance peak demand." in filtered
+    assert "Battery systems make renewable power more reliable." in filtered
+    assert "Celebrity gossip and entertainment rumors." not in filtered
+    assert "Sports scores from last night's game." not in filtered
+
+
+def test_filter_relevant_paragraphs_minimum_3() -> None:
+    markdown = (
+        "First paragraph.\n\n"
+        "Second paragraph.\n\n"
+        "Third paragraph.\n\n"
+        "Fourth paragraph."
+    )
+    mock_bm25 = MagicMock()
+    mock_bm25.get_scores.return_value = [0.2, 0.1, 0.05, 0.01]
+
+    with patch("lib.content_processing.BM25Okapi", return_value=mock_bm25):
+        filtered = filter_relevant_paragraphs(markdown, "unmatched query", threshold=10.0)
+
+    assert filtered == "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+
+
+def test_filter_relevant_paragraphs_empty_input() -> None:
+    assert filter_relevant_paragraphs("", "topic") == ""
+
+
+def test_filter_relevant_paragraphs_heading_weight() -> None:
+    heading_markdown = (
+        "# Async Python\n\n"
+        "Plain paragraph.\n\n"
+        "Irrelevant paragraph one.\n\n"
+        "Irrelevant paragraph two.\n\n"
+        "Irrelevant paragraph three.\n\n"
+        "Irrelevant paragraph four."
+    )
+    plain_markdown = heading_markdown.replace("# Async Python", "Async Python")
+    mock_bm25 = MagicMock()
+    mock_bm25.get_scores.return_value = [0.3, 1.0, 1.4, 1.3, 1.2, 1.1]
+
+    with patch("lib.content_processing.BM25Okapi", return_value=mock_bm25):
+        heading_filtered = filter_relevant_paragraphs(
+            heading_markdown, "python async tutorial", threshold=10.0
+        )
+
+    with patch("lib.content_processing.BM25Okapi", return_value=mock_bm25):
+        plain_filtered = filter_relevant_paragraphs(
+            plain_markdown, "python async tutorial", threshold=10.0
+        )
+
+    assert "# Async Python" in heading_filtered
+    assert "Async Python" not in plain_filtered
+
+
+def test_prune_html_removes_nav_footer() -> None:
+    html = (
+        "<html><body>"
+        "<nav>Navigation links</nav>"
+        "<article><h1>Keep me</h1><p>Main body text here.</p></article>"
+        "<footer>Footer links</footer>"
+        "</body></html>"
+    )
+
+    pruned = prune_html(html)
+
+    assert "Keep me" in pruned
+    assert "Main body text here." in pruned
+    assert "Navigation links" not in pruned
+    assert "Footer links" not in pruned
+
+
+def test_prune_html_empty_input() -> None:
+    assert prune_html("") == ""
+
+
+def test_chunk_with_overlap_short_text() -> None:
+    assert chunk_with_overlap("short text", window_size=10, step=8) == ["short text"]
+
+
+def test_chunk_with_overlap_splits() -> None:
+    text = " ".join(f"w{i}" for i in range(9))
+
+    chunks = chunk_with_overlap(text, window_size=4, step=3)
+
+    assert chunks == ["w0 w1 w2 w3", "w3 w4 w5 w6", "w5 w6 w7 w8"]
+
+
+def test_chunk_with_overlap_last_chunk() -> None:
+    text = " ".join(f"w{i}" for i in range(10))
+
+    chunks = chunk_with_overlap(text, window_size=4, step=4)
+
+    assert chunks == ["w0 w1 w2 w3", "w4 w5 w6 w7", "w6 w7 w8 w9"]
+
+
+def test_convert_to_citations() -> None:
+    converted, references = convert_to_citations(
+        "See [Example](https://example.com/resource) for details."
+    )
+
+    assert converted == "See Example⟨1⟩ for details."
+    assert "## References" in references
+    assert "⟨1⟩ https://example.com/resource: Example" in references
+
+
+def test_convert_to_citations_dedup() -> None:
+    converted, references = convert_to_citations(
+        "See [One](https://example.com) and [Two](https://example.com)."
+    )
+
+    assert converted == "See One⟨1⟩ and Two⟨1⟩."
+    assert references.count("https://example.com") == 1
+
+
+def test_is_blocked_cloudflare() -> None:
+    html = (
+        "<html><body>"
+        '<form id="challenge-form" action="/__cf_chl_f_tk=token">'
+        "Checking your browser"
+        "</form>"
+        "</body></html>"
+    )
+
+    blocked, reason = is_blocked(200, html)
+
+    assert blocked is True
+    assert "Cloudflare" in reason
+
+
+def test_is_blocked_normal_page() -> None:
+    html = (
+        "<html><body><article>"
+        "<h1>Normal page</h1>"
+        "<p>This page has enough visible article text to avoid being treated as a "
+        "shell or challenge page during the structural integrity checks.</p>"
+        "<p>It also includes multiple content elements so the block detector sees "
+        "a normal page rather than an anti-bot response.</p>"
+        "</article></body></html>"
+    )
+
+    blocked, reason = is_blocked(200, html)
+
+    assert blocked is False
+    assert reason == ""
+
+
+def test_is_blocked_429() -> None:
+    blocked, reason = is_blocked(429, "<html><body>Rate limited</body></html>")
+
+    assert blocked is True
+    assert reason == "HTTP 429 Too Many Requests"
+
+
+def test_is_blocked_empty_200() -> None:
+    blocked, reason = is_blocked(200, "<html><body></body></html>")
+
+    assert blocked is True
+    assert "Near-empty content" in reason

--- a/tests/test_content_processing.py
+++ b/tests/test_content_processing.py
@@ -34,16 +34,15 @@ def test_filter_relevant_paragraphs_keeps_relevant() -> None:
 
 def test_filter_relevant_paragraphs_minimum_3() -> None:
     markdown = (
-        "First paragraph.\n\n"
-        "Second paragraph.\n\n"
-        "Third paragraph.\n\n"
-        "Fourth paragraph."
+        "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.\n\nFourth paragraph."
     )
     mock_bm25 = MagicMock()
     mock_bm25.get_scores.return_value = [0.2, 0.1, 0.05, 0.01]
 
     with patch("lib.content_processing.BM25Okapi", return_value=mock_bm25):
-        filtered = filter_relevant_paragraphs(markdown, "unmatched query", threshold=10.0)
+        filtered = filter_relevant_paragraphs(
+            markdown, "unmatched query", threshold=10.0
+        )
 
     assert filtered == "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
 

--- a/tests/test_search_runner.py
+++ b/tests/test_search_runner.py
@@ -86,7 +86,7 @@ def test_make_result_basic():
 
 
 def test_make_result_snippet_truncation():
-    snippet = "a" * 600
+    snippet = "a" * 2000
     result = make_result(
         url="https://example.com",
         title="Title",
@@ -95,8 +95,8 @@ def test_make_result_snippet_truncation():
         query="query",
     )
 
-    assert len(result["snippet"]) == 500
-    assert result["snippet"] == "a" * 500
+    assert len(result["snippet"]) == 1500
+    assert result["snippet"] == "a" * 1500
 
 
 def test_make_result_date_extraction():


### PR DESCRIPTION
## Summary

Adds a content processing pipeline replicated from crawl4ai at code level, enabling deep extraction for top search results.

**Content processing** (`lib/content_processing.py` — new, ~350 lines):
- BM25 paragraph relevance filtering with snowball stemming and tag priority weights
- HTML noise pruning via 5-metric DOM scoring
- Sliding window chunking with overlap
- Markdown citation formatting
- 3-tier anti-bot detection

**Content enrichment** (`lib/enrichment.py` — extended):
- Top results fetched via Jina Reader, BM25-filtered, stored as `metadata["extracted_content"]`
- Fallback to direct httpx with antibot detection and HTML pruning
- Re-scores results on full-content relevance after enrichment

**Two-tier claims** (`skills/llm-evaluate/SKILL.md`):
- Tier 1 (with extracted_content): claim + evidence + data_points
- Tier 2 (snippet only): claim only

**Snippet quality**: HN story_text, arXiv full abstracts, cap 500→1500

## Test plan

- [x] 15 content_processing tests
- [x] 8 content_enrichment tests
- [x] Full suite: 488 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)