### PR TITLE
feat: pipeline foundation — shared models + M0 recall + M1 full clarify

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -1,17 +1,12 @@
 # Source: gpt-researcher/cli.py:L28-L216 (adapted)
-from enum import StrEnum
 from typing import Annotated
 
 import typer
 
 from autosearch import __version__
+from autosearch.core.models import SearchMode
 
 app = typer.Typer(add_completion=False, no_args_is_help=False)
-
-
-class SearchMode(StrEnum):
-    FAST = "fast"
-    DEEP = "deep"
 
 
 def _version_callback(value: bool) -> None:

--- a/autosearch/core/__init__.py
+++ b/autosearch/core/__init__.py
@@ -1,0 +1,1 @@
+# Self-written, plan v2.3 § 13.5

--- a/autosearch/core/clarify.py
+++ b/autosearch/core/clarify.py
@@ -1,0 +1,122 @@
+# Source: open_deep_research/src/open_deep_research/prompts.py:L3-L41 (adapted)
+from datetime import date
+from textwrap import dedent
+
+import structlog
+from pydantic import BaseModel, Field
+
+from autosearch.core.models import ClarifyRequest, ClarifyResult, Rubric, SearchMode
+from autosearch.llm.client import LLMClient
+
+CLARIFY_PROMPT = dedent(
+    """\
+    These are the messages that have been exchanged so far from the user asking for the report:
+    <Messages>
+    {messages}
+    </Messages>
+
+    Today's date is {date}.
+
+    {mode_preference}
+
+    Assess whether you need to ask a clarifying question, or if the user has already provided
+    enough information for you to start research. IMPORTANT: If you can see in the messages
+    history that you have already asked a clarifying question, you almost always do not need to
+    ask another one. Only ask another question if ABSOLUTELY NECESSARY.
+
+    If there are acronyms, abbreviations, or unknown terms, ask the user to clarify.
+    If you need to ask a question, follow these guidelines:
+    - Be concise while gathering all necessary information
+    - Make sure to gather all the information needed to carry out the research task in a concise,
+      well-structured manner
+    - Use bullet points or numbered lists if appropriate for clarity. Make sure that this uses
+      markdown formatting and will be rendered correctly if the string output is passed to a
+      markdown renderer
+    - Don't ask for unnecessary information, or information that the user has already provided.
+      If you can see that the user has already provided the information, do not ask for it again
+
+    Respond in valid JSON format with these exact keys:
+    - "need_clarification": boolean
+    - "question": "<question to ask the user to clarify the report scope>"
+    - "verification": "<verification message that we will start research>"
+    - "rubrics": ["<short binary evaluation criterion>", "..."]
+    - "mode": "fast" or "deep"
+
+    If you need to ask a clarifying question, return:
+    - "need_clarification": true
+    - "question": "<your clarifying question>"
+    - "verification": ""
+
+    If you do not need to ask a clarifying question, return:
+    - "need_clarification": false
+    - "question": ""
+    - "verification": "<acknowledgement message that you will now start research based on the
+      provided information>"
+
+    For the verification message when no clarification is needed:
+    - Acknowledge that you have sufficient information to proceed
+    - Briefly summarize the key aspects of what you understand from their request
+    - Confirm that you will now begin the research process
+    - Keep the message concise and professional
+
+    For the added fields:
+    - Always return 3 to 5 short rubrics, even if you also ask one clarifying question
+    - Each rubric must be binary and easy to check in the final report
+    - Recommend "fast" for focused or lightweight research and "deep" for broad, comparative,
+      time-sensitive, or higher-stakes research
+    """
+).strip()
+
+
+class _ClarifyCompletion(BaseModel):
+    need_clarification: bool
+    question: str = ""
+    verification: str = ""
+    rubrics: list[str] = Field(default_factory=list)
+    mode: SearchMode
+
+
+class Clarifier:
+    def __init__(self) -> None:
+        self.logger = structlog.get_logger(__name__).bind(component="clarifier")
+
+    async def clarify(self, req: ClarifyRequest, client: LLMClient) -> ClarifyResult:
+        self.logger.info(
+            "clarify_started",
+            query=req.query,
+            mode_hint=req.mode_hint.value if req.mode_hint is not None else None,
+        )
+        prompt = CLARIFY_PROMPT.format(
+            messages=req.query,
+            date=date.today().isoformat(),
+            mode_preference=_mode_preference_text(req.mode_hint),
+        )
+        completion = await client.complete(prompt, _ClarifyCompletion)
+        result = ClarifyResult(
+            need_clarification=completion.need_clarification,
+            question=_normalize_optional_text(completion.question),
+            verification=_normalize_optional_text(completion.verification),
+            rubrics=[Rubric(text=text.strip()) for text in completion.rubrics if text.strip()],
+            mode=completion.mode,
+        )
+        self.logger.info(
+            "clarify_completed",
+            need_clarification=result.need_clarification,
+            rubrics=len(result.rubrics),
+            mode=result.mode.value,
+        )
+        return result
+
+
+def _mode_preference_text(mode_hint: SearchMode | None) -> str:
+    if mode_hint is None:
+        return "The user did not state a preferred research mode."
+    return (
+        f"The user prefers {mode_hint.value} mode. Treat that as the default recommendation "
+        "unless the request clearly calls for the other mode."
+    )
+
+
+def _normalize_optional_text(value: str) -> str | None:
+    stripped = value.strip()
+    return stripped or None

--- a/autosearch/core/knowledge.py
+++ b/autosearch/core/knowledge.py
@@ -1,0 +1,48 @@
+# Self-written, plan v2.3 § 1 decision 16 + § 13.5
+from textwrap import dedent
+
+import structlog
+
+from autosearch.core.models import KnowledgeRecall
+from autosearch.llm.client import LLMClient
+
+KNOWLEDGE_RECALL_PROMPT = dedent(
+    """\
+    You are preparing for a research task.
+
+    User query:
+    <Query>
+    {query}
+    </Query>
+
+    Return only what you can state confidently without doing any search.
+    Separate that from the unknowns that require research.
+
+    Respond in valid JSON with these exact keys:
+    - "known_facts": a list of concise bullet-style facts you can answer confidently now
+    - "gaps": a list of objects with exact keys "topic" and "reason"
+
+    Rules:
+    - Keep known_facts factual, specific, and short
+    - Do not guess, hedge, or include facts that need verification
+    - Use gaps to name the missing information that should be searched next
+    - An empty known_facts list is allowed
+    - An empty gaps list is allowed if the query is answerable from prior knowledge
+    """
+).strip()
+
+
+class KnowledgeRecaller:
+    def __init__(self) -> None:
+        self.logger = structlog.get_logger(__name__).bind(component="knowledge_recaller")
+
+    async def recall(self, query: str, client: LLMClient) -> KnowledgeRecall:
+        self.logger.info("knowledge_recall_started", query=query)
+        prompt = KNOWLEDGE_RECALL_PROMPT.format(query=query)
+        result = await client.complete(prompt, KnowledgeRecall)
+        self.logger.info(
+            "knowledge_recall_completed",
+            known_facts=len(result.known_facts),
+            gaps=len(result.gaps),
+        )
+        return result

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -1,0 +1,75 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SearchMode(StrEnum):
+    FAST = "fast"
+    DEEP = "deep"
+
+
+class SubQuery(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    text: str
+    rationale: str
+
+
+class Evidence(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    url: str
+    title: str
+    snippet: str | None = None
+    content: str | None = None
+    source_channel: str
+    fetched_at: datetime
+    score: float | None = None
+
+
+class Gap(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    topic: str
+    reason: str
+
+
+class Rubric(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    text: str
+    weight: float = 1.0
+
+
+class Section(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    heading: str
+    content: str
+    ref_ids: list[int]
+
+
+class ClarifyRequest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    query: str
+    mode_hint: SearchMode | None = None
+
+
+class ClarifyResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    need_clarification: bool
+    question: str | None = None
+    verification: str | None = None
+    rubrics: list[Rubric] = Field(default_factory=list)
+    mode: SearchMode
+
+
+class KnowledgeRecall(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    known_facts: list[str]
+    gaps: list[Gap]

--- a/autosearch/llm/types.py
+++ b/autosearch/llm/types.py
@@ -1,8 +1,0 @@
-# Self-written, plan v2.3 § 13.5
-from pydantic import BaseModel, Field
-
-
-class ClarifyOutput(BaseModel):
-    need_clarification: bool
-    question: str | None = None
-    rubric: list[str] = Field(default_factory=list)

--- a/docs/spikes/spike-1-auto-detect.md
+++ b/docs/spikes/spike-1-auto-detect.md
@@ -6,7 +6,7 @@ Validate the M1 `LLMClient` auto-detect path and structured-output reliability b
 
 - Scope: 30 calls x 4 providers x 1 schema = 120 total calls.
 - Providers: `claude_code`, `anthropic`, `openai`, `gemini`.
-- Schema: `ClarifyOutput`.
+- Schema: `ClarifyResult`.
 - Pass criteria: fail rate `< 5%` per provider, per plan v2.3 § 6.
 
 ## Local Harness
@@ -16,14 +16,14 @@ Run this from the repo root after exporting any provider credentials you want to
 ```python
 import asyncio
 
+from autosearch.core.models import ClarifyResult
 from autosearch.llm.client import LLMClient
-from autosearch.llm.types import ClarifyOutput
 
 RUNS = 30
 PROMPT = (
     "You are the M1 clarify step. Return JSON only. "
     "Decide whether the query 'best AI coding setup for a solo founder' needs clarification. "
-    "Always include a rubric list."
+    "Always include rubrics and a mode recommendation."
 )
 
 
@@ -33,7 +33,7 @@ async def probe(provider_name: str) -> tuple[int, list[str]]:
     for index in range(RUNS):
         try:
             client = LLMClient(provider_name=provider_name)
-            await client.complete(PROMPT, ClarifyOutput)
+            await client.complete(PROMPT, ClarifyResult)
         except Exception as exc:  # noqa: BLE001
             failures += 1
             notes.append(f"run {index + 1}: {type(exc).__name__}: {exc}")

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -1,0 +1,103 @@
+# Self-written, plan v2.3 § 13.5
+from pydantic import BaseModel
+
+from autosearch.core.clarify import Clarifier
+from autosearch.core.models import ClarifyRequest, SearchMode
+
+
+class DummyClient:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls = 0
+        self.prompts: list[str] = []
+        self.response_models: list[type[BaseModel]] = []
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        self.calls += 1
+        self.prompts.append(prompt)
+        self.response_models.append(response_model)
+        return response_model.model_validate(self.payload)
+
+
+async def test_clarifier_returns_question_for_ambiguous_query() -> None:
+    client = DummyClient(
+        {
+            "need_clarification": True,
+            "question": "Do you want a consumer recommendation or an engineering comparison?",
+            "verification": "",
+            "rubrics": [
+                "States the target audience",
+                "Compares named options directly",
+                "Uses sources newer than one year when possible",
+            ],
+            "mode": "deep",
+        }
+    )
+
+    result = await Clarifier().clarify(ClarifyRequest(query="best search tools"), client)
+
+    assert result.need_clarification is True
+    assert result.question == "Do you want a consumer recommendation or an engineering comparison?"
+    assert result.verification is None
+    assert result.mode is SearchMode.DEEP
+    assert client.calls == 1
+
+
+async def test_clarifier_returns_rubrics_and_mode_for_clear_query() -> None:
+    client = DummyClient(
+        {
+            "need_clarification": False,
+            "question": "",
+            "verification": "I have enough information to compare the four providers and will start research now.",
+            "rubrics": [
+                "Covers all four providers",
+                "Includes pricing citations",
+                "Calls out current model support",
+            ],
+            "mode": "fast",
+        }
+    )
+
+    result = await Clarifier().clarify(
+        ClarifyRequest(query="Compare Claude, OpenAI, Gemini, and Anthropic API pricing"),
+        client,
+    )
+
+    assert result.need_clarification is False
+    assert result.question is None
+    assert result.verification is not None
+    assert [rubric.text for rubric in result.rubrics] == [
+        "Covers all four providers",
+        "Includes pricing citations",
+        "Calls out current model support",
+    ]
+    assert all(rubric.weight == 1.0 for rubric in result.rubrics)
+    assert result.mode is SearchMode.FAST
+
+
+async def test_clarifier_includes_mode_hint_when_provided() -> None:
+    client = DummyClient(
+        {
+            "need_clarification": False,
+            "question": "",
+            "verification": "I have enough information to proceed.",
+            "rubrics": [
+                "Names the comparison set",
+                "Uses fresh sources",
+                "Explains the tradeoffs clearly",
+            ],
+            "mode": "deep",
+        }
+    )
+
+    result = await Clarifier().clarify(
+        ClarifyRequest(
+            query="Research the long-term tradeoffs of local vs hosted code search",
+            mode_hint=SearchMode.DEEP,
+        ),
+        client,
+    )
+
+    assert result.mode is SearchMode.DEEP
+    assert "The user prefers deep mode." in client.prompts[0]
+    assert client.calls == 1

--- a/tests/unit/test_knowledge.py
+++ b/tests/unit/test_knowledge.py
@@ -1,0 +1,58 @@
+# Self-written, plan v2.3 § 13.5
+from pydantic import BaseModel
+
+from autosearch.core.knowledge import KnowledgeRecaller
+from autosearch.core.models import Gap, KnowledgeRecall
+
+
+class DummyClient:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls = 0
+        self.prompts: list[str] = []
+        self.response_models: list[type[BaseModel]] = []
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        self.calls += 1
+        self.prompts.append(prompt)
+        self.response_models.append(response_model)
+        return response_model.model_validate(self.payload)
+
+
+async def test_knowledge_recall_returns_structured_result() -> None:
+    client = DummyClient(
+        {
+            "known_facts": ["SQLite FTS5 includes BM25 ranking support."],
+            "gaps": [{"topic": "Current provider limits", "reason": "Needs fresh verification"}],
+        }
+    )
+
+    result = await KnowledgeRecaller().recall("SQLite FTS5 for search relevance", client)
+
+    assert result == KnowledgeRecall(
+        known_facts=["SQLite FTS5 includes BM25 ranking support."],
+        gaps=[Gap(topic="Current provider limits", reason="Needs fresh verification")],
+    )
+    assert client.calls == 1
+    assert client.response_models == [KnowledgeRecall]
+
+
+async def test_knowledge_recall_allows_empty_gaps() -> None:
+    client = DummyClient({"known_facts": ["Typer is a Python CLI framework."], "gaps": []})
+
+    result = await KnowledgeRecaller().recall("What is Typer?", client)
+
+    assert result.known_facts == ["Typer is a Python CLI framework."]
+    assert result.gaps == []
+
+
+async def test_knowledge_recall_calls_client_once_per_request() -> None:
+    client = DummyClient({"known_facts": [], "gaps": []})
+    recaller = KnowledgeRecaller()
+
+    await recaller.recall("Need a quick grounding pass", client)
+
+    assert client.calls == 1
+    assert (
+        "Return only what you can state confidently without doing any search." in client.prompts[0]
+    )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,128 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from autosearch.core.models import (
+    ClarifyRequest,
+    ClarifyResult,
+    Evidence,
+    Gap,
+    KnowledgeRecall,
+    Rubric,
+    SearchMode,
+    Section,
+    SubQuery,
+)
+
+FIXED_TIME = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("factory", "field_name", "field_value", "invalid_payload"),
+    [
+        (
+            lambda: SubQuery(text="sqlite fts5 tokenizer", rationale="search strategy seed"),
+            "text",
+            "updated",
+            {"text": None, "rationale": "search strategy seed"},
+        ),
+        (
+            lambda: Evidence(
+                url="https://example.com",
+                title="Example",
+                snippet="snippet",
+                content="content",
+                source_channel="web",
+                fetched_at=FIXED_TIME,
+                score=0.8,
+            ),
+            "title",
+            "Updated",
+            {
+                "url": "https://example.com",
+                "title": "Example",
+                "snippet": "snippet",
+                "content": "content",
+                "source_channel": "web",
+                "fetched_at": "not-a-date",
+                "score": 0.8,
+            },
+        ),
+        (
+            lambda: Gap(topic="pricing", reason="needs current vendor data"),
+            "reason",
+            "changed",
+            {"topic": "pricing", "reason": None},
+        ),
+        (
+            lambda: Rubric(text="Includes direct source links"),
+            "weight",
+            2.0,
+            {"text": "Includes direct source links", "weight": "high"},
+        ),
+        (
+            lambda: Section(heading="Summary", content="Answer", ref_ids=[1, 2]),
+            "heading",
+            "Updated",
+            {"heading": "Summary", "content": "Answer", "ref_ids": ["bad"]},
+        ),
+        (
+            lambda: ClarifyRequest(query="best agentic search tools", mode_hint=SearchMode.FAST),
+            "query",
+            "updated",
+            {"query": None, "mode_hint": "fast"},
+        ),
+        (
+            lambda: ClarifyResult(
+                need_clarification=False,
+                verification="Starting research",
+                rubrics=[Rubric(text="Uses recent sources")],
+                mode=SearchMode.DEEP,
+            ),
+            "mode",
+            SearchMode.FAST,
+            {
+                "need_clarification": False,
+                "verification": "Starting research",
+                "rubrics": ["bad"],
+                "mode": "deep",
+            },
+        ),
+        (
+            lambda: KnowledgeRecall(
+                known_facts=["SQLite FTS5 supports BM25 ranking"],
+                gaps=[Gap(topic="Chinese tokenization", reason="needs current implementation")],
+            ),
+            "known_facts",
+            [],
+            {"known_facts": "not-a-list", "gaps": []},
+        ),
+    ],
+)
+def test_models_validate_and_are_frozen(
+    factory: object,
+    field_name: str,
+    field_value: object,
+    invalid_payload: dict[str, object],
+) -> None:
+    model = factory()
+
+    assert model is not None
+
+    with pytest.raises(ValidationError):
+        setattr(model, field_name, field_value)
+
+    with pytest.raises(ValidationError):
+        type(model).model_validate(invalid_payload)
+
+
+def test_search_mode_parses_valid_values() -> None:
+    assert SearchMode("fast") is SearchMode.FAST
+    assert SearchMode("deep") is SearchMode.DEEP
+
+
+def test_search_mode_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError):
+        SearchMode("slow")


### PR DESCRIPTION
## Summary
波 1 of pipeline functionality (channel layer deferred per boss).

- `autosearch/core/models.py` — shared Pydantic types: `SubQuery / Evidence / Gap / Rubric / Section / ClarifyRequest / ClarifyResult / KnowledgeRecall / SearchMode` (all frozen)
- `autosearch/core/knowledge.py` — M0 `KnowledgeRecaller` (single LLM call, known_facts + gaps) — plan v2.3 § 13.5 M0 (self-written, node-deepresearch semantics)
- `autosearch/core/clarify.py` — M1 full `Clarifier` (port open_deep_research `prompts.py:L3-L41` + extended per plan § 13.5 M1 with rubrics + mode recommendation)
- M1 skeleton `ClarifyOutput` stub removed from `autosearch/llm/types.py` (file deleted); `ClarifyResult` in core now canonical

## Test plan
- [x] `pytest -x -q -m "not network"` — 22 passed (6 existing + 16 new)
- [x] `ruff check .` — 0 issues
- [x] `ruff format --check .` — clean
- [x] 1:1 source comment on every new `.py`
- [x] PII scan clean

## Next (波 2 — after this merges)
5 Codex in parallel:
- M2 Search Strategy (gpt-researcher `prompts.py:L213-L255`)
- M3 IterationController (open_deep_research legacy `graph.py:L235-L354`, port w/ rewrite ~3-5d)
- M4 trafilatura wrapper (storm `utils.py:L685-L711`)
- M5 Evidence Processor (URL dedup + BM25 + SimHash + jieba)
- M7 Report Synthesizer (storm outline + per-section + citation remap)
- M8 Quality Gate (open_deep_research legacy `prompts.py:L168-L198`)

Channel layer uses mock fixture during波 2 (plan channel impl deferred).