### PR TITLE
fix: remove enrichment score threshold — extracted_content 2% to 90%

### DIFF
--- a/lib/enrichment.py
+++ b/lib/enrichment.py
@@ -221,7 +221,6 @@ async def enrich_content(
             for r in results
             if r.get("source") != "reddit"
             and not r.get("metadata", {}).get("extracted_content")
-            and r.get("metadata", {}).get("composite_score", 0) >= 30
         ]
         candidates.sort(
             key=lambda r: r.get("metadata", {}).get("composite_score", 0),

--- a/tests/test_content_enrichment.py
+++ b/tests/test_content_enrichment.py
@@ -81,14 +81,17 @@ async def test_enrich_content_skips_reddit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_enrich_content_skips_low_score() -> None:
-    result = _make_result(composite_score=29)
+async def test_enrich_content_respects_max_items() -> None:
+    """Enrichment processes up to max_items results regardless of score."""
+    results = [_make_result(composite_score=10), _make_result(composite_score=5)]
+    mock_response = _make_response(text="Short")
+    mock_client = _make_async_client(AsyncMock(return_value=mock_response))
 
-    with patch("lib.enrichment.httpx.AsyncClient") as mock_async_client:
-        await enrich_content([result], "topic", max_items=1)
+    with patch("lib.enrichment.httpx.AsyncClient", return_value=mock_client):
+        await enrich_content(results, "topic", max_items=1)
 
-    mock_async_client.assert_not_called()
-    assert "extracted_content" not in result["metadata"]
+    # max_items=1 so only the highest-scored result should be attempted
+    mock_client.get.assert_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Content enrichment pipeline had a `composite_score >= 30` gate that blocked 90%+ of results from getting full-text content. Most results score 15-25 due to low Jaccard similarity, so enrichment never triggered.

### Fix

Removed the score threshold. Enrichment now processes top N results by score (sorted + `max_items=10` cap). The sort + cap is the correct gate.

### Before/After

```
web-ddgs "RAG retrieval augmented generation" (10 results):
  Before: 0/10 extracted_content (0%)
  After:  9/10 extracted_content (90%), each 3000ch via Jina Reader
```

## Test plan

- [x] 516 unit tests pass
- [x] Live verification: 0/10 → 9/10 extracted_content
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)