### PR TITLE
fix: auto-sync changelog to docs site on every commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.06.4"
+    "version": "2026.04.06.5"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.06.4",
+      "version": "2026.04.06.5",
       "author": {
         "name": "0xmariowu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.06.4",
+  "version": "2026.04.06.5",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.06.5
+
 ## 2026.04.06.4
 
 ### Changes

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -12,6 +12,8 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.06.5
+
 ## 2026.04.06.4
 
 ### Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xmariowu/autosearch",
-  "version": "2026.04.06.4",
+  "version": "2026.04.06.5",
   "description": "Self-evolving deep research for Claude Code. Gets smarter every time you use it.",
   "author": "0xmariowu",
   "license": "MIT",

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.04.06.4",
+  "version": "2026.04.06.5",
   "channel_count": 34,
   "skill_count": 54,
   "channels": [

--- a/scripts/committer
+++ b/scripts/committer
@@ -59,6 +59,26 @@ if [[ -f "$LOCK" ]]; then
   done
 fi
 
+# --- Auto-sync: if CHANGELOG.md is staged, sync to docs/changelog.mdx ---
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCS_CHANGELOG="$REPO_ROOT/docs/changelog.mdx"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+for file in "${FILES[@]}"; do
+  if [[ "$(basename "$file")" == "CHANGELOG.md" ]] && [[ -f "$DOCS_CHANGELOG" ]] && [[ -f "$CHANGELOG" ]]; then
+    {
+      echo '---'
+      echo 'title: Changelog'
+      echo 'description: All changes to AutoSearch, organized by release.'
+      echo '---'
+      echo ''
+      tail -n +2 "$CHANGELOG" | sed '/./,$!d'
+    } > "$DOCS_CHANGELOG"
+    FILES+=("docs/changelog.mdx")
+    printf "${DIM}auto-synced CHANGELOG.md → docs/changelog.mdx${NC}\n"
+    break
+  fi
+done
+
 # --- Clean slate: unstage everything, then stage only our files ---
 git restore --staged :/ 2>/dev/null || true
 git add -- "${FILES[@]}"


### PR DESCRIPTION
## Summary

`bump-version.sh` syncs CHANGELOG → docs/changelog.mdx at bump time, but CHANGELOG content is written *after* bump. Result: docs site shows empty version sections.

### Fix

Added auto-sync to `scripts/committer`: when CHANGELOG.md is in the staged file list, it regenerates docs/changelog.mdx and includes it in the same commit. This means docs are *always* in sync — no matter when CHANGELOG content is written.

### How it works

```
# Before (gap between bump and content write)
bump-version.sh → creates empty section → syncs docs (EMPTY)
write CHANGELOG content
committer "chore: ..." CHANGELOG.md  → docs NOT synced ← BUG

# After (committer auto-syncs)
bump-version.sh → creates empty section → syncs docs (EMPTY)  
write CHANGELOG content
committer "chore: ..." CHANGELOG.md  → auto-syncs docs ← FIXED
```

Verified: the version bump commit in this PR shows `auto-synced CHANGELOG.md → docs/changelog.mdx` in output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)