### PR TITLE
fix: correct Mintlify navbar config

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,8 +11,8 @@
   "navbar": {
     "links": [
       {
-        "label": "GitHub",
-        "url": "https://github.com/0xmariowu/Autosearch"
+        "type": "github",
+        "href": "https://github.com/0xmariowu/Autosearch"
       }
     ]
   },

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -47,3 +47,4 @@ AutoSearch asks two questions — how deep and what format — then searches, ev
 ## The key insight
 
 Claude already knows 60-70% of most research topics from training data. AutoSearch doesn't waste time re-searching what Claude already knows. It maps gaps first, then searches specifically for fresh data, community voice, Chinese sources, and niche repositories that Claude's training missed.
+


### PR DESCRIPTION
Fix navbar.links format: use href+type instead of url+label.