### PR TITLE
feat: improve skill scores for Autosearch

### DIFF
--- a/skills/decompose-task/SKILL.md
+++ b/skills/decompose-task/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: decompose-task
-description: "Use when a research task is too broad or multi-dimensional for a single query strategy to cover well. Breaks complex questions into independent sub-questions."
+description: "Use when you need to break down a broad research task, multi-part question, or multi-dimensional topic into a structured research plan. Decomposes complex questions into independent sub-questions, assigns platforms and query budgets per sub-question, then merges and deduplicates results across all dimensions."
 ---
 
 # Purpose
 
-Some tasks are too broad for gene-query.md alone.
-"Find self-evolving AI agent frameworks" has at least 5 sub-dimensions: open-source projects, academic papers, commercial products, design patterns, and risks.
-A single query strategy covers 1-2 dimensions well and misses the rest.
-
-Decomposition turns one broad task into 3-5 focused sub-tasks, each with its own search strategy.
+Decomposition turns one broad task into 3-5 focused sub-tasks, each with its own search strategy, platform assignment, and query budget — covering dimensions that gene-query.md alone would miss.
 
 # When To Decompose
 
@@ -49,6 +45,21 @@ The knowledge map IS the decomposition input.
 3. For each dimension, write a focused sub-question
 4. Check independence: would the same search results answer two sub-questions? If yes, merge them.
 5. Assign platform preferences per sub-question (e.g., papers → arXiv + web, repos → GitHub, products → web)
+
+# Decomposition Output Template
+
+After decomposing, produce a table in this format before executing any searches:
+
+| # | Sub-question | Confidence | Platform(s) | Query Budget |
+|---|-------------|------------|-------------|--------------|
+| 1 | What open-source self-evolving agent frameworks exist? | LOW | GitHub, web | 3 |
+| 2 | What academic papers define the foundations of self-evolving agents? | MEDIUM | arXiv, own-knowledge | 2 |
+| 3 | What commercial products use self-evolving agent technology? | GAP | web | 3 |
+| 4 | What design patterns are used in self-evolving agent architectures? | HIGH | own-knowledge, web | 1 |
+| 5 | What are the known risks and limitations? | MEDIUM | papers, blogs | 2 |
+
+- **Confidence** comes from systematic-recall.md. HIGH = use own knowledge, skip search. MEDIUM = verify with 1-2 queries. LOW/GAP = full search.
+- **Query Budget** = number of queries allocated to this sub-question. Must sum to ≤ total research-mode budget.
 
 # Example
 

--- a/skills/gene-query/SKILL.md
+++ b/skills/gene-query/SKILL.md
@@ -1,164 +1,118 @@
 ---
 name: gene-query
-description: "Use when you need to expand a task into diverse search queries built from entity, pain_verb, object, symptom, and context genes."
+description: "Use when you need to expand a task into diverse search queries, perform query expansion, or generate search terms by combining entity, pain_verb, object, symptom, and context gene dimensions into targeted keyword research phrases."
 ---
+
+# Workflow
+
+1. **Extract genes** — Parse the task into six dimensions (entity, pain_verb, object, symptom, context, content_type).
+2. **Check knowledge map** — If systematic-recall.md produced a map, identify GAP/LOW/MEDIUM items to target.
+3. **Build gene pool** — Gather candidates from the task, winning history, query performance data, and your own judgment.
+4. **Generate queries** — Combine 2-3 dimensions per query following the mix ratio (60% gene combos, 15% LLM, 15% patterns, 10% proven winners).
+5. **Apply mandatory rules** — Ensure topic-specific required queries are included (academic, tool/product, freshness).
+6. **Adapt language** — Translate queries for Chinese-language channels; keep English for all others.
+7. **Deduplicate and cap** — Remove queries sharing 60%+ content words; stay within `max_total_queries`.
+8. **Output JSON** — Emit the final array for search_runner.py.
 
 # Model Recommendation
 
-Query generation is a structured expansion task. Use Haiku when possible — it generates diverse queries effectively at lower cost. When spawning an agent for query generation, set `model: "haiku"`.
-
-# Purpose
-
-Generate queries from five gene dimensions instead of improvising all search text from scratch.
-This restores a reusable query grammar that turns vague tasks into targeted searches.
+Use Haiku when possible — query generation is a structured expansion task that runs effectively at lower cost. Set `model: "haiku"` when spawning an agent.
 
 # The Six Dimensions
 
-- `entity` = WHO is involved
-- `pain_verb` = ACTION or failure mode
-- `object` = WHAT artifact, tool, concept, or target is involved
-- `symptom` = HOW the problem appears
-- `context` = WHERE or under what condition it happens
-- `content_type` = WHAT KIND of result you want (repo, paper, blog, tutorial, company, video, awesome-list, conference-workshop, company-product, comparison)
+- `entity` — WHO is involved
+- `pain_verb` — ACTION or failure mode
+- `object` — WHAT artifact, tool, concept, or target
+- `symptom` — HOW the problem appears
+- `context` — WHERE or under what condition
+- `content_type` — WHAT KIND of result (repo, paper, blog, tutorial, company, video, awesome-list, conference-workshop, company-product, comparison)
 
-Good queries usually need only 2 or 3 dimensions.
-Do not cram all six into every query.
+Good queries need only 2-3 dimensions. Do not cram all six into every query.
 
-Use `content_type` to steer queries toward underrepresented evidence.
-If the current bundle is heavy on repos and light on papers or blogs, generate queries that explicitly target the missing types.
-Examples: "self-evolving agent tutorial", "self-improving AI startup company", "self-evolving agent survey paper".
+Use `content_type` to steer toward underrepresented evidence. If the bundle is heavy on repos, target missing types explicitly (e.g., "self-evolving agent tutorial", "self-improving AI startup company").
 
-# Gap-Driven Query Generation (Claude-First Mode)
+# Gap-Driven Generation
 
 When systematic-recall.md has produced a knowledge map, generate queries from GAPS, not from the task text.
 
-For each GAP or LOW confidence item in the knowledge map:
-- Convert the gap into a specific search query
-- Target the platform most likely to fill that gap
-- Example: GAP in "commercial players" → query "self-evolving AI agent startup 2026" on web-ddgs
+- **GAP / LOW confidence** — Convert to a specific search query targeting the platform most likely to fill it.
+  Example: GAP in "commercial players" → `"self-evolving AI agent startup 2026"` on web-ddgs
+- **MEDIUM confidence** — Generate a verification query.
+  Example: MEDIUM on "STOP framework" → `"STOP self-taught optimizer latest"` on arxiv/web
+- **HIGH confidence** — Skip. Already covered by own-knowledge.
 
-For each MEDIUM confidence item:
-- Generate a verification query
-- Example: MEDIUM on "STOP framework" → query "STOP self-taught optimizer latest" on arxiv/web
+**Minimum query floor**: ALWAYS generate at least 4 queries regardless of confidence levels. Search adds timeliness (post-cutoff developments), specificity (concrete companies, repos, data points), and verification (HIGH confidence does not mean correct).
 
-Do NOT generate queries for HIGH confidence items — those are already in the evidence bundle from own-knowledge.
-
-**Minimum query floor**: regardless of confidence levels, ALWAYS generate at least 4 queries. Even when all dimensions are HIGH confidence, search adds value through:
-- **Timeliness**: Claude's knowledge has a cutoff date. Search finds developments after that date.
-- **Specificity**: Claude knows general patterns. Search finds specific companies, repos, articles, and data points.
-- **Verification**: HIGH confidence ≠ correct. Search verifies or corrects Claude's priors.
-
-If all dimensions are HIGH, generate 4 "freshness check" queries: the topic + "2026" + "latest" + "new" across the selected channels.
-
-This is the most efficient use of search budget: every query targets a known gap.
+If all dimensions are HIGH, generate 4 freshness-check queries: topic + "2026" / "latest" / "new" across selected channels.
 
 # Mandatory Query Rules
 
-Certain topic types MUST generate specific query types to avoid systematic coverage gaps.
-
 ## Academic/research topics
 
-- MUST generate at least 1 query with `content_type=conference-workshop` (e.g., "topic workshop NeurIPS ICML 2025")
-- MUST generate at least 1 query targeting `arxiv` or `semantic-scholar` channel
+- At least 1 query with `content_type=conference-workshop` (e.g., "topic workshop NeurIPS ICML 2025")
+- At least 1 query targeting `arxiv` or `semantic-scholar`
 
 ## Tool/product topics
 
-- MUST generate at least 1 query with `content_type=company-product` (e.g., "topic startup company funding")
-- MUST generate at least 1 query targeting `producthunt` or `crunchbase` channel
-- MUST generate at least 1 query targeting enterprise/non-GitHub alternatives (e.g., "GitLab Duo", "AWS CodeGuru", "Atlassian Bitbucket AI") when the topic involves developer tools. Because: AVO found r003/r006 consistently fail without enterprise platform queries.
-- MUST generate at least 1 query with `content_type=comparison` that includes "pricing" or "deployment" (e.g., "topic pricing free tier enterprise"). Because: AVO found r008 (pricing/deployment info) fails without explicit pricing queries.
+- At least 1 query with `content_type=company-product` (e.g., "topic startup company funding")
+- At least 1 query targeting `producthunt` or `crunchbase`
+- At least 1 query targeting enterprise/non-GitHub alternatives (e.g., "GitLab Duo", "AWS CodeGuru") when topic involves developer tools
+- At least 1 query with `content_type=comparison` including "pricing" or "deployment" (e.g., "topic pricing free tier enterprise")
 
 ## Any topic
 
-- MUST generate at least 1 query targeting `twitter` channel for recent announcements
-- MUST generate at least 1 Chinese-language query if any Chinese channel is selected
+- At least 1 query targeting `twitter` for recent announcements
+- At least 1 Chinese-language query if any Chinese channel is selected
+- At least 2 freshness queries with explicit year markers (e.g., "topic 2026") for Standard or Deep depth — target arxiv for one, web-ddgs for the other
 
-These rules exist because AVO analysis found that r005 (commercial companies) and r013 (conference info) consistently fail when these query types are missing.
-
-# Input Sources (General)
+# Input Sources
 
 Build the gene pool from four places:
 
-- The task itself: entities, artifacts, constraints, and pain language from the user or goal case
-- Winning history: patterns from `state/patterns.jsonl` (filter to `winning_pattern` and `platform_insight` types only — ignore `session_stats`, `outcome_boost`, and `winning_words` entries, which are statistical noise that does not inform query strategy) and proven queries from `state/outcomes.jsonl`
-- Query performance data: read `state/query-outcomes.jsonl` if it exists. Group by query text or semantic family (queries sharing 2+ content words). Boost: include queries with `relevant_rate >= 0.7` AND `results_count >= 3` — these are proven performers. Suppress: do not generate queries that closely match patterns with `relevant_rate <= 0.2` OR `results_count == 0` for the same `topic_type` — these are proven failures.
-- Your own judgment: missing synonyms, domain terms, and alternate framings not yet present in state
+1. **Task** — entities, artifacts, constraints, and pain language from the user or goal case
+2. **Winning history** — patterns from `state/patterns.jsonl` (filter to `winning_pattern` and `platform_insight` types only) and proven queries from `state/outcomes.jsonl`
+3. **Query performance** — from `state/query-outcomes.jsonl`. Boost queries with `relevant_rate >= 0.7` AND `results_count >= 3`. Suppress queries matching patterns with `relevant_rate <= 0.2` OR `results_count == 0` for the same `topic_type`.
+4. **Your judgment** — missing synonyms, domain terms, and alternate framings not yet in state
 
 # Mix Ratio
 
-Generate candidate queries with this mix:
-
+- 60% gene combinations
 - 15% LLM suggestions
 - 15% winning patterns (from state/patterns.jsonl)
-- 10% high-performing queries (from state/query-outcomes.jsonl, boost proven winners)
-- 60% gene combinations
+- 10% high-performing queries (from state/query-outcomes.jsonl)
 
-Keep the ratio in spirit, not as rigid bookkeeping.
-If one source is exhausted, backfill from the others without collapsing into a single style.
+Keep the ratio in spirit, not as rigid bookkeeping. Backfill from other sources if one is exhausted.
 
 # Combination Rule
 
 For each gene-combination query:
 
-- pick 2 or 3 dimensions
-- pick exactly 1 value from each chosen dimension
-- join them into a terse search phrase
+- Pick 2 or 3 dimensions
+- Pick exactly 1 value from each chosen dimension
+- Join into a terse search phrase
 
-Examples of the shape:
-
-- `entity + object`
-- `pain_verb + object`
-- `entity + symptom + context`
-- `pain_verb + object + context`
-
-Prefer specific combinations that narrow meaning without becoming long natural-language sentences.
+Example shapes: `entity + object`, `pain_verb + object`, `entity + symptom + context`, `pain_verb + object + context`.
 
 # Query Construction Heuristics
 
-Keep one anchor term that strongly binds the topic.
-Add one discriminator that changes what results appear.
-Add a third term only when it meaningfully sharpens retrieval.
+- One **anchor term** binding the topic + one **discriminator** changing what results appear. Add a third term only when it meaningfully sharpens retrieval.
+- Target **3-5 words** for most channels. Academic channels (arxiv, semantic-scholar, google-scholar) may use up to 7. Split overlength queries into two shorter ones.
+- Prefer concrete tokens over generic prose, symptoms over emotional adjectives, observable failures over abstract aspirations.
+- Use winning query patterns from state when they clearly transfer. Keep seed queries from the task or config even if not gene-generated.
 
-Target query length: 3-5 words for most channels. Academic channels (arxiv, semantic-scholar, google-scholar) may use up to 7 words when specificity demands it. If a gene combination produces a query longer than the limit, split it into two shorter queries rather than keeping one long one. Short, precise queries consistently outperform long natural-language phrases on search APIs (SE-Search found 33.8% improvement with atomic queries).
+# Diversity and Dedup
 
-Prefer concrete tokens over generic prose.
-Prefer symptoms over emotional adjectives.
-Prefer observable failures over abstract aspirations.
+Vary the dimension mix: some entity-led, some pain-led, some object-led, some context-led. Avoid a pool where every query starts from the same noun phrase.
 
-Use winning query patterns from state when they clearly transfer.
-Boost queries whose words or families have proven outcomes.
-Keep seed queries from the task or config in the set even if they are not gene-generated.
+Deduplicate semantically, not only by exact string. Final dedup pass: if two queries share 60%+ content words, keep the more specific one. The final set MUST NOT exceed `max_total_queries` from config.json.
 
-# Diversity Rules
+# Freshness and Time
 
-Do not emit many trivial variations of the same query.
-Vary the dimension mix across the set:
-
-- some entity-led
-- some pain-led
-- some object-led
-- some context-led
-
-Avoid a pool where every query starts from the same noun phrase.
-Deduplicate semantically, not only by exact string match.
-After generating all candidate queries, run a final dedup pass: if two queries share 60% or more of their content words, keep the more specific one and drop the other.
-The final query set after dedup MUST NOT exceed `max_total_queries` from config.json.
-
-# Freshness And Time
-
-Do not hard-cap all generated queries by recency.
-Add time qualifiers only when the task explicitly needs freshness or the prior round showed stale retrieval.
-
-## Mandatory Freshness Queries (Standard and Deep depth)
-
-For Standard or Deep depth sessions, MUST generate at least 2 queries with explicit year markers targeting the current year (e.g., "topic 2026", "topic latest 2026").
-Reason: Freshness dimension scores 0.47 on average without year-targeted queries — the judge treats undated results as old. Year markers bias retrieval toward recent papers and repos without requiring a paid API date filter.
-Placement: target the arxiv channel for one freshness query and web-ddgs for the other.
-Example: {"channel": "arxiv", "query": "self-evolving search 2026", "max_results": 10}
+Do not hard-cap all queries by recency. Add time qualifiers only when the task explicitly needs freshness or the prior round showed stale retrieval.
 
 # Output Format
 
-Output a JSON array compatible with search_runner.py:
+JSON array compatible with search_runner.py:
 
 ```json
 [
@@ -168,7 +122,7 @@ Output a JSON array compatible with search_runner.py:
 ]
 ```
 
-Each entry needs: `channel` (from select-channels output), `query` (the search text), `max_results` (optional, default 10).
+Each entry needs: `channel` (from select-channels output), `query` (search text), `max_results` (optional, default 10).
 
 # Language Adaptation Rules
 

--- a/skills/rerank-evidence/SKILL.md
+++ b/skills/rerank-evidence/SKILL.md
@@ -1,77 +1,75 @@
 ---
 name: rerank-evidence
-description: "Use after LLM evaluation to rank relevant results by importance and select the top-K for synthesis. Orders evidence by task relevance, not just binary relevant/not-relevant."
+description: "Prioritize results, rank findings, or select the most relevant evidence after evaluation. Use when you need to filter top results from a scored set, order search hits by importance, or pick the best sources for a final answer."
 ---
 
 # Purpose
 
-llm-evaluate.md produces a binary filter: relevant or not.
-But among relevant results, some are far more important than others.
-A foundational paper is more important than a blog post summarizing it.
-A 10K-star framework is more important than a 50-star toy project.
-
-Reranking orders the relevant results so synthesis focuses on the best evidence.
+After llm-evaluate.md marks results as relevant or not, rerank the relevant set so the strongest evidence rises to the top. This ensures synthesis focuses on primary sources and high-quality findings rather than treating all relevant results equally.
 
 # When To Use
 
-Use after llm-evaluate.md has set `metadata.llm_relevant` on all results.
-Use before assemble-context.md selects the final evidence bundle.
+- User asks to "prioritize results", "rank findings", "filter top results", or "select most relevant"
+- After llm-evaluate.md has set `metadata.llm_relevant` on all results
+- Before assemble-context.md selects the final evidence bundle
+- When a large relevant set needs to be narrowed to the top-K items for synthesis
 
 # Ranking Criteria
 
-Rank by these factors, in roughly this priority:
+Score each result on six weighted criteria. Each criterion is scored 0-10.
 
-## 1. Task Relevance (highest weight)
-How directly does this result address the core question?
-- Primary source (original framework, paper, product) > Secondary source (blog summary, news article)
-- Specific to the topic > Generally related
-- Answers a gap in current evidence > Duplicates existing coverage
+| # | Criterion | Weight | What to assess |
+|---|-----------|--------|----------------|
+| 1 | **Task Relevance** | 30% | Primary source vs. secondary; topic-specific vs. tangential; fills a gap vs. duplicates coverage |
+| 2 | **Evidence Quality** | 25% | Peer-reviewed > preprint > blog; official docs > third-party tutorial; full content > snippet-only; verifiable claims > opinion |
+| 3 | **Source Authority** | 20% | Known research lab/company > unknown author; high-star repo > low-star; top conference (NeurIPS, ICLR, ICML) > workshop > arXiv-only |
+| 4 | **Freshness** | 10% | More recent is better in fast-moving fields. Foundational works (STaR, Reflexion, Voyager) keep high scores regardless of age |
+| 5 | **Diversity Bonus** | 10% | Underrepresented platform or content type gets a boost. If the bundle is 80% GitHub repos, a paper or blog ranks higher than another repo |
+| 6 | **Cross-Source Convergence** | 5% | Appears on multiple platforms (`also_on` non-empty). Confirmed across Reddit, HN, and Twitter signals a canonical finding |
 
-## 2. Evidence Quality
-How trustworthy and substantive is this result?
-- Peer-reviewed paper > preprint > blog post
-- Official documentation > third-party tutorial
-- Result with fetched full content > snippet-only result
-- Result with verifiable claims > opinion piece
+**Composite score formula:**
 
-## 3. Source Authority
-How credible is the source?
-- Well-known research lab or company > unknown author
-- High-star GitHub repo > low-star repo
-- Conference paper (NeurIPS, ICLR, ICML) > workshop paper > arXiv-only
-- Domain expert blog > generic tech blog
+```
+score = (relevance * 0.30) + (quality * 0.25) + (authority * 0.20)
+      + (freshness * 0.10) + (diversity * 0.10) + (convergence * 0.05)
+```
 
-## 4. Freshness (when relevant)
-More recent is better when the field is evolving quickly.
-But foundational works (STaR, Reflexion, Voyager) should rank high regardless of age.
+# Workflow
 
-## 5. Diversity Bonus
-A result from an underrepresented platform or content type gets a boost.
-If the bundle is 80% GitHub repos, a blog post or paper should rank higher than another repo.
+1. **Load**: Read all results where `metadata.llm_relevant = true`
+2. **Score**: For each result, assign 0-10 on each of the six criteria and compute the composite score
+3. **Rank**: Sort by composite score descending. Assign `metadata.rank` (1 = most important)
+4. **Validate**: Check the top 5 — confirm no duplicates, at least two distinct source types, and that the top result is a primary source. If validation fails, adjust scores and re-sort
+5. **Output**: Write ranked results for assemble-context.md to consume
 
-## 6. Cross-Source Convergence
-A result that appears across multiple platforms (`also_on` field non-empty) is stronger evidence than a single-source finding. Treat convergent items one tier higher than equivalent single-source items. The same story confirmed by Reddit, HN, and Twitter is likely canonical and should rank near the top.
+For large result sets (>50 relevant results), rank in batches of 20. Compare top results across batches to produce a final ranking.
 
-# How To Rank
+# Example
 
-You are Claude. You can read all the results and judge their relative importance.
-No external embedding API is needed.
+**Input** (3 relevant JSONL results):
 
-Process:
-1. Read all results where `metadata.llm_relevant = true`
-2. For each result, mentally score it on the 5 criteria above
-3. Sort by overall importance
-4. Output the ranked list for assemble-context.md to use
+```jsonl
+{"title": "Voyager: An Open-Ended Embodied Agent", "url": "https://arxiv.org/abs/2305.16291", "source": "arxiv", "metadata": {"llm_relevant": true, "also_on": ["github", "hackernews"]}}
+{"title": "Summary of Voyager paper", "url": "https://blog.example.com/voyager-summary", "source": "blog", "metadata": {"llm_relevant": true, "also_on": []}}
+{"title": "voyager-minecraft GitHub repo", "url": "https://github.com/MineDojo/Voyager", "source": "github", "metadata": {"llm_relevant": true, "stars": 5200, "also_on": ["arxiv"]}}
+```
 
-For large result sets (>50 relevant results), rank in batches of 20.
-Compare top results across batches to produce a final ranking.
+**Scoring:**
 
-# Output
+| Result | Relevance | Quality | Authority | Freshness | Diversity | Convergence | Composite |
+|--------|-----------|---------|-----------|-----------|-----------|-------------|-----------|
+| Voyager paper (arxiv) | 10 | 9 | 9 | 8 | 7 | 10 | **9.15** |
+| Voyager repo (github) | 9 | 7 | 8 | 8 | 5 | 8 | **7.70** |
+| Blog summary | 6 | 4 | 3 | 7 | 8 | 0 | **4.90** |
 
-Add `metadata.rank` (integer, 1 = most important) to each relevant result.
-Or simply reorder the evidence JSONL file by importance.
+**Output** (ranked):
+
+```jsonl
+{"title": "Voyager: An Open-Ended Embodied Agent", "url": "https://arxiv.org/abs/2305.16291", "source": "arxiv", "metadata": {"llm_relevant": true, "also_on": ["github", "hackernews"], "rank": 1, "rerank_score": 9.15}}
+{"title": "voyager-minecraft GitHub repo", "url": "https://github.com/MineDojo/Voyager", "source": "github", "metadata": {"llm_relevant": true, "stars": 5200, "also_on": ["arxiv"], "rank": 2, "rerank_score": 7.70}}
+{"title": "Summary of Voyager paper", "url": "https://blog.example.com/voyager-summary", "source": "blog", "metadata": {"llm_relevant": true, "also_on": [], "rank": 3, "rerank_score": 4.90}}
+```
 
 # Quality Bar
 
-A good ranking puts foundational works, canonical tools, and primary sources at the top.
-A bad ranking is dominated by secondary sources, duplicative content, or popularity-biased ordering.
+A good ranking puts foundational works, canonical tools, and primary sources at the top. The top 5 should include at least two distinct source types and no duplicates. A bad ranking is dominated by secondary sources, duplicative content, or popularity-biased ordering.

--- a/skills/research-mode/SKILL.md
+++ b/skills/research-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-mode
-description: "Use at the start of a task to choose speed, balanced, or deep research depth from the user's urgency and complexity."
+description: "Use when the user asks for a quick lookup, a brief answer, a deep dive, thorough research, or a comprehensive analysis to select speed, balanced, or deep search depth before querying. Use when you need to decide how many search rounds and queries to budget for a research task."
 ---
 
 # Purpose
@@ -40,6 +40,17 @@ Choose `deep` when:
 - earlier rounds plateaued but the problem remains unsolved
 
 If the user gives no clear signal, default to `balanced`.
+
+# Examples
+
+**"What year was Python 3.10 released?"**
+→ `speed` — narrow factual question, one query is enough, answer in seconds.
+
+**"Compare the top three open-source vector databases for a RAG pipeline."**
+→ `balanced` — bounded comparison across a few products, needs iteration and follow-up but scope is clear.
+
+**"Give me a comprehensive survey of federated learning techniques, their trade-offs, and which frameworks implement them."**
+→ `deep` — multi-dimensional topic, high ambiguity, the user explicitly wants thoroughness, and the answer will inform an architecture decision.
 
 # Mode Behavior
 

--- a/skills/synthesize-knowledge/SKILL.md
+++ b/skills/synthesize-knowledge/SKILL.md
@@ -1,251 +1,134 @@
 ---
 name: synthesize-knowledge
-description: "Use before delivery to turn collected evidence and prior knowledge into conceptual frameworks, design patterns, risks, and decision-relevant understanding rather than a list of links."
+description: "Use when you need to synthesize research findings, combine search results into a structured report, build a comparison framework, or turn raw evidence into decision-ready analysis. Triggers: 'synthesize', 'analyze findings', 'compare options', 'build a report', 'summarize research', 'what does this mean'."
 ---
 
-# Purpose
+# Workflow
 
-After collecting results and using your own knowledge, organize the field by concept, not by platform.
-The output should help the user understand the landscape and make decisions.
-
-This skill exists to produce the kind of depth that raw search results alone do not provide.
+1. **Collect** — Gather search results, fetched full-text, and relevant prior knowledge
+2. **Deduplicate** — Resolve overlap across sources; distill shared patterns, keep only meaningful disagreements
+3. **Organize** — Choose the axis that best supports the user's decision (mechanism, architecture, maturity, tradeoff, risk, adoption)
+4. **Analyze** — Produce at least 3 of the 5 analysis types (see Analysis Requirements below)
+5. **Cite** — Lock all URLs to a numbered reference list compiled from search results only
+6. **Structure** — Write the delivery using typed blocks (see Delivery Structure)
+7. **Verify** — Run the citation completeness check and named-entity coverage check
+8. **Evaluate** — Run evaluate-delivery.md to confirm quality bar
 
 # Core Principle
 
-Do not deliver a platform-by-platform dump.
-Reorganize the material into the structure that best explains the field.
+Organize by concept, not by platform. Do not deliver a platform-by-platform dump. Reorganize material into the structure that best explains the field: categorization frameworks, design patterns, risk analysis, landscape maps, or gap analysis.
 
-Possible synthesis outputs include:
-
-- categorization frameworks
-- evolution dimensions
-- design pattern identification
-- risk and limitation analysis
-- landscape maps of who is doing what
-- gap analysis of what is still missing or underexplored
-
-Choose the structures that make the topic legible.
-
-# What To Combine
-
-Combine:
-
-- high-quality external results
-- fetched full-text material when available
-- extracted reusable knowledge
-- your own prior knowledge about the domain
-
-Synthesis should resolve overlap, not preserve it.
-If five sources say the same thing, distill the shared pattern and note meaningful disagreement only where it matters.
-
-# Organizing Principles
-
-Organize by whichever axis best supports understanding, such as:
-
-- mechanism
-- architecture
-- maturity
-- tradeoff
-- workflow role
-- risk profile
-- adoption pattern
-
-The right structure depends on the user's decision, not on the retrieval tools used.
+The right structure depends on the user's decision context, not on how results were retrieved.
 
 # Decision Support
 
-Every synthesis should move beyond "what exists" toward "what this means."
-Explain:
-
-- which approaches dominate
-- where the real differentiation lies
-- what risks or constraints recur
-- what is missing from the market or literature
-- which paths look promising versus fragile
-
-This is the difference between a search log and a report.
-
-# API Catalog Topic Requirements
-
-When the topic is primarily an **API / data source catalog** (identified by rubrics that ask to "compare APIs on access model", "distinguish between X and Y type", or "use cases a developer can build"), the delivery MUST include all three of the following sections, regardless of depth level:
-
-1. **Access model comparison table** — compare at least 5 APIs/platforms on: access model (free/registration/paid), data freshness (real-time/near-real-time/archival), and primary data type. Do not omit this table; it directly addresses "compare at least 3 APIs" rubrics.
-
-2. **Domain distinction** — a dedicated paragraph or section that explicitly distinguishes the major API categories by purpose (e.g., space telescope archives vs. Earth observation/remote sensing vs. satellite tracking), explains when each is appropriate, and names at least one concrete developer scenario per category.
-
-3. **Developer use cases** — a concrete list of 2-5 applications a developer or researcher could build with these APIs, named specifically (e.g., "transient alert dashboard", "satellite pass tracker", "exoplanet parameter browser"). This is MANDATORY — do not omit use cases even when the task spec does not ask for them explicitly.
-
-Why: rubrics r016, r017, r018 failed in the telescope-satellite-api session (2026-04-04) because synthesis produced an API catalog without a comparison table, domain distinction section, or use cases. These three items are the minimum analytical layer for any API catalog topic.
+Every synthesis must move beyond "what exists" toward "what this means":
+- Which approaches dominate and why
+- Where real differentiation lies
+- What risks or constraints recur
+- What is missing from the market or literature
+- Which paths are promising versus fragile
 
 # Analysis Requirements
 
-Beyond organizing what was found, synthesis must produce original analysis.
-Every delivery should contain at least three of these five analysis types:
+Every delivery must contain at least 3 of these 5 analysis types:
 
-## 1. Comparison
-
-Compare at least 3 approaches, tools, or methods head-to-head.
-State concrete differences, not just "A is different from B."
-Include at least one tradeoff for each comparison (what you gain vs what you lose).
-
-## 2. Trend
-
-Identify at least one directional shift in the field.
-Explain what changed, when, and why.
-Use evidence from multiple sources to support the trend claim.
-
-## 3. Causal Reasoning
-
-For at least one major pattern or outcome, explain WHY it happened.
-Go beyond correlation to mechanism.
-If the cause is uncertain, say so explicitly rather than implying certainty.
-
-## 4. Recommendation
-
-For at least one decision the user might face, state which option to choose and why.
-Ground the recommendation in evidence from the search, not personal preference.
-Acknowledge when the right answer depends on context and explain the deciding factors.
-
-## 5. Controversy or Open Problem
-
-Identify at least one area where experts disagree or where the problem is unsolved.
-Present the strongest argument on each side.
-Do not resolve the disagreement artificially — state what is genuinely uncertain.
+1. **Comparison** — Compare 3+ approaches head-to-head with concrete tradeoffs (what you gain vs. lose)
+2. **Trend** — Identify a directional shift: what changed, when, why, with multi-source evidence
+3. **Causal reasoning** — Explain WHY a major pattern occurred; state uncertainty explicitly when cause is unclear
+4. **Recommendation** — For a user decision, state which option to choose and why, grounded in evidence
+5. **Controversy / open problem** — Where experts disagree or the problem is unsolved; present strongest arguments per side without artificial resolution
 
 # Delivery Structure
 
-Organize the delivery as typed blocks, not one monolithic document:
+Organize output as typed blocks, each self-contained:
 
-1. **Executive framework** — the conceptual model (axes, dimensions, taxonomy)
-2. **Evidence tables** — organized by concept, with adoption signals (stars, citations, venue). When claims include `evidence` or `data_points` fields, use the exact quotes and numbers in the table — do not paraphrase. These come from BM25-filtered full-page content and are more specific than snippet-based claims.
-3. **Design patterns** — recurring approaches identified across multiple projects
-4. **Risk analysis** — known limitations, failure modes, open problems
-5. **Gap declaration** — what the search did NOT find, what remains uncertain
-6. **Resource index** — curated entry points for the user to explore further
+1. **Executive framework** — Conceptual model (axes, dimensions, taxonomy)
+2. **Evidence tables** — Organized by concept with adoption signals (stars, citations, venue). Use exact quotes and numbers from `evidence`/`data_points` fields
+3. **Design patterns** — Recurring approaches across multiple projects
+4. **Risk analysis** — Limitations, failure modes, open problems
+5. **Gap declaration** — What the search did NOT find; what remains uncertain
+6. **Resource index** — Curated entry points for further exploration
 
-Each block should be self-contained and independently valuable.
+## Example: Executive Framework for a CI/CD Tools Synthesis
+
+```markdown
+## Executive Framework
+
+CI/CD tools organize along three axes:
+
+| Axis | Spectrum | Examples |
+|------|----------|----------|
+| Hosting model | Self-hosted ↔ Fully managed | Jenkins ↔ GitHub Actions |
+| Config paradigm | Declarative YAML ↔ Programmatic SDK | CircleCI ↔ Dagger |
+| Ecosystem lock-in | Vendor-neutral ↔ Platform-native | Tekton ↔ GitLab CI |
+
+**Key finding**: The market is converging on declarative + managed,
+but teams with complex build graphs increasingly adopt SDK-based
+tools (Dagger, Earthly) to escape YAML complexity [1][3].
+
+**Trend**: Since 2024, "CI as code" (programmatic pipelines) grew
+from niche to mainstream — Dagger adoption tripled [2].
+
+**Recommendation**: For teams under 50 engineers on GitHub, start
+with GitHub Actions. Switch to Dagger when YAML configs exceed
+~500 lines or cross-repo orchestration is needed [4][5].
+```
+
+# Content Depth (auto-determined)
+
+- **Quick** — 1 page max. Key insight, 3-5 bullets, one comparison table (max 5 rows), 2-3 next steps.
+- **Standard** (default) — Full delivery structure with all 5 analysis types.
+- **Deep** — Full report plus appendices: complete evidence table, gap queries, methodology notes.
+
+# Delivery Format (user-selected)
+
+- **Markdown** (default) — Write to `delivery/{date}-{topic-slug}.md`. Standard markdown, `## Sources` at end.
+- **Rich HTML** — Write to `delivery/{date}-{topic-slug}.html`. Self-contained with embedded CSS, styled tables, Mermaid.js diagrams, floating TOC, collapsible evidence sections.
+- **Slides** — Write to `delivery/{date}-{topic-slug}-slides.html`. reveal.js from CDN. One slide per finding, speaker notes with evidence, title + takeaways + sources slides.
+
+# API Catalog Requirements
+
+When the topic is an API/data-source catalog, always include:
+
+1. **Access model table** — Compare 5+ APIs on: access model (free/registration/paid), data freshness, primary data type
+2. **Domain distinction** — Distinguish major API categories by purpose with one developer scenario per category
+3. **Developer use cases** — 2-5 concrete applications named specifically (e.g., "transient alert dashboard", "satellite pass tracker")
 
 # Citation Rules
 
-## Mandatory inline citations
+Every factual claim must have an inline citation from search results.
 
-Every factual claim, data point, project description, or paper reference MUST include an inline citation linking to a search result URL:
+**Format by source type:**
 - Tools/repos: `[Project Name](url) — description`
 - Papers: `[Paper Title](url) (Venue Year)`
-- Articles/posts: `[Author/Org](url)`
+- Articles: `[Author/Org](url)`
 
-## URL source restriction
+**Two-stage citation lock:**
+1. Before writing, compile a numbered reference list from search results: `[1] Name — url`
+2. During synthesis, cite only by number: `[1]`, `[2]`
+3. Append full list as `## Sources`
 
-URLs MUST come from the search results collected during this session. Do NOT use URLs recalled from training data — they may be outdated, broken, or fabricated.
+**URL restriction:** URLs must come from this session's search results. Mark training-data context as `[background knowledge]` — never give it a fake URL.
 
-If your training knowledge adds context that was not found in search results, mark it explicitly:
-- `[background knowledge]` — for facts from training data without a search result URL
-- Never present background knowledge as if it has a source URL
+**Completeness check** — After writing, verify: every tool/paper/data-point has a `[N]` citation, no URL exists outside the reference list, background knowledge is marked.
 
-## Two-stage citation lock
+# Named Entity Coverage
 
-Before writing the final report, first compile a numbered reference list from all search results:
-
-```
-[1] Project Name — https://url1
-[2] Paper Title — https://url2
-...
-```
-
-During synthesis, cite ONLY by these numbers: `[1]`, `[2]`. This prevents URL fabrication.
-
-Append the full reference list as `## Sources` at the end of every delivery.
-
-## Citation completeness check
-
-After writing the report, verify:
-1. Every project/tool mentioned has a `[N]` citation
-2. Every paper mentioned has a `[N]` citation
-3. Every specific data point (star count, funding amount, benchmark score) has a `[N]` citation
-4. No URL appears that is not in the numbered reference list
-5. Background knowledge items are marked `[background knowledge]`, not cited with fake URLs
-
-If any item fails this check, fix it before delivering.
-
-# Named Entity Coverage Rule
-
-When the task spec, rubric set, or user query names specific competitors, companies, products, or people by name, every named entity MUST receive explicit coverage in the delivery — at minimum a summary paragraph, even when data is sparse.
-
-Do NOT silently omit a named entity because:
-- it is declining (e.g., Fitbit post-Google acquisition)
-- its data is ambiguous
-- it seems less important than others
-- it was listed as a knowledge gap elsewhere
-
-If data is sparse, write a brief paragraph explaining current status and knowledge limits. Move it to the knowledge gaps section with a summary note in the competitive section.
-
-Why: rubric r002 failure (2026-04-04) — Fitbit/Google was in the task spec's competitor list but received no competitive coverage in the delivery. A named entity check at synthesis time prevents this.
+When the query names specific competitors, products, or people, every named entity MUST appear in the delivery. If data is sparse, write a brief status paragraph and note knowledge limits. Never silently omit a named entity.
 
 # Failure Modes
 
 Avoid:
-
 - URL lists with light commentary
-- one subsection per platform just because that mirrors search collection
-- shallow "pros and cons" tables with no framework
-- repeating source snippets without abstraction
-- claims without source attribution
-- mixing own-knowledge with search results without marking the distinction
+- One subsection per platform mirroring search order
+- Shallow pros/cons tables without a framework
+- Source snippets repeated without abstraction
+- Claims without attribution
+- Mixing prior knowledge with search results without marking the distinction
 
-If the user could have gotten the same output from scrolling search results, the synthesis failed.
-
-# Content Structure (auto-determined by Depth)
-
-The content structure is chosen automatically based on the user's Depth selection. Do not ask the user to pick a content structure.
-
-## Quick → Executive Summary
-- 1 page maximum
-- Lead with the key insight or recommendation
-- 3-5 bullet points covering: what exists, what matters, what to do
-- One comparison table (max 5 rows)
-- End with "Next steps" (2-3 actionable items)
-
-## Standard → Full Report [default]
-- Use the standard Delivery Structure from this skill (executive framework, evidence tables, design patterns, risk analysis, gap declaration, resource index)
-- Include all five Analysis Requirements (comparison, trend, causal reasoning, recommendation, controversy)
-
-## Deep → Full Report + Evidence Appendix
-- Everything in Full Report, plus:
-- Appendix A: complete evidence table (every search result with score, source, date)
-- Appendix B: gap declaration with specific queries that returned zero results
-- Appendix C: methodology notes (channels used, rounds, patterns applied)
-
-# Delivery Format (user-selected)
-
-The user chooses the delivery medium. Write the output in the chosen format.
-
-## Markdown Report (.md) [default]
-- Write to `delivery/{date}-{topic-slug}.md`
-- Standard markdown with tables, headers, bullet lists
-- Citation reference list at the end as `## Sources`
-- This is the default when the user does not specify
-
-## Rich HTML Report
-- Write to `delivery/{date}-{topic-slug}.html`
-- Single self-contained HTML file with embedded CSS (no external dependencies)
-- Use a clean, professional stylesheet: max-width 900px, system font stack, good typography
-- Render comparison tables as styled HTML tables with alternating row colors
-- Use Mermaid.js (CDN) for framework/relationship diagrams where appropriate
-- Add `<details>` collapsible sections for evidence and methodology
-- Include a floating table of contents
-- Citation links should be clickable anchors
-
-## Presentation Slides
-- Write to `delivery/{date}-{topic-slug}-slides.html`
-- Single self-contained HTML file using reveal.js from CDN
-- One slide per major finding or section
-- Use tables and key quotes as slide content (not walls of text)
-- Add speaker notes (`<aside class="notes">`) with detailed evidence for each slide
-- Include a title slide with topic, date, and source count
-- End with a "Key Takeaways" slide and a "Sources" slide
+If the user could get the same output by scrolling search results, the synthesis failed.
 
 # Quality Bar
 
-A good synthesis gives the user conceptual compression.
-They should leave with a clearer model of the space, not just more tabs to open.
-Run evaluate-delivery.md after synthesis to verify the output meets the 4-dimension quality check.
+A good synthesis gives the user conceptual compression. They should leave with a clearer model of the space, not just more tabs to open. Run evaluate-delivery.md after synthesis to verify the output meets the 4-dimension quality check.


### PR DESCRIPTION
Hey @0xmariowu 👋

34 dedicated search connectors including 12 Chinese-language platforms that no other research tool covers, with a self-evolution loop that actually prevents gaming by keeping judge.py fixed. The architecture of learning which channels work for which topics while never letting the evaluator drift is a really sharp design decision. We tightened up several of the skill files across the pipeline and channel definitions

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="910" alt="score_card" src="https://github.com/user-attachments/assets/f708969a-02ad-4b22-997e-989c4baa0479" />


<details>
<summary>Changes made</summary>

**synthesize-knowledge** (+39%)
- Rewrote description with natural trigger terms ("synthesize", "analyze findings", "compare options", "build a report")
- Added explicit 8-step workflow sequence at the top
- Added concrete example showing an executive framework for CI/CD tools
- Cut ~47% of content (252 → 135 lines) by removing internal postmortem details, session dates, and redundant rationale
- Compacted delivery format specs and content depth tiers

**rerank-evidence** (+24%)
- Replaced jargon-heavy description with user-facing terms ("prioritize results", "rank findings", "filter top results")
- Added weighted scoring formula: `score = (relevance * 0.30) + (quality * 0.25) + (authority * 0.20) + (freshness * 0.10) + (diversity * 0.10) + (convergence * 0.05)`
- Added concrete worked example with 3 sample JSONL inputs, scoring breakdown, and ranked output
- Added validation step checking for duplicates, source diversity, and primary-source dominance

**research-mode** (+18%)
- Rewrote description with natural trigger terms ("quick lookup", "deep dive", "thorough research", "comprehensive analysis")
- Added worked examples section: 3 sample user requests mapped to speed/balanced/deep modes

**gene-query** (+13%)
- Added natural trigger terms ("query expansion", "generate search terms", "keyword research")
- Added explicit 8-step numbered workflow at the top
- Removed all internal rationale sentences ("Because: AVO found...", "SE-Search found 33.8%...")
- Trimmed from 186 → 140 lines while preserving all actionable content

**decompose-task** (+7%)
- Expanded description with trigger terms ("break down", "multi-part question", "research plan") and post-decomposition actions
- Trimmed Purpose section to a single line
- Added structured decomposition output template table (sub-question, confidence, platform, query budget)

</details>

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏