### PR TITLE
docs: spike 2 result — trafilatura alone insufficient for Chinese sites

### DIFF
--- a/docs/spikes/spike-2-trafilatura.md
+++ b/docs/spikes/spike-2-trafilatura.md
@@ -28,23 +28,43 @@ Playwright is explicitly deferred. Per plan § 8 TBD-C, the default chain stays 
 | 掘金 | Public `juejin.cn/post/<id>` posts from frontend, backend, Python, AI, and computing-history searches; mixed explainers, notes, and hands-on walkthroughs. |
 | 微信公众号 | Canonical `mp.weixin.qq.com` article URLs copied from public reshare/archive pages for tech accounts such as 腾讯技术工程, 阿里技术, AI前线 / InfoQ, and 阮一峰 related reposts. |
 
-### Result Table
+### Result Table (run 2026-04-17, local)
 
-| site | pass_rate | top_fail_reason | verdict (pass/fail/needs-cleaner) |
-|---|---|---|---|
-| zhihu |  |  |  |
-| csdn |  |  |  |
-| juejin |  |  |  |
-| wechat |  |  |  |
+| site | pass_rate | top fail pattern | avg html size | verdict |
+|---|---|---|---|---|
+| zhihu | 0/30 (0.0%) | 26× `403/http_error`, 4× `200/antibot` | 25.8 KB | **FAIL** — needs cookie + UA spoof + Playwright fallback |
+| csdn | 0/30 (0.0%) | 30× `521/http_error` (Cloudflare JS challenge) | 2.1 KB | **FAIL** — Cloudflare wall, Playwright/Camoufox required |
+| juejin | 0/30 (0.0%) | 27× `200/antibot`, 3× `404/http_error` | 139.3 KB | **FAIL** — SPA, needs Playwright for JS rendering |
+| wechat | 22/30 (73.3%) | 7× `200/antibot`, 1× `200/short_extract` | 2.2 MB | **MARGINAL** — below 90% bar, mostly works with httpx |
 
-### Remediation Map
+### Verdict
+
+Plan § 6 bar (`> 90%` per site) is **not met** on any site. `httpx + trafilatura` alone is insufficient for Chinese extraction.
+
+### Implications for plan v2.3
+
+1. **§ 8 TBD-C needs revision**: "Playwright 非主力" is wrong for Chinese sites. For zhihu / csdn / juejin, Playwright (or Camoufox) must be the primary fetch path, not a fallback.
+2. **§ 13.5 M4 per-source cleaner framework**: still needed for wechat's 7 antibot cases and for cleaning Playwright-rendered HTML per site.
+3. **M3 channel strategy (plan § 12)**: the v1 legacy tags confirmed Agent-Reach uses `xhs-cli` subprocess, `rdt-cli`, `gh`, `douyin-mcp-server` — these wrap native SDKs/CLIs rather than scraping HTML. Spike 2 confirms: for any Chinese platform without such a wrapper (e.g. direct blog scraping on CSDN / juejin), browser automation is mandatory.
+4. **Cost**: plan § 4 "non-Playwright primary" budget optimistic. Realistic: every Chinese site needs Playwright/Camoufox unless a native SDK/CLI exists.
+
+### Per-site remediation
+
+| site | recommended chain |
+|---|---|
+| zhihu | cookie (`z_c0`) + `UA: Mozilla/5.0 (Windows NT 10.0...) zh-CN` + `Referer: https://www.zhihu.com/` via httpx; fallback Playwright+cookie for 403 retries. Status: plan § 12 already budgets 2-3 weeks for from-scratch zhihu channel — spike confirms scope. |
+| csdn | Playwright/Camoufox required (Cloudflare 521 is JS challenge, no headers bypass). Add per-source cleaner to strip navigation + CSDN-specific SPA wrappers. Plan § 12 budgets ~2 days via searxng sogou_wechat reference — **needs revision to include Playwright cost** (~2-3 days). |
+| juejin | Playwright required for SPA hydration. `juejin.cn/post/<id>` serves shell HTML only; article body rendered client-side. Plan (no 1:1 source for juejin) — self-written channel, ~2-3 days including Playwright wrapper. |
+| wechat | Keep httpx primary; reserve Playwright for 23% antibot cases. Per-source cleaner for wechat-specific `__biz` / `mid` / `idx` URL validation + redirect handling. Aligned with plan § 12 (~2 days + maintenance). |
+
+### Remediation Map (unchanged)
 
 | fail_reason | next action |
 |---|---|
-| `http_error` | HTTP retry layer |
-| `antibot` | Playwright fallback plan § 8 TBD-C |
+| `http_error` | HTTP retry layer + cookie/UA injection |
+| `antibot` | Playwright/Camoufox fallback plan § 8 TBD-C |
 | `empty_extract` | per-source cleaner plan § 13.5 M4 |
 | `short_extract` | per-source cleaner plan § 13.5 M4 |
 | `js_only` | Playwright fallback |
 
-Claude runs locally via `python tests/eval/spike_2_trafilatura.py` and fills result table.
+Raw data: `tests/eval/spike_2_results.json` (120 entries, one per URL).

--- a/tests/eval/spike_2_results.json
+++ b/tests/eval/spike_2_results.json
@@ -1,0 +1,1119 @@
+{
+  "zhihu": {
+    "pass_count": 0,
+    "fail_count": 30,
+    "pass_rate": 0.0,
+    "fail_reason_counts": {
+      "antibot": 4,
+      "http_error": 26
+    }
+  },
+  "csdn": {
+    "pass_count": 0,
+    "fail_count": 30,
+    "pass_rate": 0.0,
+    "fail_reason_counts": {
+      "http_error": 30
+    }
+  },
+  "juejin": {
+    "pass_count": 0,
+    "fail_count": 30,
+    "pass_rate": 0.0,
+    "fail_reason_counts": {
+      "antibot": 27,
+      "http_error": 3
+    }
+  },
+  "wechat": {
+    "pass_count": 22,
+    "fail_count": 8,
+    "pass_rate": 0.7333,
+    "fail_reason_counts": {
+      "antibot": 7,
+      "short_extract": 1
+    }
+  },
+  "details": [
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/21521104",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/264744357",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/304543222",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/9424560964",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/63883507",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/7859966761",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/19550225",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://www.zhihu.com/question/11116099784",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/676544930",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/713690467",
+      "status_code": 200,
+      "html_size": 191297,
+      "extracted_len": 3240,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/1926699171760530309",
+      "status_code": 200,
+      "html_size": 174703,
+      "extracted_len": 2981,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/1976645826832009193",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/696022954",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/690440069",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/1976246979429412953",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/2235270209",
+      "status_code": 200,
+      "html_size": 158229,
+      "extracted_len": 1395,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/1976280823109010488",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/683151159",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/1981503694995472810",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/2027029874909397801",
+      "status_code": 200,
+      "html_size": 251380,
+      "extracted_len": 16876,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/451132410",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/692873436",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/141187042",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/355305874",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/1966799912785131490",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/679425346",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/30032032196",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/372662362",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/165219444",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "zhihu",
+      "url": "https://zhuanlan.zhihu.com/p/435006249",
+      "status_code": 403,
+      "html_size": 650,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_43055485/article/details/118572395",
+      "status_code": 521,
+      "html_size": 2186,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2302_80742310/article/details/152450243",
+      "status_code": 521,
+      "html_size": 2195,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/m0_52000372/article/details/115407616",
+      "status_code": 521,
+      "html_size": 2186,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2301_76925430/article/details/153136627",
+      "status_code": 521,
+      "html_size": 2159,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_27353441/article/details/144570400",
+      "status_code": 521,
+      "html_size": 2142,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_43483502/article/details/129018407",
+      "status_code": 521,
+      "html_size": 2188,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/bask2312/article/details/131090464",
+      "status_code": 521,
+      "html_size": 2232,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/Dash4664/article/details/143840474",
+      "status_code": 521,
+      "html_size": 2169,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2303_79387663/article/details/136265845",
+      "status_code": 521,
+      "html_size": 2199,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/m0_64363449/article/details/131806824",
+      "status_code": 521,
+      "html_size": 2249,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_20245171/article/details/138243789",
+      "status_code": 521,
+      "html_size": 2142,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_45062768/article/details/132357617",
+      "status_code": 521,
+      "html_size": 2141,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2301_79181030/article/details/141226970",
+      "status_code": 521,
+      "html_size": 2159,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_41035650/article/details/145453931",
+      "status_code": 521,
+      "html_size": 2143,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/m0_48860687/article/details/143921636",
+      "status_code": 521,
+      "html_size": 2250,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_20245171/article/details/144296372",
+      "status_code": 521,
+      "html_size": 2189,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/xxx1276063856/article/details/135900720",
+      "status_code": 521,
+      "html_size": 2153,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2302_76756558/article/details/150618794",
+      "status_code": 521,
+      "html_size": 2159,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2401_83916326/article/details/138091997",
+      "status_code": 521,
+      "html_size": 2262,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/qq_36708269/article/details/150559621",
+      "status_code": 521,
+      "html_size": 2253,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/mmc123125/article/details/146279067",
+      "status_code": 521,
+      "html_size": 2132,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/lifanping/article/details/148774135",
+      "status_code": 521,
+      "html_size": 2174,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/sp_programmer/article/details/49640017",
+      "status_code": 521,
+      "html_size": 2149,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/summer_xj1/article/details/88799389",
+      "status_code": 521,
+      "html_size": 2174,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/applebear1123/article/details/120049207",
+      "status_code": 521,
+      "html_size": 2157,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2503_90543222/article/details/149631124",
+      "status_code": 521,
+      "html_size": 2157,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2502_92141759/article/details/152092437",
+      "status_code": 521,
+      "html_size": 2261,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2501_91483426/article/details/149126491",
+      "status_code": 521,
+      "html_size": 2199,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2403_86762465/article/details/145309528",
+      "status_code": 521,
+      "html_size": 2197,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "csdn",
+      "url": "https://blog.csdn.net/2302_80143362/article/details/153460144",
+      "status_code": 521,
+      "html_size": 2195,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7256161389021265978",
+      "status_code": 404,
+      "html_size": 49933,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/6927150271118196749",
+      "status_code": 200,
+      "html_size": 227175,
+      "extracted_len": 13406,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/6844904157829136398",
+      "status_code": 200,
+      "html_size": 196304,
+      "extracted_len": 10083,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7469693391439396901",
+      "status_code": 200,
+      "html_size": 128813,
+      "extracted_len": 3889,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7585034139662581779",
+      "status_code": 200,
+      "html_size": 132194,
+      "extracted_len": 4103,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7030733515482202119",
+      "status_code": 200,
+      "html_size": 278408,
+      "extracted_len": 24032,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7101141794657665054",
+      "status_code": 200,
+      "html_size": 97982,
+      "extracted_len": 2709,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/6960222427959803917",
+      "status_code": 200,
+      "html_size": 101275,
+      "extracted_len": 2116,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/6857446580643954701",
+      "status_code": 200,
+      "html_size": 99900,
+      "extracted_len": 3041,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7068865005436796958",
+      "status_code": 200,
+      "html_size": 133856,
+      "extracted_len": 4846,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7535277686312091686",
+      "status_code": 200,
+      "html_size": 154996,
+      "extracted_len": 7186,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7377578894591049738",
+      "status_code": 200,
+      "html_size": 101639,
+      "extracted_len": 2168,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7476434412272877622",
+      "status_code": 200,
+      "html_size": 140755,
+      "extracted_len": 3681,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7102707312179036196",
+      "status_code": 200,
+      "html_size": 101438,
+      "extracted_len": 1348,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/6844903477752102919",
+      "status_code": 200,
+      "html_size": 175088,
+      "extracted_len": 8581,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7462177888706019340",
+      "status_code": 200,
+      "html_size": 110772,
+      "extracted_len": 2596,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7603352061469442090",
+      "status_code": 200,
+      "html_size": 161356,
+      "extracted_len": 4968,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7602464510608539674",
+      "status_code": 404,
+      "html_size": 49933,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7380252830504058906",
+      "status_code": 200,
+      "html_size": 94790,
+      "extracted_len": 2131,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7452992730319519785",
+      "status_code": 404,
+      "html_size": 49933,
+      "extracted_len": 0,
+      "pass": false,
+      "fail_reason": "http_error"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7083458769551622175",
+      "status_code": 200,
+      "html_size": 128813,
+      "extracted_len": 4857,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7380188819187826751",
+      "status_code": 200,
+      "html_size": 99382,
+      "extracted_len": 303,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7310402897006510106",
+      "status_code": 200,
+      "html_size": 238228,
+      "extracted_len": 3294,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7312817096549974043",
+      "status_code": 200,
+      "html_size": 355515,
+      "extracted_len": 9873,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7280054124507070500",
+      "status_code": 200,
+      "html_size": 94927,
+      "extracted_len": 1066,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7308780924195012618",
+      "status_code": 200,
+      "html_size": 148506,
+      "extracted_len": 6881,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7308733982807293962",
+      "status_code": 200,
+      "html_size": 149195,
+      "extracted_len": 8534,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7543167809410596910",
+      "status_code": 200,
+      "html_size": 269765,
+      "extracted_len": 22790,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/6935374113443676174",
+      "status_code": 200,
+      "html_size": 91053,
+      "extracted_len": 1884,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "juejin",
+      "url": "https://juejin.cn/post/7309920313369968650",
+      "status_code": 200,
+      "html_size": 117993,
+      "extracted_len": 4970,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/H5vfiuIFW7Qe0r0TsW6BeA",
+      "status_code": 200,
+      "html_size": 2306569,
+      "extracted_len": 152,
+      "pass": false,
+      "fail_reason": "short_extract"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/jcKe6SrI-vxXKZv8tHDxBg",
+      "status_code": 200,
+      "html_size": 2829854,
+      "extracted_len": 408,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/71jJm5iFmi2hcU8oKADNlg",
+      "status_code": 200,
+      "html_size": 2823216,
+      "extracted_len": 553,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/gd59U50tlJPa4B4avXRG1Q",
+      "status_code": 200,
+      "html_size": 2913879,
+      "extracted_len": 3657,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/pMOqLJVCVuKG65ClXKHv7g",
+      "status_code": 200,
+      "html_size": 2869287,
+      "extracted_len": 3570,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/TvHY2i1FX1zS_WHdCvK-wA",
+      "status_code": 200,
+      "html_size": 2927686,
+      "extracted_len": 6326,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/fiUUkT7hyJwXmAGQ1kMcqQ",
+      "status_code": 200,
+      "html_size": 3024399,
+      "extracted_len": 13186,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/E3PGP6FDBFUcghYfpe6vsg",
+      "status_code": 200,
+      "html_size": 2971345,
+      "extracted_len": 1045,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/d6k8_b3d1AK1_xo8vT4zEw",
+      "status_code": 200,
+      "html_size": 2966672,
+      "extracted_len": 3833,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/q6BfOINeqgm5nffrHu4kQA",
+      "status_code": 200,
+      "html_size": 3027218,
+      "extracted_len": 16042,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/lqwGUCKZM0AvEw_xh-7BDA",
+      "status_code": 200,
+      "html_size": 3183253,
+      "extracted_len": 17234,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/UVZKFmv8p4ghm8ICdz85wQ",
+      "status_code": 200,
+      "html_size": 2963666,
+      "extracted_len": 11263,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/-op5WR1wSkgAuP7JYZWP8g",
+      "status_code": 200,
+      "html_size": 3130310,
+      "extracted_len": 21166,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/ggPftQm2ewGOJwlRDQGgDQ",
+      "status_code": 200,
+      "html_size": 2906833,
+      "extracted_len": 4992,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/COQu3rckfZJUelSVBV6IMA",
+      "status_code": 200,
+      "html_size": 3007843,
+      "extracted_len": 2043,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/HdP5NcQIdzfznGwcHLTvMw",
+      "status_code": 200,
+      "html_size": 3203934,
+      "extracted_len": 21128,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/zGJljF6NxcYIe-evv8d0DA",
+      "status_code": 200,
+      "html_size": 3003838,
+      "extracted_len": 8379,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/vv2RZHcinKwPyq5_qzNxTg",
+      "status_code": 200,
+      "html_size": 3078115,
+      "extracted_len": 7076,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/M2M808PwQ2JcMqfLQfXQMw",
+      "status_code": 200,
+      "html_size": 2849702,
+      "extracted_len": 1558,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/QfHHJnzD4vhenjFcFSNMhQ",
+      "status_code": 200,
+      "html_size": 2965173,
+      "extracted_len": 6655,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/0GHTm6hToNzPTtQMcEZalw",
+      "status_code": 200,
+      "html_size": 3051361,
+      "extracted_len": 11229,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/NiP6BcGi1Lil12pKQpnokg",
+      "status_code": 200,
+      "html_size": 2899862,
+      "extracted_len": 772,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s/YNjylhmo1IlvAEKwpjjMkg",
+      "status_code": 200,
+      "html_size": 3007378,
+      "extracted_len": 9579,
+      "pass": true,
+      "fail_reason": "ok"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s?__biz=MzU1NDA4NjU2MA==&mid=2247615439&idx=3&sn=a9b400a37ddcfe4fa7856d264d3a947a",
+      "status_code": 200,
+      "html_size": 17760,
+      "extracted_len": 36,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s?__biz=MzU1NDA4NjU2MA==&mid=2247617948&idx=2&sn=d5b7143e85baf286f5d449ebf15a95b9",
+      "status_code": 200,
+      "html_size": 17760,
+      "extracted_len": 36,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s?__biz=MzU1NDA4NjU2MA==&mid=2247610909&idx=2&sn=dc3f1d32bb200d8a4f7ed4ded5a75c9",
+      "status_code": 200,
+      "html_size": 17759,
+      "extracted_len": 36,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s?__biz=MzU1NDA4NjU2MA==&mid=2247636434&idx=3&sn=a39290e001c83616dc9b14f0ed8ac474",
+      "status_code": 200,
+      "html_size": 17760,
+      "extracted_len": 36,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s?__biz=MzU1NDA4NjU2MA==&mid=2247619826&idx=3&sn=1dee33c054d68fc5509cd3577d1f02a1",
+      "status_code": 200,
+      "html_size": 17761,
+      "extracted_len": 36,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s?__biz=MzU1NDA4NjU2MA==&mid=2247617875&idx=3&sn=fdbd469374a14b775d91ab9c305f7f35",
+      "status_code": 200,
+      "html_size": 17761,
+      "extracted_len": 36,
+      "pass": false,
+      "fail_reason": "antibot"
+    },
+    {
+      "site": "wechat",
+      "url": "https://mp.weixin.qq.com/s?__biz=MzU1NDA4NjU2MA==&mid=2247613822&idx=1&sn=6c74ce9b38063832a8c8e011c5391c0a",
+      "status_code": 200,
+      "html_size": 17760,
+      "extracted_len": 36,
+      "pass": false,
+      "fail_reason": "antibot"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Ran `tests/eval/spike_2_trafilatura.py` locally against 120 URLs (30 each for 知乎/CSDN/掘金/微信).

| site | pass_rate | top fail | verdict |
|---|---|---|---|
| zhihu | 0/30 (0%) | 26× 403, 4× antibot | FAIL — needs cookie + UA + Playwright fallback |
| csdn | 0/30 (0%) | 30× 521 (Cloudflare JS challenge) | FAIL — Playwright/Camoufox required |
| juejin | 0/30 (0%) | 27× antibot (SPA shell) | FAIL — Playwright required |
| wechat | 22/30 (73%) | 7× antibot, 1× short | MARGINAL — below 90% bar but mostly works |

## Plan v2.3 implications (needs boss review)
1. **§ 8 TBD-C revision**: "Playwright 非主力" is wrong for zhihu / csdn / juejin — Playwright is primary, not fallback.
2. **§ 12 工程量修正**: csdn 原估 ~2d (searxng sogou-wechat reference) → needs +2-3d Playwright/Camoufox work. juejin no 1:1 source → self-written + Playwright ~2-3d.
3. **§ 13.5 M4 per-source cleaner**: still needed even after Playwright — rendered HTML still has nav/ads to strip.
4. **§ 4 stack implication**: Playwright is now essential dep (not optional) for all 3 failing sites. Camoufox should be evaluated for Cloudflare bypass.

## Test plan
- [x] 120 URLs fetched + processed (run log `/tmp/s2-run.log`)
- [x] Raw data committed at `tests/eval/spike_2_results.json`
- [x] pytest 6/6 green (no new tests, no regression)
- [x] ruff clean

## Decision needed
Should we (a) update plan v2.3 to mark Playwright as primary for 3 Chinese sites before M2, or (b) defer plan update to M3 and note findings here?