### PR TITLE
feat: judge v2 — report quality scoring + evolution loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.06.6"
+    "version": "2026.04.06.7"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.06.6",
+      "version": "2026.04.06.7",
       "author": {
         "name": "0xmariowu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.06.6",
+  "version": "2026.04.06.7",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.06.7
+
+### Changes
+
+- You can now see report-quality scores instead of search-pipeline metrics — judge.py redesigned with 6 new dimensions: rubric pass rate (0.30), groundedness (0.20), relevant yield (0.15), content depth (0.15), source diversity (0.10), quantity (0.10)
+- You can now get deep LLM-as-judge evaluation via quality_eval.py — 6 quality dimensions + claim-level groundedness check, adapted from LangChain open_deep_research
+- Evolution (Block 6) now always runs instead of being skipped when over time budget — writes query-outcomes, winning patterns, rubric history, and evolution diagnostics every session
+- Removed latency, freshness, adoption, and knowledge_growth from judge — latency is a constraint not a goal, freshness is topic-dependent (now handled via rubrics), adoption and knowledge_growth were ghost dimensions reading nonexistent files
+
 ## 2026.04.06.6
 
 ### Changes

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -58,8 +58,8 @@ Run `judge.py` at least once in every variation step.
 Run `python3 judge.py <evidence-file> [--target N]`.
 Require Python 3.10 or newer.
 Treat the judge interface as fixed.
-Let `judge.py` read the evidence JSONL plus `state/timing.json` and `state/adoption.json`.
-Score against seven dimensions: `quantity`, `diversity`, `relevance`, `freshness`, `efficiency`, `latency`, and `adoption`.
+Let `judge.py` read the evidence JSONL plus `state/rubric-history.jsonl` and delivery files.
+Score against six dimensions: `rubric_pass_rate`, `groundedness`, `relevant_yield`, `content_depth`, `source_diversity`, and `quantity`.
 Treat `metadata.llm_relevant` as the relevance signal expected by the judge.
 Use `llm-evaluate.md` when you need to populate that field.
 Capture the full judge output in your records.

--- a/commands/autosearch.md
+++ b/commands/autosearch.md
@@ -206,7 +206,7 @@ After Block 5 returns, parse its summary and output:
 
 #### Block 6: Evolve (Phase 6) — Sonnet
 
-**Skip if over time budget.** Evolution is valuable but not worth making the user wait.
+**Always run.** Evolution is the session's core value, not an optional add-on. If time is tight, do minimal evolution (patterns + query-outcomes only), but never skip entirely.
 
 Spawn a Sonnet agent (`model: "sonnet"`) with this task:
 
@@ -217,12 +217,13 @@ Spawn a Sonnet agent (`model: "sonnet"`) with this task:
 >
 > Read `skills/pipeline-flow/SKILL.md` Phase 6 for context.
 >
-> 1. Read `skills/knowledge-map/SKILL.md` and save updated knowledge map.
-> 2. Append winning patterns to `state/patterns-v2.jsonl`.
-> 3. Read `skills/auto-evolve/SKILL.md` and run one evolution step.
+> 1. **Write query outcomes**: Read `evidence/{session_id}-results.jsonl`. For each unique query+channel combination, compute results_count and relevant_count (from `metadata.llm_relevant`). Append to `state/query-outcomes.jsonl`.
+> 2. **Write winning patterns**: From query-outcomes just written, extract combinations with relevant_rate > 0.5. Append to `state/patterns-v2.jsonl` with type `winning_pattern`, channel, topic_type, and confidence.
+> 3. Read `skills/auto-evolve/SKILL.md` and run one evolution step (diagnose failed rubrics → modify one skill/data file → git commit → record in evolution-log.jsonl).
 > 4. Append to `state/worklog.jsonl`: task_spec, search_run, reflection, delivery entries.
+> 5. Read `skills/knowledge-map/SKILL.md` and save updated knowledge map.
 >
-> At the end, output a JSON summary: `{"patterns_saved": N, "evolved": true/false}`
+> At the end, output a JSON summary: `{"patterns_saved": N, "query_outcomes_written": N, "evolved": true/false, "evolution_file": "path or null"}`
 
 After Block 6 returns, parse its summary and output:
 ```

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -12,6 +12,15 @@ All changes to AutoSearch. Format: `## YYYY.MM.DD.N` with `### Changes` and `###
 
 ---
 
+## 2026.04.06.7
+
+### Changes
+
+- You can now see report-quality scores instead of search-pipeline metrics — judge.py redesigned with 6 new dimensions: rubric pass rate (0.30), groundedness (0.20), relevant yield (0.15), content depth (0.15), source diversity (0.10), quantity (0.10)
+- You can now get deep LLM-as-judge evaluation via quality_eval.py — 6 quality dimensions + claim-level groundedness check, adapted from LangChain open_deep_research
+- Evolution (Block 6) now always runs instead of being skipped when over time budget — writes query-outcomes, winning patterns, rubric history, and evolution diagnostics every session
+- Removed latency, freshness, adoption, and knowledge_growth from judge — latency is a constraint not a goal, freshness is topic-dependent (now handled via rubrics), adoption and knowledge_growth were ghost dimensions reading nonexistent files
+
 ## 2026.04.06.6
 
 ### Changes

--- a/lib/judge.py
+++ b/lib/judge.py
@@ -9,19 +9,28 @@ from collections import Counter
 from pathlib import Path
 
 DEFAULT_WEIGHTS = {
-    "quantity": 0.12,
-    "diversity": 0.13,
-    "relevance": 0.22,
-    "freshness": 0.10,
-    "efficiency": 0.10,
-    "latency": 0.08,
-    "adoption": 0.12,
-    "knowledge_growth": 0.13,
+    "rubric_pass_rate": 0.30,
+    "groundedness": 0.20,
+    "relevant_yield": 0.15,
+    "content_depth": 0.15,
+    "source_diversity": 0.10,
+    "quantity": 0.10,
 }
 WORD_RE = re.compile(r"\w+")
-DATE_FIELDS = ("published_at", "created_utc", "updated_at")
-DEFAULT_LATENCY_BUDGET_SECONDS = 120.0
+HTML_CITATION_RE = re.compile(
+    r'<li\b[^>]*\bid="ref-\d+"[^>]*>[\s\S]*?<a\b[^>]*\bhref="([^"]+)"',
+    re.IGNORECASE,
+)
+MARKDOWN_CITATION_RE = re.compile(r"\[(\d+)\]\((https?://[^)\s]+)\)")
+# [N] Title — URL  (common in AutoSearch .md deliveries)
+MARKDOWN_PLAIN_CITATION_RE = re.compile(
+    r"^\[(\d+)\]\s+.+?\s+—\s+(https?://\S+)", re.MULTILINE
+)
 NEUTRAL_DIMENSION_SCORE = 0.5
+
+
+def clamp_score(value: float) -> float:
+    return max(0.0, min(value, 1.0))
 
 
 def parse_args() -> argparse.Namespace:
@@ -64,6 +73,28 @@ def load_state_json(evidence_file: str | Path | None, filename: str) -> dict | N
     return None
 
 
+def load_state_jsonl(evidence_file: str | Path | None, filename: str) -> list[dict]:
+    for state_dir in candidate_state_dirs(evidence_file):
+        path = state_dir / filename
+        try:
+            with path.open(encoding="utf-8") as handle:
+                rows: list[dict] = []
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(payload, dict):
+                        rows.append(payload)
+        except OSError:
+            continue
+        return rows
+    return []
+
+
 def coerce_float(value: object, default: float) -> float:
     try:
         return float(value)
@@ -84,34 +115,7 @@ def load_scoring_config(evidence_file: str | Path | None = None) -> dict[str, ob
             if name in configured_weights:
                 weights[name] = coerce_float(configured_weights[name], weights[name])
 
-    latency_budget_seconds = coerce_float(
-        scoring.get("latency_budget_seconds"), DEFAULT_LATENCY_BUDGET_SECONDS
-    )
-    if latency_budget_seconds <= 0:
-        latency_budget_seconds = DEFAULT_LATENCY_BUDGET_SECONDS
-
-    # Freshness profile: topic-type → cutoff days
-    freshness_profiles = scoring.get("freshness_profiles")
-    if not isinstance(freshness_profiles, dict):
-        freshness_profiles = {
-            "default": 183,
-            "emerging": 90,
-            "news": 30,
-            "academic": 365,
-            "historical": 730,
-        }
-
-    # Active freshness days: check for session-level override, else default
-    freshness_days = coerce_float(
-        scoring.get("freshness_days"), freshness_profiles.get("default", 183)
-    )
-
-    return {
-        "dimension_weights": weights,
-        "latency_budget_seconds": latency_budget_seconds,
-        "freshness_days": freshness_days,
-        "freshness_profiles": freshness_profiles,
-    }
+    return {"dimension_weights": weights}
 
 
 def load_default_weights(evidence_file: str | Path | None = None) -> dict[str, float]:
@@ -148,78 +152,198 @@ def parse_date(value: object) -> dt.datetime | None:
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
 
 
-def score_latency(evidence_file: str, budget_seconds: float) -> float:
-    timing = load_state_json(evidence_file, "timing.json")
-    if not timing:
-        return NEUTRAL_DIMENSION_SCORE
+def score_rubric_pass_rate(evidence_file: str) -> float:
+    history = load_state_jsonl(evidence_file, "rubric-history.jsonl")
+    if not history:
+        return 0.0
 
-    start = parse_date(timing.get("start_ts"))
-    end = parse_date(timing.get("end_ts"))
-    if not start or not end:
-        return NEUTRAL_DIMENSION_SCORE
+    latest_entry: dict | None = None
+    latest_timestamp: dt.datetime | None = None
+    for entry in history:
+        parsed = parse_date(entry.get("timestamp"))
+        if parsed is None:
+            continue
+        if latest_timestamp is None or parsed > latest_timestamp:
+            latest_timestamp = parsed
+            latest_entry = entry
 
-    elapsed_seconds = max((end - start).total_seconds(), 0.0)
-    return 1.0 - min(elapsed_seconds / budget_seconds, 1.0)
+    if latest_entry is None:
+        return 0.0
+
+    if "pass_rate" in latest_entry:
+        return clamp_score(coerce_float(latest_entry.get("pass_rate"), 0.0))
+
+    total = coerce_float(latest_entry.get("total"), 0.0)
+    passed = coerce_float(latest_entry.get("passed"), 0.0)
+    if total <= 0:
+        return 0.0
+    return clamp_score(passed / total)
 
 
-def score_adoption(evidence_file: str) -> float:
-    adoption = load_state_json(evidence_file, "adoption.json")
-    if not adoption:
-        return NEUTRAL_DIMENSION_SCORE
-    return max(
-        0.0,
-        min(coerce_float(adoption.get("score"), NEUTRAL_DIMENSION_SCORE), 1.0),
-    )
+def candidate_delivery_dirs(evidence_file: str | Path) -> list[Path]:
+    evidence_path = Path(evidence_file)
+    candidates = [
+        evidence_path.parent.parent / "delivery",
+        evidence_path.parent.parent.parent / "delivery",
+        evidence_path.parent / "delivery",
+    ]
+
+    unique_candidates: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique_candidates.append(candidate)
+    return unique_candidates
 
 
-def score_knowledge_growth(evidence_file: str) -> float:
-    """Score cumulative knowledge growth across sessions.
+def find_latest_delivery_file(evidence_file: str | Path) -> Path | None:
+    evidence_name = Path(
+        evidence_file
+    ).stem  # e.g. "20260404-ai-code-review-tools-results"
+    # Strip common suffixes to get the session slug
+    session_slug = evidence_name
+    for suffix in ("-results", "-claims", "-search-errors"):
+        if session_slug.endswith(suffix):
+            session_slug = session_slug[: -len(suffix)]
+            break
 
-    Reads state/knowledge-growth.json with fields:
-    - initial_entries: knowledge map size at session start
-    - final_entries: knowledge map size at session end
-    - initial_gaps: GAP-tagged items at session start
-    - remaining_gaps: GAP-tagged items at session end
-    - high_confidence: HIGH-tagged items at session end
+    # First pass: try to match by session slug prefix
+    for delivery_dir in candidate_delivery_dirs(evidence_file):
+        if not delivery_dir.is_dir():
+            continue
+        for path in delivery_dir.iterdir():
+            if not path.is_file():
+                continue
+            if path.stem.startswith(session_slug):
+                return path
 
-    Score = weighted combination of:
-    - growth_ratio: new entries / max(initial, 1) (capped at 1.0 for 100% growth)
-    - gap_closure: (initial_gaps - remaining_gaps) / max(initial_gaps, 1)
-    - confidence_ratio: high_confidence / max(final_entries, 1)
+    # Fallback: most recently modified file
+    latest_file: Path | None = None
+    latest_mtime = -1.0
+    for delivery_dir in candidate_delivery_dirs(evidence_file):
+        if not delivery_dir.is_dir():
+            continue
+        for path in delivery_dir.iterdir():
+            if not path.is_file():
+                continue
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                continue
+            if mtime > latest_mtime:
+                latest_mtime = mtime
+                latest_file = path
+    return latest_file
 
-    Returns NEUTRAL (0.5) when the file does not exist or has no meaningful data.
-    """
-    kg = load_state_json(evidence_file, "knowledge-growth.json")
-    if not kg:
-        return NEUTRAL_DIMENSION_SCORE
 
-    initial = coerce_float(kg.get("initial_entries"), 0)
-    final = coerce_float(kg.get("final_entries"), 0)
-    initial_gaps = coerce_float(kg.get("initial_gaps"), 0)
-    remaining_gaps = coerce_float(kg.get("remaining_gaps"), 0)
-    high_confidence = coerce_float(kg.get("high_confidence"), 0)
+def extract_citation_urls(delivery_file: Path) -> list[str]:
+    try:
+        content = delivery_file.read_text(encoding="utf-8")
+    except OSError:
+        return []
 
-    # No meaningful data yet — return neutral instead of penalizing
-    if initial == 0 and final == 0 and initial_gaps == 0:
-        return NEUTRAL_DIMENSION_SCORE
+    urls = HTML_CITATION_RE.findall(content)
+    urls.extend(match[1] for match in MARKDOWN_CITATION_RE.findall(content))
+    urls.extend(match[1] for match in MARKDOWN_PLAIN_CITATION_RE.findall(content))
+    return urls
 
-    # Growth: how much did the knowledge map expand?
-    growth_ratio = (
-        min((final - initial) / max(initial, 1), 1.0) if final > initial else 0.0
-    )
 
-    # Gap closure: how many unknowns were resolved?
-    gap_closure = (
-        (initial_gaps - remaining_gaps) / max(initial_gaps, 1)
-        if initial_gaps > remaining_gaps
-        else 0.0
-    )
+def score_groundedness(evidence_file: str, results: list[dict]) -> float:
+    delivery_file = find_latest_delivery_file(evidence_file)
+    if delivery_file is None:
+        return 0.0
 
-    # Confidence: what fraction of knowledge is HIGH confidence?
-    confidence_ratio = high_confidence / max(final, 1) if final > 0 else 0.0
+    citation_urls = extract_citation_urls(delivery_file)
+    if not citation_urls:
+        return 0.0
 
-    # Weighted combination: gap closure most important, then confidence, then growth
-    return 0.4 * gap_closure + 0.35 * confidence_ratio + 0.25 * growth_ratio
+    evidence_urls = {item.get("url") for item in results if item.get("url")}
+    grounded_count = sum(1 for url in citation_urls if url in evidence_urls)
+    return clamp_score(grounded_count / len(citation_urls))
+
+
+def score_content_depth(results: list[dict]) -> float:
+    total_results = len(results)
+    if total_results == 0:
+        return 0.0
+
+    with_content = 0
+    for item in results:
+        metadata = (
+            item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        )
+        extracted_content = metadata.get("extracted_content")
+        if isinstance(extracted_content, str) and extracted_content.strip():
+            with_content += 1
+    return clamp_score(with_content / total_results)
+
+
+def score_relevant_yield(results: list[dict]) -> float:
+    total_results = len(results)
+    if total_results == 0:
+        return 0.0
+
+    queries = {
+        str(item.get("query", "")).strip()
+        for item in results
+        if str(item.get("query", "")).strip()
+    }
+    query_words = {word.lower() for query in queries for word in WORD_RE.findall(query)}
+
+    relevant_count = 0
+    for item in results:
+        metadata = (
+            item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        )
+        if "llm_relevant" in metadata:
+            if metadata.get("llm_relevant") is True:
+                relevant_count += 1
+            continue
+
+        haystack_words = {
+            word.lower()
+            for word in WORD_RE.findall(
+                f"{item.get('title', '')} {item.get('snippet', '')}"
+            )
+        }
+        if query_words and haystack_words.intersection(query_words):
+            relevant_count += 1
+    return clamp_score(relevant_count / total_results)
+
+
+def score_source_diversity(results: list[dict]) -> float:
+    if not results:
+        return 0.0
+
+    has_llm_relevant = False
+    relevant_results: list[dict] = []
+    for item in results:
+        metadata = (
+            item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        )
+        if "llm_relevant" in metadata:
+            has_llm_relevant = True
+            if metadata.get("llm_relevant") is True:
+                relevant_results.append(item)
+
+    scored_results = relevant_results if has_llm_relevant else results
+    platforms = [
+        str(item.get("source", "")).lower()
+        for item in scored_results
+        if item.get("source")
+    ]
+    total_results = len(platforms)
+    if total_results <= 1:
+        return 0.0
+
+    counts = Counter(platforms)
+    if len(counts) <= 1:
+        return 0.0
+
+    numerator = sum(count * (count - 1) for count in counts.values())
+    return clamp_score(1.0 - (numerator / (total_results * (total_results - 1))))
 
 
 def score_results(
@@ -232,6 +356,7 @@ def score_results(
     scoring_config = load_scoring_config(evidence_file)
     weights = weights or scoring_config["dimension_weights"]
     now = now or dt.datetime.now(dt.timezone.utc)
+
     total_results = len(results)
     unique_urls = {item.get("url") for item in results if item.get("url")}
     queries = {
@@ -243,64 +368,14 @@ def score_results(
         str(item.get("source", "")).lower() for item in results if item.get("source")
     ]
     counts = Counter(platforms)
-    query_words = {word.lower() for query in queries for word in WORD_RE.findall(query)}
 
-    quantity = min(len(unique_urls) / max(target, 1), 1.0)
-    if total_results <= 1:
-        diversity = 0.0
-    else:
-        numerator = sum(count * (count - 1) for count in counts.values())
-        diversity = 1.0 - (numerator / (total_results * (total_results - 1)))
-
-    match_count = 0
-    for item in results:
-        metadata = (
-            item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
-        )
-        if "llm_relevant" in metadata:
-            if metadata.get("llm_relevant") is True:
-                match_count += 1
-            continue
-
-        haystack_words = {
-            word.lower()
-            for word in WORD_RE.findall(
-                f"{item.get('title', '')} {item.get('snippet', '')}"
-            )
-        }
-        if query_words and haystack_words.intersection(query_words):
-            match_count += 1
-    relevance = match_count / total_results if total_results else 0.0
-
-    freshness_days = scoring_config.get("freshness_days", 183)
-    fresh_cutoff = now - dt.timedelta(days=freshness_days)
-    fresh_count = 0
-    for item in results:
-        metadata = (
-            item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
-        )
-        parsed = None
-        for name in DATE_FIELDS:
-            parsed = parse_date(metadata.get(name))
-            if parsed:
-                break
-        if parsed and parsed >= fresh_cutoff:
-            fresh_count += 1
-    freshness = fresh_count / total_results if total_results else 0.0
-
-    efficiency = min(len(unique_urls) / max(len(queries) * 3, 1), 1.0)
-    latency = score_latency(evidence_file, scoring_config["latency_budget_seconds"])
-    adoption = score_adoption(evidence_file)
-    knowledge_growth = score_knowledge_growth(evidence_file)
     dimensions = {
-        "quantity": quantity,
-        "diversity": diversity,
-        "relevance": relevance,
-        "freshness": freshness,
-        "efficiency": efficiency,
-        "latency": latency,
-        "adoption": adoption,
-        "knowledge_growth": knowledge_growth,
+        "rubric_pass_rate": score_rubric_pass_rate(evidence_file),
+        "groundedness": score_groundedness(evidence_file, results),
+        "relevant_yield": score_relevant_yield(results),
+        "content_depth": score_content_depth(results),
+        "source_diversity": score_source_diversity(results),
+        "quantity": clamp_score(min(len(unique_urls) / max(target, 1), 1.0)),
     }
     weight_sum = sum(float(weights.get(name, 0.0)) for name in dimensions)
     total = (
@@ -310,10 +385,8 @@ def score_results(
         else 0.0
     )
     return {
-        "total": max(0.0, min(total, 1.0)),
-        "dimensions": {
-            name: max(0.0, min(value, 1.0)) for name, value in dimensions.items()
-        },
+        "total": clamp_score(total),
+        "dimensions": {name: clamp_score(value) for name, value in dimensions.items()},
         "meta": {
             "total_results": total_results,
             "unique_urls": len(unique_urls),

--- a/lib/quality_eval.py
+++ b/lib/quality_eval.py
@@ -1,0 +1,220 @@
+"""LLM-as-judge deep evaluation for AutoSearch reports.
+
+Adapted from LangChain open_deep_research evaluators.py and prompts.py.
+
+This module defines Pydantic schemas and prompt templates for offline
+report quality evaluation. It does NOT call LLMs directly — callers
+are responsible for invoking their preferred LLM with structured output.
+
+Usage:
+    from lib.quality_eval import (
+        OverallQualityScore, GroundednessScore, CompletenessScore,
+        format_overall_quality_input, format_groundedness_input,
+        format_completeness_input,
+        OVERALL_QUALITY_PROMPT, GROUNDEDNESS_PROMPT, COMPLETENESS_PROMPT,
+    )
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class OverallQualityScore(BaseModel):
+    """Score a research report across six quality dimensions (1-5 each)."""
+
+    research_depth: int = Field(
+        description="1-5: thoroughness, coverage, depth of understanding, background context."
+    )
+    source_quality: int = Field(
+        description="1-5: authoritative sources, diversity of source types, citation integration."
+    )
+    analytical_rigor: int = Field(
+        description="1-5: sophistication, critical evaluation, nuances and limitations identified."
+    )
+    practical_value: int = Field(
+        description="1-5: clarity of insights, specific examples, actionable recommendations."
+    )
+    balance_objectivity: int = Field(
+        description="1-5: multiple perspectives, limitations acknowledged, facts vs opinions."
+    )
+    writing_quality: int = Field(
+        description="1-5: clarity, professionalism, terminology, tone consistency, readability."
+    )
+
+    def normalize(self) -> dict[str, float]:
+        """Return all scores normalized to 0-1 (raw / 5)."""
+        return {
+            "research_depth": self.research_depth / 5,
+            "source_quality": self.source_quality / 5,
+            "analytical_rigor": self.analytical_rigor / 5,
+            "practical_value": self.practical_value / 5,
+            "balance_objectivity": self.balance_objectivity / 5,
+            "writing_quality": self.writing_quality / 5,
+        }
+
+
+class GroundednessClaim(BaseModel):
+    """A single claim extracted from the report with grounding judgment."""
+
+    claim: str = Field(description="The claim extracted from the report.")
+    grounded: bool = Field(description="Whether the claim is grounded in the context.")
+
+
+class GroundednessScore(BaseModel):
+    """Extract claims from a report and check grounding against context."""
+
+    claims: list[GroundednessClaim] = Field(
+        description="All claims extracted from the report with grounding judgments."
+    )
+
+    def score(self) -> float:
+        """Return grounded claims / total claims, or 0.0 if no claims."""
+        if not self.claims:
+            return 0.0
+        grounded = sum(1 for c in self.claims if c.grounded)
+        return grounded / len(self.claims)
+
+
+class CompletenessScore(BaseModel):
+    """Score report completeness against the research question."""
+
+    reasoning: str = Field(
+        description="Explanation with specific examples from the report."
+    )
+    score: int = Field(
+        description="1-5: how completely the report covers all points from the question."
+    )
+
+    def normalize(self) -> float:
+        """Return score normalized to 0-1."""
+        return self.score / 5
+
+
+# ---------------------------------------------------------------------------
+# Prompts — adapted from open_deep_research/tests/prompts.py
+# ---------------------------------------------------------------------------
+
+
+OVERALL_QUALITY_PROMPT = """You are an expert evaluator assessing the quality of a research report.
+
+Evaluation Criteria:
+
+1. Research Depth and Comprehensiveness
+   - Thoroughness of analysis
+   - Coverage of aspects relevant to the user's input
+   - Depth of understanding
+   - Background context provided
+
+2. Source Quality and Methodology
+   - Use of authoritative sources
+   - Diversity of source types (news, papers, repos, forums)
+   - Citation quality and integration
+   - Transparency of research methodology
+
+3. Analytical Rigor
+   - Sophistication of analysis
+   - Critical evaluation of source information
+   - Identification of nuances and limitations
+
+4. Practical Value and Actionability
+   - Clarity of insights and recommendations
+   - Specific examples and use cases
+   - Does not refer to itself as the writer of the report
+
+5. Balance and Objectivity
+   - Presentation of multiple perspectives
+   - Acknowledgment of limitations and trade-offs
+   - Distinction between facts and opinions
+   - Avoidance of bias
+
+6. Writing Quality and Clarity
+   - Clarity and professionalism of writing
+   - Appropriate use of terminology
+   - Consistency of tone and style
+   - Engagement and readability
+   - Does not refer to itself as the writer of the report
+
+Scoring: 1 = Poor, 2 = Fair, 3 = Good, 4 = Very Good, 5 = Excellent
+
+Today is {today}
+
+Evaluate the research report now."""
+
+
+GROUNDEDNESS_PROMPT = """You are evaluating how well a research report is supported by retrieved context.
+
+A well-grounded report should:
+- Make claims directly supported by the retrieved context
+- Stay within the scope of information provided
+- Maintain the same meaning and intent as the source material
+- Not introduce external facts or unsupported assertions outside of basic facts
+
+An ungrounded report:
+- Makes claims without support from the context
+- Contradicts the retrieved information
+- Includes speculation or external knowledge outside of basic facts
+- Distorts or misrepresents the context
+
+Instructions:
+- Compare the report against the retrieved context carefully
+- Identify factual claims, statements, and assertions made in the report
+- For each claim, decide whether it is directly grounded in the context
+- Claims are often made where you see citations — check against the cited source
+
+<context>
+{context}
+</context>
+
+<report>
+{report}
+</report>"""
+
+
+COMPLETENESS_PROMPT = """You are evaluating the completeness of a research report.
+
+A complete report should:
+- Answer all points from the user's question
+- Cover the full scope of the research topic
+- Not make assumptions not directly stated by the user's question
+
+An incomplete report:
+- Does not answer all points from the user's question
+- Makes assumptions that are not directly stated
+
+Instructions:
+- Compare the report against the user's question
+- Identify any points that are not covered
+- Focus solely on completeness
+
+<user_question>
+{user_question}
+</user_question>
+
+<report>
+{report}
+</report>"""
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def format_overall_quality_input(query: str, report: str) -> str:
+    """Format user input for overall quality evaluation."""
+    return f"User input: {query}\n\nReport:\n\n{report}\n\nEvaluate whether the report meets the criteria."
+
+
+def format_groundedness_input(context: str, report: str) -> str:
+    """Format user input for groundedness evaluation."""
+    return GROUNDEDNESS_PROMPT.format(context=context, report=report)
+
+
+def format_completeness_input(user_question: str, report: str) -> str:
+    """Format user input for completeness evaluation."""
+    return COMPLETENESS_PROMPT.format(user_question=user_question, report=report)

--- a/lib/quality_eval.py
+++ b/lib/quality_eval.py
@@ -2,7 +2,7 @@
 
 Adapted from LangChain open_deep_research evaluators.py and prompts.py.
 
-This module defines Pydantic schemas and prompt templates for offline
+This module defines schemas and prompt templates for offline
 report quality evaluation. It does NOT call LLMs directly — callers
 are responsible for invoking their preferred LLM with structured output.
 
@@ -17,33 +17,36 @@ Usage:
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from dataclasses import dataclass, field
 
 # ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
 
 
-class OverallQualityScore(BaseModel):
+@dataclass
+class OverallQualityScore:
     """Score a research report across six quality dimensions (1-5 each)."""
 
-    research_depth: int = Field(
-        description="1-5: thoroughness, coverage, depth of understanding, background context."
-    )
-    source_quality: int = Field(
-        description="1-5: authoritative sources, diversity of source types, citation integration."
-    )
-    analytical_rigor: int = Field(
-        description="1-5: sophistication, critical evaluation, nuances and limitations identified."
-    )
-    practical_value: int = Field(
-        description="1-5: clarity of insights, specific examples, actionable recommendations."
-    )
-    balance_objectivity: int = Field(
-        description="1-5: multiple perspectives, limitations acknowledged, facts vs opinions."
-    )
-    writing_quality: int = Field(
-        description="1-5: clarity, professionalism, terminology, tone consistency, readability."
+    research_depth: int
+    source_quality: int
+    analytical_rigor: int
+    practical_value: int
+    balance_objectivity: int
+    writing_quality: int
+
+    # Class-level field metadata for introspection
+    model_fields: dict[str, object] = field(
+        default_factory=lambda: {
+            "research_depth": {},
+            "source_quality": {},
+            "analytical_rigor": {},
+            "practical_value": {},
+            "balance_objectivity": {},
+            "writing_quality": {},
+        },
+        init=False,
+        repr=False,
     )
 
     def normalize(self) -> dict[str, float]:
@@ -58,19 +61,19 @@ class OverallQualityScore(BaseModel):
         }
 
 
-class GroundednessClaim(BaseModel):
+@dataclass
+class GroundednessClaim:
     """A single claim extracted from the report with grounding judgment."""
 
-    claim: str = Field(description="The claim extracted from the report.")
-    grounded: bool = Field(description="Whether the claim is grounded in the context.")
+    claim: str
+    grounded: bool
 
 
-class GroundednessScore(BaseModel):
+@dataclass
+class GroundednessScore:
     """Extract claims from a report and check grounding against context."""
 
-    claims: list[GroundednessClaim] = Field(
-        description="All claims extracted from the report with grounding judgments."
-    )
+    claims: list[GroundednessClaim]
 
     def score(self) -> float:
         """Return grounded claims / total claims, or 0.0 if no claims."""
@@ -80,15 +83,12 @@ class GroundednessScore(BaseModel):
         return grounded / len(self.claims)
 
 
-class CompletenessScore(BaseModel):
+@dataclass
+class CompletenessScore:
     """Score report completeness against the research question."""
 
-    reasoning: str = Field(
-        description="Explanation with specific examples from the report."
-    )
-    score: int = Field(
-        description="1-5: how completely the report covers all points from the question."
-    )
+    reasoning: str
+    score: int  # 1-5
 
     def normalize(self) -> float:
         """Return score normalized to 0-1."""

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xmariowu/autosearch",
-  "version": "2026.04.06.6",
+  "version": "2026.04.06.7",
   "description": "Self-evolving deep research for Claude Code. Gets smarter every time you use it.",
   "author": "0xmariowu",
   "license": "MIT",

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.04.06.6",
+  "version": "2026.04.06.7",
   "channel_count": 34,
   "skill_count": 54,
   "channels": [

--- a/tests/integration/run_e2e_test.py
+++ b/tests/integration/run_e2e_test.py
@@ -536,20 +536,199 @@ Output ONLY the JSON array."""
         )
 
 
-async def run_block6(session: SessionDir) -> BlockResult:
-    """Block 6: Evolve — simplified (write worklog only, no git ops)."""
+def _write_query_outcomes(session: SessionDir) -> int:
+    """Extract query-level outcomes from results and append to state."""
+    results = session.read_results()
+    if not results:
+        return 0
+
+    # Group by query+channel
+    combos: dict[tuple[str, str], list[dict]] = {}
+    for r in results:
+        key = (r.get("query", ""), r.get("source", ""))
+        combos.setdefault(key, []).append(r)
+
+    outcomes_path = session.root / "state" / "query-outcomes.jsonl"
+    count = 0
+    with open(outcomes_path, "a") as f:
+        for (query, channel), items in combos.items():
+            if not query:
+                continue
+            relevant = sum(
+                1
+                for i in items
+                if isinstance(i.get("metadata"), dict)
+                and i["metadata"].get("llm_relevant") is True
+            )
+            entry = {
+                "session": session.id,
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "query": query,
+                "channel": channel,
+                "results_count": len(items),
+                "relevant_count": relevant,
+                "relevant_rate": round(relevant / len(items), 2) if items else 0,
+                "topic_type": "general",
+            }
+            f.write(json.dumps(entry) + "\n")
+            count += 1
+    return count
+
+
+def _write_winning_patterns(session: SessionDir) -> int:
+    """Extract winning patterns from query-outcomes and append to state."""
+    qo_path = session.root / "state" / "query-outcomes.jsonl"
+    if not qo_path.exists():
+        return 0
+
+    lines = qo_path.read_text().strip().split("\n")
+    outcomes = [json.loads(l) for l in lines if l.strip()]
+
+    patterns_path = session.root / "state" / "patterns-v2.jsonl"
+    count = 0
+    with open(patterns_path, "a") as f:
+        for o in outcomes:
+            if o.get("relevant_rate", 0) >= 0.5 and o.get("results_count", 0) >= 2:
+                pattern = {
+                    "session": session.id,
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "type": "winning_pattern",
+                    "pattern": f"{o['channel']} with query '{o['query']}' yielded {o['relevant_rate']:.0%} relevance",
+                    "channel": o.get("channel", ""),
+                    "topic_type": o.get("topic_type", "general"),
+                    "confidence": "medium",
+                }
+                f.write(json.dumps(pattern) + "\n")
+                count += 1
+    return count
+
+
+async def run_block6(llm: LLMClient, session: SessionDir, topic: str) -> BlockResult:
+    """Block 6: Evolve — write query-outcomes, patterns, diagnose failures, propose skill change."""
     start = time.monotonic()
     try:
-        # Write a worklog entry
-        entry = {
-            "type": "e2e_test",
+        # Step 1: Write query outcomes
+        qo_count = _write_query_outcomes(session)
+
+        # Step 2: Write winning patterns
+        patterns_count = _write_winning_patterns(session)
+
+        # Step 3: Read checked rubrics and diagnose
+        checked_path = (
+            session.root / "evidence" / f"checked-rubrics-{session.slug}.jsonl"
+        )
+        evolution_entry = None
+        evolved = False
+
+        if checked_path.exists():
+            lines = checked_path.read_text().strip().split("\n")
+            checked = [json.loads(l) for l in lines if l.strip()]
+            failed = [c for c in checked if not c.get("passed")]
+            passed_count = sum(1 for c in checked if c.get("passed"))
+            pass_rate = passed_count / len(checked) if checked else 0
+
+            if failed and pass_rate < 0.75:
+                # Diagnose and propose a skill change via LLM
+                auto_evolve_skill = read_skill("auto-evolve")
+                failed_json = json.dumps(failed[:5], indent=2)
+
+                prompt = f"""You are AutoSearch's evolution engine. Analyze failed rubrics and propose ONE skill modification.
+
+Topic: {topic}
+Pass rate: {pass_rate:.2f} ({passed_count}/{len(checked)})
+
+Failed rubrics:
+{failed_json}
+
+Available mutable skills (DO NOT modify auto-evolve, create-skill, observe-user, interact-user, discover-environment, generate-rubrics, check-rubrics, judge.py, PROTOCOL.md):
+- gene-query: query generation strategy
+- select-channels: channel selection rules
+- synthesize-knowledge: report synthesis rules
+- llm-evaluate: relevance evaluation
+
+Instructions from auto-evolve skill:
+{auto_evolve_skill[:2000]}
+
+Output ONLY a JSON object:
+{{
+  "diagnosis": "one-line root cause",
+  "weakest_category": "category name",
+  "target_rubrics": ["r001", "r002"],
+  "action": "what to change",
+  "target_file": "skills/synthesize-knowledge/SKILL.md",
+  "expected_flips": ["r001"]
+}}"""
+
+                response = await llm.chat("sonnet", prompt, max_tokens=2000)
+                try:
+                    json_match = re.search(r"\{.*\}", response, re.DOTALL)
+                    if json_match:
+                        diagnosis = json.loads(json_match.group(0))
+                        evolution_entry = {
+                            "session": session.id,
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "topic": topic,
+                            "rubric_pass_rate": round(pass_rate, 3),
+                            "failed_rubrics": [f.get("id", "") for f in failed],
+                            "weakest_category": diagnosis.get("weakest_category", ""),
+                            "target_rubrics": diagnosis.get("target_rubrics", []),
+                            "diagnosis": diagnosis.get("diagnosis", ""),
+                            "action": diagnosis.get("action", ""),
+                            "modified_file": diagnosis.get("target_file", ""),
+                            "expected_flips": diagnosis.get("expected_flips", []),
+                            "commit_hash": None,
+                            "note": "e2e_test: diagnosis only, no git commit",
+                        }
+                        evolved = True
+                except (json.JSONDecodeError, KeyError):
+                    pass
+            else:
+                evolution_entry = {
+                    "session": session.id,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "topic": topic,
+                    "rubric_pass_rate": round(pass_rate, 3),
+                    "failed_rubrics": [f.get("id", "") for f in failed],
+                    "skip_reason": f"skip: pass rate {pass_rate:.2f} >= 0.75"
+                    if pass_rate >= 0.75
+                    else "skip: no failed rubrics",
+                }
+
+        # Write evolution log
+        evo_path = session.root / "state" / "evolution-log.jsonl"
+        if evolution_entry:
+            with open(evo_path, "a") as f:
+                f.write(json.dumps(evolution_entry) + "\n")
+
+        # Write rubric history (for judge.py rubric_pass_rate dimension)
+        if checked_path.exists():
+            lines = checked_path.read_text().strip().split("\n")
+            checked = [json.loads(l) for l in lines if l.strip()]
+            passed_count = sum(1 for c in checked if c.get("passed"))
+            rh_entry = {
+                "topic": topic,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "total_rubrics": len(checked),
+                "passed": passed_count,
+                "failed": len(checked) - passed_count,
+                "pass_rate": round(passed_count / len(checked), 3) if checked else 0,
+            }
+            rh_path = session.root / "state" / "rubric-history.jsonl"
+            with open(rh_path, "a") as f:
+                f.write(json.dumps(rh_entry) + "\n")
+
+        # Write worklog
+        wl_entry = {
+            "type": "evolution",
             "ts": datetime.now(timezone.utc).isoformat(),
             "session_id": session.id,
-            "topic_id": session.topic_id,
+            "query_outcomes": qo_count,
+            "patterns_saved": patterns_count,
+            "evolved": evolved,
         }
         wl = session.root / "state" / "worklog.jsonl"
         with open(wl, "a") as f:
-            f.write(json.dumps(entry) + "\n")
+            f.write(json.dumps(wl_entry) + "\n")
 
         elapsed = int((time.monotonic() - start) * 1000)
         return BlockResult(
@@ -557,7 +736,17 @@ async def run_block6(session: SessionDir) -> BlockResult:
             name="Evolve",
             passed=True,
             time_ms=elapsed,
-            details={"worklog_written": True},
+            details={
+                "query_outcomes": qo_count,
+                "patterns_saved": patterns_count,
+                "evolved": evolved,
+                "diagnosis": evolution_entry.get("diagnosis")
+                if evolution_entry
+                else None,
+                "target_file": evolution_entry.get("modified_file")
+                if evolution_entry
+                else None,
+            },
         )
     except Exception as exc:
         elapsed = int((time.monotonic() - start) * 1000)
@@ -589,7 +778,7 @@ async def run_topic(
         ("Block 5", lambda: run_block5(llm, session)),
     ]
     if not skip_evolve:
-        blocks.append(("Block 6", lambda: run_block6(session)))
+        blocks.append(("Block 6", lambda: run_block6(llm, session, topic["topic"])))
 
     all_passed = True
     for block_name, block_fn in blocks:

--- a/tests/integration/run_e2e_test.py
+++ b/tests/integration/run_e2e_test.py
@@ -582,7 +582,7 @@ def _write_winning_patterns(session: SessionDir) -> int:
         return 0
 
     lines = qo_path.read_text().strip().split("\n")
-    outcomes = [json.loads(l) for l in lines if l.strip()]
+    outcomes = [json.loads(line) for line in lines if line.strip()]
 
     patterns_path = session.root / "state" / "patterns-v2.jsonl"
     count = 0
@@ -622,7 +622,7 @@ async def run_block6(llm: LLMClient, session: SessionDir, topic: str) -> BlockRe
 
         if checked_path.exists():
             lines = checked_path.read_text().strip().split("\n")
-            checked = [json.loads(l) for l in lines if l.strip()]
+            checked = [json.loads(line) for line in lines if line.strip()]
             failed = [c for c in checked if not c.get("passed")]
             passed_count = sum(1 for c in checked if c.get("passed"))
             pass_rate = passed_count / len(checked) if checked else 0
@@ -703,7 +703,7 @@ Output ONLY a JSON object:
         # Write rubric history (for judge.py rubric_pass_rate dimension)
         if checked_path.exists():
             lines = checked_path.read_text().strip().split("\n")
-            checked = [json.loads(l) for l in lines if l.strip()]
+            checked = [json.loads(line) for line in lines if line.strip()]
             passed_count = sum(1 for c in checked if c.get("passed"))
             rh_entry = {
                 "topic": topic,

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,3 +1,11 @@
+"""Tests for judge.py utility functions and backward-compatible interfaces.
+
+Dimension-specific tests are in test_judge_v2.py.
+This file covers: load_results, parse_date, load_scoring_config, custom weights.
+"""
+
+from __future__ import annotations
+
 import datetime as dt
 import json
 from pathlib import Path
@@ -6,14 +14,10 @@ import pytest
 
 from lib.judge import (
     DEFAULT_WEIGHTS,
-    NEUTRAL_DIMENSION_SCORE,
     load_default_weights,
     load_results,
     load_scoring_config,
     parse_date,
-    score_adoption,
-    score_knowledge_growth,
-    score_latency,
     score_results,
 )
 
@@ -26,14 +30,6 @@ def write_evidence_jsonl(tmp_path: Path, rows: list[object] | None = None) -> Pa
         content += "\n"
     evidence_path.write_text(content, encoding="utf-8")
     return evidence_path
-
-
-def write_state_json(tmp_path: Path, filename: str, payload: dict) -> Path:
-    state_dir = tmp_path / "state"
-    state_dir.mkdir(exist_ok=True)
-    path = state_dir / filename
-    path.write_text(json.dumps(payload), encoding="utf-8")
-    return path
 
 
 def make_result(
@@ -55,236 +51,13 @@ def make_result(
     }
 
 
-def test_score_empty_results(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path, [])
-
-    payload = score_results([], str(evidence_path))
-
-    assert payload["total"] == pytest.approx(
-        (
-            DEFAULT_WEIGHTS["latency"]
-            + DEFAULT_WEIGHTS["adoption"]
-            + DEFAULT_WEIGHTS["knowledge_growth"]
-        )
-        * NEUTRAL_DIMENSION_SCORE
-    )
-    assert payload["dimensions"] == {
-        "quantity": 0.0,
-        "diversity": 0.0,
-        "relevance": 0.0,
-        "freshness": 0.0,
-        "efficiency": 0.0,
-        "latency": NEUTRAL_DIMENSION_SCORE,
-        "adoption": NEUTRAL_DIMENSION_SCORE,
-        "knowledge_growth": NEUTRAL_DIMENSION_SCORE,
-    }
-
-
-def test_score_single_result(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    results = [make_result(url="https://example.com/1")]
-
-    payload = score_results(results, str(evidence_path))
-
-    assert payload["dimensions"]["diversity"] == 0.0
-
-
-def test_score_multiple_sources(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    results = [
-        make_result(url="https://example.com/1", source="google"),
-        make_result(url="https://example.com/2", source="reddit"),
-        make_result(url="https://example.com/3", source="news"),
-    ]
-
-    payload = score_results(results, str(evidence_path))
-
-    assert payload["dimensions"]["diversity"] > 0.0
-    assert payload["dimensions"]["diversity"] == pytest.approx(1.0)
-
-
-def test_relevance_keyword_match(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    results = [
-        make_result(
-            url="https://example.com/1",
-            query="openai roadmap",
-            title="OpenAI shares product roadmap",
-        )
-    ]
-
-    payload = score_results(results, str(evidence_path))
-
-    assert payload["dimensions"]["relevance"] > 0.0
-
-
-def test_relevance_llm_relevant_true(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    results = [
-        make_result(
-            url="https://example.com/1",
-            query="query words absent",
-            title="Completely unrelated title",
-            metadata={"llm_relevant": True},
-        )
-    ]
-
-    payload = score_results(results, str(evidence_path))
-
-    assert payload["dimensions"]["relevance"] == pytest.approx(1.0)
-
-
-def test_relevance_llm_relevant_false(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    results = [
-        make_result(
-            url="https://example.com/1",
-            query="openai roadmap",
-            title="OpenAI roadmap details",
-            metadata={"llm_relevant": False},
-        )
-    ]
-
-    payload = score_results(results, str(evidence_path))
-
-    assert payload["dimensions"]["relevance"] == 0.0
-
-
-def test_freshness_recent_dates(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    now = dt.datetime(2025, 7, 1, tzinfo=dt.timezone.utc)
-    results = [
-        make_result(
-            url="https://example.com/1",
-            metadata={"published_at": "2025-06-01T00:00:00Z"},
-        )
-    ]
-
-    payload = score_results(results, str(evidence_path), now=now)
-
-    assert payload["dimensions"]["freshness"] > 0.0
-    assert payload["dimensions"]["freshness"] == pytest.approx(1.0)
-
-
-def test_freshness_old_dates(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    now = dt.datetime(2025, 7, 1, tzinfo=dt.timezone.utc)
-    results = [
-        make_result(
-            url="https://example.com/1",
-            metadata={"published_at": "2024-12-01T00:00:00Z"},
-        )
-    ]
-
-    payload = score_results(results, str(evidence_path), now=now)
-
-    assert payload["dimensions"]["freshness"] == 0.0
-
-
-def test_efficiency(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    results = [
-        make_result(url=f"https://example.com/{index}", query="alpha")
-        for index in range(4)
-    ] + [
-        make_result(url=f"https://example.org/{index}", query="beta")
-        for index in range(4)
-    ]
-
-    payload = score_results(results, str(evidence_path))
-
-    assert payload["meta"]["unique_urls"] == 8
-    assert payload["meta"]["queries_used"] == 2
-    assert payload["dimensions"]["efficiency"] == pytest.approx(1.0)
-
-
-def test_score_latency_no_file(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-
-    assert score_latency(str(evidence_path), 120.0) == NEUTRAL_DIMENSION_SCORE
-
-
-def test_score_latency_with_timing(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    write_state_json(
-        tmp_path,
-        "timing.json",
-        {
-            "start_ts": "2025-03-15T10:00:00Z",
-            "end_ts": "2025-03-15T10:00:30Z",
-        },
-    )
-
-    assert score_latency(str(evidence_path), 120.0) == pytest.approx(0.75)
-
-
-def test_score_latency_missing_fields(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    write_state_json(
-        tmp_path,
-        "timing.json",
-        {"end_ts": "2025-03-15T10:00:30Z"},
-    )
-
-    assert score_latency(str(evidence_path), 120.0) == NEUTRAL_DIMENSION_SCORE
-
-
-def test_score_adoption_no_file(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-
-    assert score_adoption(str(evidence_path)) == NEUTRAL_DIMENSION_SCORE
-
-
-def test_score_adoption_with_score(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    write_state_json(tmp_path, "adoption.json", {"score": 0.8})
-
-    assert score_adoption(str(evidence_path)) == pytest.approx(0.8)
-
-
-def test_score_knowledge_growth_no_file(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-
-    assert score_knowledge_growth(str(evidence_path)) == NEUTRAL_DIMENSION_SCORE
-
-
-def test_score_knowledge_growth_all_zero(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    write_state_json(
-        tmp_path,
-        "knowledge-growth.json",
-        {
-            "initial_entries": 0,
-            "final_entries": 0,
-            "initial_gaps": 0,
-            "remaining_gaps": 0,
-            "high_confidence": 0,
-        },
-    )
-
-    assert score_knowledge_growth(str(evidence_path)) == NEUTRAL_DIMENSION_SCORE
-
-
-def test_score_knowledge_growth_with_data(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    write_state_json(
-        tmp_path,
-        "knowledge-growth.json",
-        {
-            "initial_entries": 10,
-            "final_entries": 20,
-            "initial_gaps": 5,
-            "remaining_gaps": 1,
-            "high_confidence": 8,
-        },
-    )
-
-    assert score_knowledge_growth(str(evidence_path)) == pytest.approx(0.71)
+# ---------------------------------------------------------------------------
+# load_results
+# ---------------------------------------------------------------------------
 
 
 def test_load_results_empty_file(tmp_path):
     evidence_path = write_evidence_jsonl(tmp_path, [])
-
     assert load_results(evidence_path) == []
 
 
@@ -301,7 +74,6 @@ def test_load_results_malformed_lines(tmp_path):
         + "\n",
         encoding="utf-8",
     )
-
     assert load_results(evidence_path) == [
         {"url": "https://example.com/1"},
         {"url": "https://example.com/2"},
@@ -321,19 +93,21 @@ def test_load_results_non_dict_json(tmp_path):
         + "\n",
         encoding="utf-8",
     )
-
     assert load_results(evidence_path) == [{"url": "https://example.com/1"}]
+
+
+# ---------------------------------------------------------------------------
+# parse_date
+# ---------------------------------------------------------------------------
 
 
 def test_parse_date_iso():
     parsed = parse_date("2025-03-15T10:00:00Z")
-
     assert parsed == dt.datetime(2025, 3, 15, 10, 0, tzinfo=dt.timezone.utc)
 
 
 def test_parse_date_unix_timestamp():
     timestamp = 1700000000
-
     assert parse_date(timestamp) == dt.datetime.fromtimestamp(
         timestamp, tz=dt.timezone.utc
     )
@@ -343,17 +117,27 @@ def test_parse_date_invalid():
     assert parse_date("garbage") is None
 
 
+# ---------------------------------------------------------------------------
+# Scoring config
+# ---------------------------------------------------------------------------
+
+
+def test_load_scoring_config_no_file(tmp_path):
+    evidence_path = write_evidence_jsonl(tmp_path)
+    config = load_scoring_config(str(evidence_path))
+    assert config["dimension_weights"] == DEFAULT_WEIGHTS
+    assert load_default_weights(str(evidence_path)) == DEFAULT_WEIGHTS
+
+
 def test_custom_weights(tmp_path):
     evidence_path = write_evidence_jsonl(tmp_path)
     results = [make_result(url="https://example.com/1")]
-
     payload = score_results(
         results,
         str(evidence_path),
         target=1,
         weights={"quantity": 1.0},
     )
-
     assert payload["dimensions"]["quantity"] == pytest.approx(1.0)
     assert payload["total"] == pytest.approx(1.0)
 
@@ -362,39 +146,5 @@ def test_weight_sum_zero(tmp_path):
     evidence_path = write_evidence_jsonl(tmp_path)
     results = [make_result(url="https://example.com/1")]
     zero_weights = {name: 0.0 for name in DEFAULT_WEIGHTS}
-
     payload = score_results(results, str(evidence_path), weights=zero_weights)
-
     assert payload["total"] == 0.0
-
-
-def test_load_scoring_config_no_file(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-
-    config = load_scoring_config(str(evidence_path))
-
-    assert config["dimension_weights"] == DEFAULT_WEIGHTS
-    assert config["latency_budget_seconds"] == pytest.approx(120.0)
-    assert load_default_weights(str(evidence_path)) == DEFAULT_WEIGHTS
-
-
-def test_load_scoring_config_custom(tmp_path):
-    evidence_path = write_evidence_jsonl(tmp_path)
-    write_state_json(
-        tmp_path,
-        "config.json",
-        {
-            "scoring": {
-                "dimension_weights": {"relevance": 0.5},
-                "latency_budget_seconds": 45,
-            }
-        },
-    )
-
-    config = load_scoring_config(str(evidence_path))
-
-    assert config["dimension_weights"]["relevance"] == pytest.approx(0.5)
-    assert config["dimension_weights"]["quantity"] == pytest.approx(
-        DEFAULT_WEIGHTS["quantity"]
-    )
-    assert config["latency_budget_seconds"] == pytest.approx(45.0)

--- a/tests/test_judge_v2.py
+++ b/tests/test_judge_v2.py
@@ -1,0 +1,542 @@
+"""Tests for judge.py v2 — report quality dimensions.
+
+Written test-first: these tests define the expected behavior of the new judge.
+Implementation in lib/judge.py should make all tests pass.
+
+New dimensions:
+  rubric_pass_rate (0.30) — reads rubric-history.jsonl
+  groundedness     (0.20) — delivery citation URLs vs evidence URLs
+  relevant_yield   (0.15) — llm_relevant=true / total
+  content_depth    (0.15) — extracted_content non-empty ratio
+  source_diversity (0.10) — unique platforms WITH relevant results
+  quantity         (0.10) — unique URLs / target
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lib.judge import (
+    DEFAULT_WEIGHTS,
+    score_results,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_evidence(tmp_path: Path, rows: list[dict]) -> Path:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir(exist_ok=True)
+    path = evidence_dir / "test-results.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(r) for r in rows) + ("\n" if rows else ""),
+        encoding="utf-8",
+    )
+    return path
+
+
+def write_state(tmp_path: Path, filename: str, payload: object) -> Path:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(exist_ok=True)
+    path = state_dir / filename
+    if isinstance(payload, list):
+        # JSONL format
+        path.write_text(
+            "\n".join(json.dumps(item) for item in payload) + "\n",
+            encoding="utf-8",
+        )
+    else:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def write_delivery(
+    tmp_path: Path, content: str, filename: str = "test-report.html"
+) -> Path:
+    delivery_dir = tmp_path / "delivery"
+    delivery_dir.mkdir(exist_ok=True)
+    path = delivery_dir / filename
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def make_result(
+    *,
+    url: str,
+    query: str = "test query",
+    source: str = "web-ddgs",
+    title: str = "",
+    snippet: str = "",
+    metadata: dict | None = None,
+) -> dict:
+    return {
+        "url": url,
+        "query": query,
+        "source": source,
+        "title": title,
+        "snippet": snippet,
+        "metadata": metadata or {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# T1: New default weights
+# ---------------------------------------------------------------------------
+
+
+class TestNewWeights:
+    def test_has_six_dimensions(self):
+        assert len(DEFAULT_WEIGHTS) == 6
+
+    def test_weights_sum_to_one(self):
+        assert sum(DEFAULT_WEIGHTS.values()) == pytest.approx(1.0)
+
+    def test_expected_dimensions_present(self):
+        expected = {
+            "rubric_pass_rate",
+            "groundedness",
+            "relevant_yield",
+            "content_depth",
+            "source_diversity",
+            "quantity",
+        }
+        assert set(DEFAULT_WEIGHTS.keys()) == expected
+
+    def test_old_dimensions_removed(self):
+        removed = {
+            "latency",
+            "freshness",
+            "adoption",
+            "knowledge_growth",
+            "efficiency",
+            "diversity",
+        }
+        for dim in removed:
+            assert dim not in DEFAULT_WEIGHTS, f"{dim} should be removed"
+
+    def test_rubric_pass_rate_highest_weight(self):
+        max_dim = max(DEFAULT_WEIGHTS, key=DEFAULT_WEIGHTS.get)
+        assert max_dim == "rubric_pass_rate"
+
+
+# ---------------------------------------------------------------------------
+# T2: rubric_pass_rate
+# ---------------------------------------------------------------------------
+
+
+class TestRubricPassRate:
+    def test_no_rubric_history_file(self, tmp_path):
+        evidence_path = write_evidence(tmp_path, [make_result(url="https://a.com")])
+        payload = score_results([make_result(url="https://a.com")], str(evidence_path))
+        # No rubric data = no quality evidence = 0.0
+        assert payload["dimensions"]["rubric_pass_rate"] == pytest.approx(0.0)
+
+    def test_reads_latest_entry(self, tmp_path):
+        evidence_path = write_evidence(tmp_path, [make_result(url="https://a.com")])
+        write_state(
+            tmp_path,
+            "rubric-history.jsonl",
+            [
+                {"topic": "old", "timestamp": "2026-04-01T00:00:00Z", "pass_rate": 0.5},
+                {
+                    "topic": "new",
+                    "timestamp": "2026-04-06T00:00:00Z",
+                    "pass_rate": 0.85,
+                },
+            ],
+        )
+        payload = score_results([make_result(url="https://a.com")], str(evidence_path))
+        assert payload["dimensions"]["rubric_pass_rate"] == pytest.approx(0.85)
+
+    def test_computes_from_passed_total(self, tmp_path):
+        """If pass_rate field missing, compute from passed/total."""
+        evidence_path = write_evidence(tmp_path, [make_result(url="https://a.com")])
+        write_state(
+            tmp_path,
+            "rubric-history.jsonl",
+            [
+                {
+                    "topic": "t",
+                    "timestamp": "2026-04-06T00:00:00Z",
+                    "passed": 18,
+                    "total": 24,
+                },
+            ],
+        )
+        payload = score_results([make_result(url="https://a.com")], str(evidence_path))
+        assert payload["dimensions"]["rubric_pass_rate"] == pytest.approx(0.75)
+
+    def test_single_entry(self, tmp_path):
+        evidence_path = write_evidence(tmp_path, [make_result(url="https://a.com")])
+        write_state(
+            tmp_path,
+            "rubric-history.jsonl",
+            [
+                {"topic": "t", "timestamp": "2026-04-06T00:00:00Z", "pass_rate": 1.0},
+            ],
+        )
+        payload = score_results([make_result(url="https://a.com")], str(evidence_path))
+        assert payload["dimensions"]["rubric_pass_rate"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# T3: groundedness
+# ---------------------------------------------------------------------------
+
+
+class TestGroundedness:
+    def test_no_delivery_file(self, tmp_path):
+        evidence_path = write_evidence(tmp_path, [make_result(url="https://a.com")])
+        payload = score_results([make_result(url="https://a.com")], str(evidence_path))
+        assert payload["dimensions"]["groundedness"] == pytest.approx(0.0)
+
+    def test_no_citations_in_delivery(self, tmp_path):
+        evidence_path = write_evidence(tmp_path, [make_result(url="https://a.com")])
+        write_delivery(tmp_path, "<html><body>Report with no citations</body></html>")
+        payload = score_results([make_result(url="https://a.com")], str(evidence_path))
+        assert payload["dimensions"]["groundedness"] == pytest.approx(0.0)
+
+    def test_all_citations_grounded(self, tmp_path):
+        urls = ["https://example.com/1", "https://example.com/2"]
+        evidence_path = write_evidence(
+            tmp_path,
+            [
+                make_result(url=urls[0]),
+                make_result(url=urls[1]),
+            ],
+        )
+        html = """<html><body>
+        <p>Finding <a href="#ref-1" class="cite">[1]</a> and <a href="#ref-2" class="cite">[2]</a></p>
+        <ol>
+        <li id="ref-1"><a href="https://example.com/1">Source 1</a></li>
+        <li id="ref-2"><a href="https://example.com/2">Source 2</a></li>
+        </ol>
+        </body></html>"""
+        write_delivery(tmp_path, html)
+        payload = score_results([make_result(url=u) for u in urls], str(evidence_path))
+        assert payload["dimensions"]["groundedness"] == pytest.approx(1.0)
+
+    def test_partial_grounding(self, tmp_path):
+        evidence_path = write_evidence(
+            tmp_path,
+            [
+                make_result(url="https://example.com/1"),
+                # url /2 NOT in evidence
+            ],
+        )
+        html = """<html><body>
+        <li id="ref-1"><a href="https://example.com/1">Source 1</a></li>
+        <li id="ref-2"><a href="https://example.com/2">Source 2</a></li>
+        </body></html>"""
+        write_delivery(tmp_path, html)
+        payload = score_results(
+            [make_result(url="https://example.com/1")], str(evidence_path)
+        )
+        # 1 grounded out of 2 cited = 0.5
+        assert payload["dimensions"]["groundedness"] == pytest.approx(0.5)
+
+    def test_markdown_format(self, tmp_path):
+        evidence_path = write_evidence(
+            tmp_path,
+            [
+                make_result(url="https://example.com/1"),
+            ],
+        )
+        md = "# Report\nSee [1](https://example.com/1) and [2](https://example.com/2)\n"
+        write_delivery(tmp_path, md, filename="test-report.md")
+        payload = score_results(
+            [make_result(url="https://example.com/1")], str(evidence_path)
+        )
+        assert payload["dimensions"]["groundedness"] == pytest.approx(0.5)
+
+    def test_plain_markdown_citation_format(self, tmp_path):
+        """[N] Title — URL format used in AutoSearch .md deliveries."""
+        evidence_path = write_evidence(
+            tmp_path,
+            [
+                make_result(url="https://example.com/1"),
+                make_result(url="https://example.com/2"),
+            ],
+        )
+        md = (
+            "# Report\nSome findings.\n\n"
+            "## References\n"
+            "[1] Source One — https://example.com/1\n"
+            "[2] Source Two — https://example.com/2\n"
+            "[3] Source Three — https://example.com/3\n"
+        )
+        write_delivery(tmp_path, md, filename="test-report.md")
+        payload = score_results(
+            [
+                make_result(url="https://example.com/1"),
+                make_result(url="https://example.com/2"),
+            ],
+            str(evidence_path),
+        )
+        # 2 grounded out of 3 cited
+        assert payload["dimensions"]["groundedness"] == pytest.approx(2.0 / 3.0)
+
+
+# ---------------------------------------------------------------------------
+# T4: content_depth
+# ---------------------------------------------------------------------------
+
+
+class TestContentDepth:
+    def test_all_empty_content(self, tmp_path):
+        results = [make_result(url=f"https://a.com/{i}") for i in range(5)]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["content_depth"] == pytest.approx(0.0)
+
+    def test_all_rich_content(self, tmp_path):
+        results = [
+            make_result(
+                url=f"https://a.com/{i}",
+                metadata={"extracted_content": "Full article text here..."},
+            )
+            for i in range(5)
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["content_depth"] == pytest.approx(1.0)
+
+    def test_mixed_content(self, tmp_path):
+        results = [
+            make_result(
+                url="https://a.com/1", metadata={"extracted_content": "Content"}
+            ),
+            make_result(
+                url="https://a.com/2", metadata={"extracted_content": "Content"}
+            ),
+            make_result(
+                url="https://a.com/3", metadata={"extracted_content": "Content"}
+            ),
+            make_result(url="https://a.com/4"),  # no content
+            make_result(url="https://a.com/5"),  # no content
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["content_depth"] == pytest.approx(0.6)
+
+    def test_empty_string_not_counted(self, tmp_path):
+        results = [
+            make_result(url="https://a.com/1", metadata={"extracted_content": ""}),
+            make_result(
+                url="https://a.com/2", metadata={"extracted_content": "Real content"}
+            ),
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["content_depth"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# T5: relevant_yield (replaces old relevance + efficiency)
+# ---------------------------------------------------------------------------
+
+
+class TestRelevantYield:
+    def test_all_relevant(self, tmp_path):
+        results = [
+            make_result(url=f"https://a.com/{i}", metadata={"llm_relevant": True})
+            for i in range(5)
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["relevant_yield"] == pytest.approx(1.0)
+
+    def test_none_relevant(self, tmp_path):
+        results = [
+            make_result(url=f"https://a.com/{i}", metadata={"llm_relevant": False})
+            for i in range(5)
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["relevant_yield"] == pytest.approx(0.0)
+
+    def test_mixed_relevance(self, tmp_path):
+        results = [
+            make_result(url="https://a.com/1", metadata={"llm_relevant": True}),
+            make_result(url="https://a.com/2", metadata={"llm_relevant": False}),
+            make_result(url="https://a.com/3", metadata={"llm_relevant": True}),
+            make_result(url="https://a.com/4", metadata={"llm_relevant": False}),
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["relevant_yield"] == pytest.approx(0.5)
+
+    def test_fallback_keyword_match(self, tmp_path):
+        """Without llm_relevant, falls back to keyword overlap."""
+        results = [
+            make_result(
+                url="https://a.com/1", query="openai api", title="OpenAI API docs"
+            ),
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["relevant_yield"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# T6: source_diversity (only platforms with relevant results count)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceDiversity:
+    def test_multiple_platforms_all_relevant(self, tmp_path):
+        results = [
+            make_result(
+                url="https://a.com/1",
+                source="github-repos",
+                metadata={"llm_relevant": True},
+            ),
+            make_result(
+                url="https://a.com/2",
+                source="web-ddgs",
+                metadata={"llm_relevant": True},
+            ),
+            make_result(
+                url="https://a.com/3", source="arxiv", metadata={"llm_relevant": True}
+            ),
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["source_diversity"] == pytest.approx(1.0)
+
+    def test_many_platforms_but_only_one_relevant(self, tmp_path):
+        """Searched 3 platforms, but only 1 had relevant results."""
+        results = [
+            make_result(
+                url="https://a.com/1",
+                source="github-repos",
+                metadata={"llm_relevant": True},
+            ),
+            make_result(
+                url="https://a.com/2",
+                source="web-ddgs",
+                metadata={"llm_relevant": False},
+            ),
+            make_result(
+                url="https://a.com/3", source="arxiv", metadata={"llm_relevant": False}
+            ),
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        # Only 1 platform contributed relevant results — low diversity
+        assert payload["dimensions"]["source_diversity"] < 0.5
+
+    def test_single_platform(self, tmp_path):
+        results = [
+            make_result(
+                url=f"https://a.com/{i}",
+                source="web-ddgs",
+                metadata={"llm_relevant": True},
+            )
+            for i in range(5)
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert payload["dimensions"]["source_diversity"] == pytest.approx(0.0)
+
+    def test_no_llm_relevant_falls_back(self, tmp_path):
+        """Without llm_relevant field, count all platforms."""
+        results = [
+            make_result(url="https://a.com/1", source="github-repos"),
+            make_result(url="https://a.com/2", source="web-ddgs"),
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        # Fallback: treat all as contributing
+        assert payload["dimensions"]["source_diversity"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# T7: quantity (unchanged logic)
+# ---------------------------------------------------------------------------
+
+
+class TestQuantity:
+    def test_below_target(self, tmp_path):
+        results = [make_result(url=f"https://a.com/{i}") for i in range(15)]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path), target=30)
+        assert payload["dimensions"]["quantity"] == pytest.approx(0.5)
+
+    def test_at_target(self, tmp_path):
+        results = [make_result(url=f"https://a.com/{i}") for i in range(30)]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path), target=30)
+        assert payload["dimensions"]["quantity"] == pytest.approx(1.0)
+
+    def test_above_target_capped(self, tmp_path):
+        results = [make_result(url=f"https://a.com/{i}") for i in range(60)]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path), target=30)
+        assert payload["dimensions"]["quantity"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# T8: score_results interface compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestScoreResultsInterface:
+    def test_returns_total_dimensions_meta(self, tmp_path):
+        evidence_path = write_evidence(tmp_path, [])
+        payload = score_results([], str(evidence_path))
+        assert "total" in payload
+        assert "dimensions" in payload
+        assert "meta" in payload
+
+    def test_total_in_range(self, tmp_path):
+        results = [make_result(url=f"https://a.com/{i}") for i in range(10)]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        assert 0.0 <= payload["total"] <= 1.0
+
+    def test_all_dimensions_in_range(self, tmp_path):
+        results = [
+            make_result(
+                url=f"https://a.com/{i}",
+                source=f"platform-{i}",
+                metadata={"llm_relevant": True, "extracted_content": "text"},
+            )
+            for i in range(5)
+        ]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        for name, value in payload["dimensions"].items():
+            assert 0.0 <= value <= 1.0, f"{name} = {value} out of range"
+
+    def test_empty_results_no_crash(self, tmp_path):
+        evidence_path = write_evidence(tmp_path, [])
+        payload = score_results([], str(evidence_path))
+        assert payload["total"] == pytest.approx(0.0)
+        for value in payload["dimensions"].values():
+            assert 0.0 <= value <= 1.0
+
+    def test_custom_weights(self, tmp_path):
+        results = [make_result(url="https://a.com/1")]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(
+            results, str(evidence_path), target=1, weights={"quantity": 1.0}
+        )
+        assert payload["dimensions"]["quantity"] == pytest.approx(1.0)
+        assert payload["total"] == pytest.approx(1.0)
+
+    def test_meta_fields(self, tmp_path):
+        results = [make_result(url="https://a.com/1")]
+        evidence_path = write_evidence(tmp_path, results)
+        payload = score_results(results, str(evidence_path))
+        meta = payload["meta"]
+        assert "total_results" in meta
+        assert "unique_urls" in meta
+        assert "platforms" in meta
+        assert "target" in meta
+        assert "queries_used" in meta

--- a/tests/test_quality_eval.py
+++ b/tests/test_quality_eval.py
@@ -1,0 +1,175 @@
+"""Tests for lib/quality_eval.py — LLM-as-judge deep evaluation.
+
+Tests cover schema validation and prompt formatting.
+Actual LLM calls are not tested here (they require API keys).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestOverallQualityScore:
+    def test_valid_scores(self):
+        from lib.quality_eval import OverallQualityScore
+
+        score = OverallQualityScore(
+            research_depth=4,
+            source_quality=3,
+            analytical_rigor=5,
+            practical_value=2,
+            balance_objectivity=4,
+            writing_quality=3,
+        )
+        assert score.research_depth == 4
+        assert score.writing_quality == 3
+
+    def test_has_six_fields(self):
+        from lib.quality_eval import OverallQualityScore
+
+        fields = OverallQualityScore.model_fields
+        assert len(fields) == 6
+
+    def test_field_names(self):
+        from lib.quality_eval import OverallQualityScore
+
+        expected = {
+            "research_depth",
+            "source_quality",
+            "analytical_rigor",
+            "practical_value",
+            "balance_objectivity",
+            "writing_quality",
+        }
+        assert set(OverallQualityScore.model_fields.keys()) == expected
+
+    def test_normalize(self):
+        from lib.quality_eval import OverallQualityScore
+
+        score = OverallQualityScore(
+            research_depth=5,
+            source_quality=5,
+            analytical_rigor=5,
+            practical_value=5,
+            balance_objectivity=5,
+            writing_quality=5,
+        )
+        normalized = score.normalize()
+        for value in normalized.values():
+            assert value == pytest.approx(1.0)
+
+    def test_normalize_min(self):
+        from lib.quality_eval import OverallQualityScore
+
+        score = OverallQualityScore(
+            research_depth=1,
+            source_quality=1,
+            analytical_rigor=1,
+            practical_value=1,
+            balance_objectivity=1,
+            writing_quality=1,
+        )
+        normalized = score.normalize()
+        for value in normalized.values():
+            assert value == pytest.approx(0.2)
+
+
+class TestGroundednessSchemas:
+    def test_claim_schema(self):
+        from lib.quality_eval import GroundednessClaim
+
+        claim = GroundednessClaim(claim="AI agents can self-improve", grounded=True)
+        assert claim.claim == "AI agents can self-improve"
+        assert claim.grounded is True
+
+    def test_groundedness_score(self):
+        from lib.quality_eval import GroundednessClaim, GroundednessScore
+
+        score = GroundednessScore(
+            claims=[
+                GroundednessClaim(claim="Claim 1", grounded=True),
+                GroundednessClaim(claim="Claim 2", grounded=False),
+                GroundednessClaim(claim="Claim 3", grounded=True),
+            ]
+        )
+        assert len(score.claims) == 3
+        assert score.score() == pytest.approx(2.0 / 3.0)
+
+    def test_groundedness_empty_claims(self):
+        from lib.quality_eval import GroundednessScore
+
+        score = GroundednessScore(claims=[])
+        assert score.score() == pytest.approx(0.0)
+
+
+class TestCompletenessScore:
+    def test_schema(self):
+        from lib.quality_eval import CompletenessScore
+
+        score = CompletenessScore(reasoning="Covers all aspects", score=4)
+        assert score.reasoning == "Covers all aspects"
+        assert score.score == 4
+
+    def test_normalize(self):
+        from lib.quality_eval import CompletenessScore
+
+        score = CompletenessScore(reasoning="Good", score=4)
+        assert score.normalize() == pytest.approx(0.8)
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestPrompts:
+    def test_overall_quality_prompt_has_placeholders(self):
+        from lib.quality_eval import OVERALL_QUALITY_PROMPT
+
+        assert "{today}" in OVERALL_QUALITY_PROMPT
+
+    def test_groundedness_prompt_has_placeholders(self):
+        from lib.quality_eval import GROUNDEDNESS_PROMPT
+
+        assert "{context}" in GROUNDEDNESS_PROMPT
+        assert "{report}" in GROUNDEDNESS_PROMPT
+
+    def test_completeness_prompt_has_placeholders(self):
+        from lib.quality_eval import COMPLETENESS_PROMPT
+
+        assert "{user_question}" in COMPLETENESS_PROMPT
+        assert "{report}" in COMPLETENESS_PROMPT
+
+    def test_format_overall_prompt(self):
+        from lib.quality_eval import format_overall_quality_input
+
+        result = format_overall_quality_input(
+            query="What are AI agent frameworks?",
+            report="# Report\nContent here.",
+        )
+        assert "What are AI agent frameworks?" in result
+        assert "Content here." in result
+
+    def test_format_groundedness_input(self):
+        from lib.quality_eval import format_groundedness_input
+
+        result = format_groundedness_input(
+            context="Source material here.",
+            report="# Report\nClaims here.",
+        )
+        assert "Source material here." in result
+        assert "Claims here." in result
+
+    def test_format_completeness_input(self):
+        from lib.quality_eval import format_completeness_input
+
+        result = format_completeness_input(
+            user_question="Compare X and Y",
+            report="# Report\nComparison here.",
+        )
+        assert "Compare X and Y" in result
+        assert "Comparison here." in result

--- a/tests/test_quality_eval.py
+++ b/tests/test_quality_eval.py
@@ -29,12 +29,17 @@ class TestOverallQualityScore:
         assert score.writing_quality == 3
 
     def test_has_six_fields(self):
+        import dataclasses
+
         from lib.quality_eval import OverallQualityScore
 
-        fields = OverallQualityScore.model_fields
-        assert len(fields) == 6
+        # Exclude internal helper fields (model_fields)
+        init_fields = [f for f in dataclasses.fields(OverallQualityScore) if f.init]
+        assert len(init_fields) == 6
 
     def test_field_names(self):
+        import dataclasses
+
         from lib.quality_eval import OverallQualityScore
 
         expected = {
@@ -45,7 +50,10 @@ class TestOverallQualityScore:
             "balance_objectivity",
             "writing_quality",
         }
-        assert set(OverallQualityScore.model_fields.keys()) == expected
+        init_fields = {
+            f.name for f in dataclasses.fields(OverallQualityScore) if f.init
+        }
+        assert init_fields == expected
 
     def test_normalize(self):
         from lib.quality_eval import OverallQualityScore


### PR DESCRIPTION
## Summary

- **Judge redesign**: Replace 8 search-pipeline dimensions with 6 report-quality dimensions (rubric_pass_rate 0.30, groundedness 0.20, relevant_yield 0.15, content_depth 0.15, source_diversity 0.10, quantity 0.10). Based on analysis of 5 industry projects (open_deep_research, node-deepresearch, gpt-researcher, swirl-search, MindSearch) — none use pipeline metrics as quality judge
- **Quality eval layer**: New `lib/quality_eval.py` with LLM-as-judge evaluation (6 quality dimensions + claim-level groundedness), adapted from LangChain open_deep_research
- **Evolution loop**: Block 6 now always runs, writes query-outcomes, patterns, rubric-history, and evolution diagnostics. E2E test harness rewritten to execute real evolution (LLM diagnosis of failed rubrics)

## Test plan

- [x] 551 unit tests pass (was 516 before, +35 new)
- [x] Judge v2 validated on 4 real sessions (ai-code-review, ai-product-dev-trends, smart-wearable, telescope-satellite)
- [x] Groundedness works for both HTML (`id="ref-N"` multi-line) and MD (`[N] Title — URL`) citation formats
- [ ] T1: Run same topic twice with evolution in between — verify rubric_pass_rate improves (post-merge)
- [ ] T2: Verify evolution generalizes across topics (post-merge)


🤖 Generated with [Claude Code](https://claude.com/claude-code)