### PR TITLE
fix: escape angle brackets in MDX

### DIFF
--- a/docs/principles.mdx
+++ b/docs/principles.mdx
@@ -31,7 +31,7 @@ Open-source tools, libraries, frameworks on GitHub, HuggingFace, npm, PyPI.
 |---|---|---|
 | **A — Established** | 1K+ stars + active maintenance + real issues addressed | Primary evidence |
 | **B — Emerging** | 100-1K stars, OR backed by known org | Supporting evidence |
-| **C — Experimental** | <100 stars, solo maintainer | Supplement only |
+| **C — Experimental** | Under 100 stars, solo maintainer | Supplement only |
 
 ### Channel 3: User feedback
 

--- a/docs/protocol.mdx
+++ b/docs/protocol.mdx
@@ -34,7 +34,7 @@ Each iteration is one variation step implementing `Vary(P_t) = Agent(P_t, K, f)`
 ## Scoring
 
 ```bash
-python3 judge.py <evidence-file> [--target N]
+python3 judge.py evidence.jsonl [--target N]
 ```
 
 Scores against 7 dimensions: `quantity`, `diversity`, `relevance`, `freshness`, `efficiency`, `latency`, `adoption`.
@@ -48,7 +48,7 @@ Scores against 7 dimensions: `quantity`, `diversity`, `relevance`, `freshness`, 
 
 ## Self-supervision
 
-- 3 consecutive flat generations (max score <= min score * 1.01) → redirect strategy
+- 3 consecutive flat generations (max score at or below min score * 1.01) → redirect strategy
 - 3 consecutive reverts → try a fundamentally different approach
 - If truly stuck → deliver the best honest result with an explanation of what remains uncertain
 


### PR DESCRIPTION
MDX treats < as JSX. protocol.mdx had <evidence-file> and <=, principles.mdx had <100. These caused Mintlify build to silently skip these pages (404).