### PR TITLE
feat: pipeline orchestrator + e2e smoke (m0-m8 wired up)

### DIFF
--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -1,0 +1,340 @@
+# Self-written, plan v2.3 § 2
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+import structlog
+
+from autosearch.channels.base import Channel
+from autosearch.core.clarify import Clarifier
+from autosearch.core.evidence import EvidenceProcessor
+from autosearch.core.iteration import IterationBudget, IterationController
+from autosearch.core.knowledge import KnowledgeRecaller
+from autosearch.core.models import (
+    ClarifyRequest,
+    ClarifyResult,
+    EvaluationResult,
+    Evidence,
+    Gap,
+    GradeOutcome,
+    SearchMode,
+    Section,
+    SubQuery,
+)
+from autosearch.core.strategy import QueryStrategist
+from autosearch.llm.client import LLMClient
+from autosearch.quality.gate import QualityGate
+from autosearch.synthesis.report import ReportSynthesizer
+
+_SECTION_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
+_INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    status: Literal["ok", "needs_clarification"]
+    clarification: ClarifyResult
+    markdown: str | None = None
+    evidences: list[Evidence] = field(default_factory=list)
+    quality: EvaluationResult | None = None
+    iterations: int = 0
+
+
+class Pipeline:
+    def __init__(
+        self,
+        llm: LLMClient,
+        channels: list[Channel],
+        budget: IterationBudget = IterationBudget(),
+        top_k_evidence: int = 20,
+    ) -> None:
+        self.llm = llm
+        self.channels = channels
+        self.budget = budget
+        self.top_k_evidence = top_k_evidence
+        self.knowledge_recaller = KnowledgeRecaller()
+        self.clarifier = Clarifier()
+        self.query_strategist = QueryStrategist()
+        self.evidence_processor = EvidenceProcessor()
+        self.report_synthesizer = ReportSynthesizer()
+        self.quality_gate = QualityGate()
+        self.logger = structlog.get_logger(__name__).bind(component="pipeline")
+
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+    ) -> PipelineResult:
+        iteration_controller = _TrackingIterationController(
+            evidence_processor=self.evidence_processor
+        )
+
+        self.logger.info("pipeline_phase_started", phase="m0_recall", query=query)
+        recall = await self.knowledge_recaller.recall(query, self.llm)
+        self.logger.info(
+            "pipeline_phase_completed",
+            phase="m0_recall",
+            known_facts=len(recall.known_facts),
+            gaps=len(recall.gaps),
+        )
+
+        self.logger.info(
+            "pipeline_phase_started",
+            phase="m1_clarify",
+            mode_hint=mode_hint.value if mode_hint is not None else None,
+        )
+        clarification = await self.clarifier.clarify(
+            ClarifyRequest(query=query, mode_hint=mode_hint),
+            self.llm,
+        )
+        self.logger.info(
+            "pipeline_phase_completed",
+            phase="m1_clarify",
+            need_clarification=clarification.need_clarification,
+            rubrics=len(clarification.rubrics),
+            mode=clarification.mode.value,
+        )
+
+        if clarification.need_clarification:
+            self.logger.info("pipeline_run_completed", status="needs_clarification")
+            return PipelineResult(
+                status="needs_clarification",
+                clarification=clarification,
+                iterations=0,
+            )
+
+        self.logger.info(
+            "pipeline_phase_started",
+            phase="m2_strategy",
+            requested_subqueries=_initial_subquery_count(clarification.mode),
+        )
+        initial_queries = await self.query_strategist.generate_subqueries(
+            clarify=clarification,
+            recall=recall,
+            client=self.llm,
+            n=_initial_subquery_count(clarification.mode),
+        )
+        self.logger.info(
+            "pipeline_phase_completed",
+            phase="m2_strategy",
+            subqueries=len(initial_queries),
+        )
+
+        self.logger.info(
+            "pipeline_phase_started",
+            phase="m3_iteration",
+            subqueries=len(initial_queries),
+            channels=len(self.channels),
+            max_iterations=self.budget.max_iterations,
+        )
+        evidences = await iteration_controller.run(
+            query=query,
+            initial_queries=initial_queries,
+            channels=self.channels,
+            budget=self.budget,
+            client=self.llm,
+        )
+        self.logger.info(
+            "pipeline_phase_completed",
+            phase="m3_iteration",
+            evidences=len(evidences),
+            iterations=iteration_controller.iterations_executed,
+        )
+
+        self.logger.info(
+            "pipeline_phase_started",
+            phase="m5_evidence_processing",
+            evidences=len(evidences),
+            top_k=self.top_k_evidence,
+        )
+        processed_evidences = self._finalize_evidences(evidences, query)
+        self.logger.info(
+            "pipeline_phase_completed",
+            phase="m5_evidence_processing",
+            evidences=len(processed_evidences),
+        )
+
+        self.logger.info(
+            "pipeline_phase_started",
+            phase="m7_synthesis",
+            evidences=len(processed_evidences),
+        )
+        markdown = await self.report_synthesizer.synthesize(
+            query=query,
+            evidences=processed_evidences,
+            rubrics=clarification.rubrics,
+            client=self.llm,
+        )
+        self.logger.info(
+            "pipeline_phase_completed",
+            phase="m7_synthesis",
+            markdown_chars=len(markdown),
+        )
+
+        first_section = _extract_first_section(markdown)
+        self.logger.info(
+            "pipeline_phase_started",
+            phase="m8_quality_gate",
+            section_heading=first_section.heading,
+        )
+        quality = await self.quality_gate.evaluate(
+            section=first_section,
+            rubrics=clarification.rubrics,
+            evidences=processed_evidences,
+            client=self.llm,
+        )
+        self.logger.info(
+            "pipeline_phase_completed",
+            phase="m8_quality_gate",
+            grade=quality.grade.value,
+            follow_up_gaps=len(quality.follow_up_gaps),
+        )
+
+        if quality.grade is GradeOutcome.FAIL:
+            retry_queries = _subqueries_from_gaps(quality.follow_up_gaps)
+            if retry_queries:
+                retry_budget = IterationBudget(
+                    max_iterations=1,
+                    per_channel_rate_limit=self.budget.per_channel_rate_limit,
+                )
+                self.logger.info(
+                    "pipeline_quality_retry_started",
+                    retry_subqueries=len(retry_queries),
+                )
+                retry_evidences = await iteration_controller.run(
+                    query=query,
+                    initial_queries=retry_queries,
+                    channels=self.channels,
+                    budget=retry_budget,
+                    client=self.llm,
+                )
+                processed_evidences = self._finalize_evidences(
+                    processed_evidences + retry_evidences,
+                    query,
+                )
+                markdown = await self.report_synthesizer.synthesize(
+                    query=query,
+                    evidences=processed_evidences,
+                    rubrics=clarification.rubrics,
+                    client=self.llm,
+                )
+                self.logger.info(
+                    "pipeline_quality_retry_completed",
+                    retry_evidences=len(retry_evidences),
+                    total_evidences=len(processed_evidences),
+                    markdown_chars=len(markdown),
+                )
+
+        self.logger.info(
+            "pipeline_run_completed",
+            status="ok",
+            evidences=len(processed_evidences),
+            iterations=iteration_controller.iterations_executed,
+        )
+        return PipelineResult(
+            status="ok",
+            clarification=clarification,
+            markdown=markdown,
+            evidences=processed_evidences,
+            quality=quality,
+            iterations=iteration_controller.iterations_executed,
+        )
+
+    def _finalize_evidences(self, evidences: list[Evidence], query: str) -> list[Evidence]:
+        deduped = self.evidence_processor.dedup_urls(evidences)
+        deduped = self.evidence_processor.dedup_simhash(deduped)
+        return self.evidence_processor.rerank_bm25(
+            deduped,
+            query,
+            top_k=self.top_k_evidence,
+        )
+
+
+class _TrackingIterationController(IterationController):
+    def __init__(self, evidence_processor: EvidenceProcessor) -> None:
+        super().__init__(evidence_processor=evidence_processor)
+        self.iterations_executed = 0
+
+    async def _reflect(
+        self,
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        client: LLMClient,
+    ) -> list[Gap]:
+        self.iterations_executed += 1
+        return await super()._reflect(
+            query=query,
+            iteration=iteration,
+            max_iterations=max_iterations,
+            subqueries=subqueries,
+            evidences=evidences,
+            client=client,
+        )
+
+
+def _initial_subquery_count(mode: SearchMode) -> int:
+    if mode is SearchMode.FAST:
+        return 3
+    return 5
+
+
+def _subqueries_from_gaps(gaps: list[Gap]) -> list[SubQuery]:
+    seen: set[str] = set()
+    subqueries: list[SubQuery] = []
+    for gap in gaps:
+        text = gap.topic.strip()
+        key = text.casefold()
+        if not text or key in seen:
+            continue
+        seen.add(key)
+        subqueries.append(SubQuery(text=text, rationale=gap.reason.strip() or text))
+    return subqueries
+
+
+def _extract_first_section(markdown: str) -> Section:
+    heading: str | None = None
+    content_lines: list[str] = []
+
+    for line in markdown.splitlines():
+        heading_match = _SECTION_HEADING_RE.match(line)
+        if heading_match is None:
+            if heading is not None:
+                content_lines.append(line)
+            continue
+
+        candidate_heading = heading_match.group(1).strip()
+        if heading is None and candidate_heading not in {"References", "Sources"}:
+            heading = candidate_heading
+            continue
+        if heading is not None:
+            break
+
+    if heading is None:
+        content = markdown.strip()
+        return Section(
+            heading="Overview",
+            content=content,
+            ref_ids=_extract_ref_ids(content),
+        )
+
+    content = "\n".join(content_lines).strip()
+    return Section(
+        heading=heading,
+        content=content,
+        ref_ids=_extract_ref_ids(content),
+    )
+
+
+def _extract_ref_ids(content: str) -> list[int]:
+    seen: set[int] = set()
+    ref_ids: list[int] = []
+    for match in _INLINE_CITATION_RE.finditer(content):
+        ref_id = int(match.group(1))
+        if ref_id in seen:
+            continue
+        seen.add(ref_id)
+        ref_ids.append(ref_id)
+    return ref_ids

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Self-written, plan v2.3 § 13.5

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+# Self-written, plan v2.3 § 13.5

--- a/tests/fixtures/fake_channel.py
+++ b/tests/fixtures/fake_channel.py
@@ -1,0 +1,26 @@
+# Self-written, plan v2.3 § 13.5
+from collections.abc import Callable
+
+from autosearch.channels.base import Channel
+from autosearch.core.models import Evidence, SubQuery
+
+
+class FakeChannel(Channel):
+    def __init__(
+        self,
+        name: str,
+        evidences: list[Evidence] | None = None,
+        factory: Callable[[SubQuery], list[Evidence]] | None = None,
+    ) -> None:
+        self.name = name
+        self._evidences = list(evidences or [])
+        self._factory = factory
+        self.call_count = 0
+        self.queries: list[SubQuery] = []
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        self.call_count += 1
+        self.queries.append(query)
+        if self._factory is not None:
+            return list(self._factory(query))
+        return list(self._evidences)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+# Self-written, plan v2.3 § 13.5

--- a/tests/integration/test_pipeline_clarification_exit.py
+++ b/tests/integration/test_pipeline_clarification_exit.py
@@ -1,0 +1,84 @@
+# Self-written, plan v2.3 § 13.5
+import json
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel
+
+from autosearch.core.clarify import _ClarifyCompletion
+from autosearch.core.models import Gap, KnowledgeRecall, SearchMode
+from autosearch.core.pipeline import Pipeline
+from autosearch.llm.client import LLMClient
+from tests.fixtures.fake_channel import FakeChannel
+
+# These internal response models are imported on purpose so the scripted provider can assert that
+# Pipeline is using the existing clarify module contract for the early-exit branch.
+
+
+@dataclass(frozen=True)
+class CompletionStep:
+    response_model: type[BaseModel]
+    payload: dict[str, object]
+
+
+class ScriptedProvider:
+    name = "scripted"
+
+    def __init__(self, steps: list[CompletionStep]) -> None:
+        self.steps = list(steps)
+        self.calls = 0
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> str:
+        _ = prompt
+        if self.calls >= len(self.steps):
+            raise AssertionError(f"Unexpected extra LLM call for {response_model.__name__}")
+        step = self.steps[self.calls]
+        self.calls += 1
+        if response_model is not step.response_model:
+            raise AssertionError(
+                "Expected response model "
+                f"{step.response_model.__name__}, got {response_model.__name__}"
+            )
+        return json.dumps(step.payload)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_exits_early_when_clarification_is_required() -> None:
+    provider = ScriptedProvider(
+        [
+            CompletionStep(
+                response_model=KnowledgeRecall,
+                payload=KnowledgeRecall(
+                    known_facts=[],
+                    gaps=[Gap(topic="Target audience", reason="Needed to scope the report")],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_ClarifyCompletion,
+                payload=_ClarifyCompletion(
+                    need_clarification=True,
+                    question="Do you want an engineering comparison or a buyer guide?",
+                    verification="",
+                    rubrics=[
+                        "States the audience explicitly",
+                        "Names the comparison target",
+                        "Explains the selection criteria",
+                    ],
+                    mode=SearchMode.DEEP,
+                ).model_dump(mode="json"),
+            ),
+        ]
+    )
+    llm = LLMClient(provider_name="scripted", providers={"scripted": provider})
+    channel = FakeChannel(name="web", evidences=[])
+
+    result = await Pipeline(llm=llm, channels=[channel]).run("best search tool")
+
+    assert result.status == "needs_clarification"
+    assert result.markdown is None
+    assert result.evidences == []
+    assert result.quality is None
+    assert result.iterations == 0
+    assert result.clarification.need_clarification is True
+    assert channel.call_count == 0
+    assert provider.calls == len(provider.steps)

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -1,0 +1,198 @@
+# Self-written, plan v2.3 § 13.5
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+from pydantic import BaseModel
+
+from autosearch.core.clarify import _ClarifyCompletion
+from autosearch.core.iteration import _GapReflectionResponse
+from autosearch.core.models import EvaluationResult, Gap, GradeOutcome, KnowledgeRecall, SearchMode
+from autosearch.core.pipeline import Pipeline
+from autosearch.core.strategy import _SubQueryBatch
+from autosearch.llm.client import LLMClient
+from autosearch.synthesis.outline import OutlineResponse
+from autosearch.synthesis.section import _SectionWriteResponse
+from tests.fixtures.fake_channel import FakeChannel
+
+# These internal response models are imported on purpose so the scripted provider can assert that
+# Pipeline is exercising the existing module contracts instead of bypassing them in tests.
+
+NOW = datetime(2026, 4, 17, 12, 0, 0)
+
+
+@dataclass(frozen=True)
+class CompletionStep:
+    response_model: type[BaseModel]
+    payload: dict[str, object]
+
+
+class ScriptedProvider:
+    name = "scripted"
+
+    def __init__(self, steps: list[CompletionStep]) -> None:
+        self.steps = list(steps)
+        self.calls = 0
+        self.prompts: list[str] = []
+        self.response_models: list[type[BaseModel]] = []
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> str:
+        self.prompts.append(prompt)
+        self.response_models.append(response_model)
+        if self.calls >= len(self.steps):
+            raise AssertionError(
+                f"Unexpected extra LLM call for {response_model.__name__}: {prompt[:120]!r}"
+            )
+
+        step = self.steps[self.calls]
+        self.calls += 1
+        if response_model is not step.response_model:
+            raise AssertionError(
+                "Expected response model "
+                f"{step.response_model.__name__}, got {response_model.__name__}"
+            )
+        return json.dumps(step.payload)
+
+
+def make_evidence(url: str, title: str, source_channel: str, body: str) -> BaseModel:
+    from autosearch.core.models import Evidence
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=body[:80],
+        content=body,
+        source_channel=source_channel,
+        fetched_at=NOW,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_produces_report_and_quality_pass() -> None:
+    provider = ScriptedProvider(
+        [
+            CompletionStep(
+                response_model=KnowledgeRecall,
+                payload=KnowledgeRecall(
+                    known_facts=["BM25 is a lexical ranking method."],
+                    gaps=[Gap(topic="Current benchmarks", reason="Need fresh comparisons")],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_ClarifyCompletion,
+                payload=_ClarifyCompletion(
+                    need_clarification=False,
+                    question="",
+                    verification="I have enough information to research the current tradeoffs.",
+                    rubrics=[
+                        "Includes recent evidence",
+                        "Compares the sources directly",
+                        "Provides cited conclusions",
+                    ],
+                    mode=SearchMode.FAST,
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_SubQueryBatch,
+                payload=_SubQueryBatch(
+                    subqueries=[
+                        {
+                            "text": "bm25 ranking benchmarks 2026",
+                            "rationale": "covers current benchmark evidence",
+                        },
+                        {
+                            "text": "bm25 retrieval tradeoffs comparison",
+                            "rationale": "covers direct tradeoff analysis",
+                        },
+                        {
+                            "text": "bm25 relevance evaluation sources",
+                            "rationale": "covers cited conclusions",
+                        },
+                    ]
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_GapReflectionResponse,
+                payload=_GapReflectionResponse(gaps=[]).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=OutlineResponse,
+                payload=OutlineResponse(headings=["Overview", "Practical Takeaways"]).model_dump(
+                    mode="json"
+                ),
+            ),
+            CompletionStep(
+                response_model=_SectionWriteResponse,
+                payload=_SectionWriteResponse(
+                    content=(
+                        "BM25 remains competitive for lexical retrieval and is easy to reason "
+                        "about in ranking pipelines [1][2]."
+                    ),
+                    ref_ids=[1, 2],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_SectionWriteResponse,
+                payload=_SectionWriteResponse(
+                    content=(
+                        "Operationally, the strongest signal here is straightforward deployment "
+                        "and transparent scoring behavior backed by multiple sources [2][3]."
+                    ),
+                    ref_ids=[2, 3],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=EvaluationResult,
+                payload=EvaluationResult(
+                    grade=GradeOutcome.PASS,
+                    follow_up_gaps=[],
+                ).model_dump(mode="json"),
+            ),
+        ]
+    )
+    llm = LLMClient(provider_name="scripted", providers={"scripted": provider})
+    channel = FakeChannel(
+        name="web",
+        evidences=[
+            make_evidence(
+                "https://example.com/benchmarks",
+                "BM25 benchmark summary",
+                "web",
+                "A benchmark summary comparing BM25 to related ranking approaches.",
+            ),
+            make_evidence(
+                "https://example.com/tradeoffs",
+                "BM25 tradeoffs",
+                "web",
+                "Tradeoffs between BM25 and adjacent retrieval strategies in production.",
+            ),
+            make_evidence(
+                "https://example.com/deployment",
+                "Deploying BM25 systems",
+                "web",
+                "Practical deployment notes and transparent scoring details for BM25.",
+            ),
+            make_evidence(
+                "https://example.com/citations",
+                "Evidence-backed BM25 conclusions",
+                "web",
+                "A cited write-up that summarizes the most important BM25 conclusions.",
+            ),
+        ],
+    )
+
+    result = await Pipeline(llm=llm, channels=[channel]).run(
+        "Should I still use BM25 for lexical search?",
+    )
+
+    assert result.status == "ok"
+    assert result.markdown is not None
+    assert "## References" in result.markdown
+    assert "## Sources" in result.markdown
+    assert "## Overview" in result.markdown
+    assert result.evidences
+    assert result.quality is not None
+    assert result.quality.grade is GradeOutcome.PASS
+    assert channel.call_count >= 1
+    assert provider.calls == len(provider.steps)


### PR DESCRIPTION
## Summary
Wires the 8 pipeline modules (M0-M8) into a single `Pipeline` orchestrator and proves end-to-end with fake Channel.

- `autosearch/core/pipeline.py` — `Pipeline` class composing M0 recall → M1 clarify (early exit if `need_clarification`) → M2 strategy → M3 iteration (channels) → M5 dedup + BM25 → M7 synthesize → M8 quality gate (one retry on fail)
- `tests/fixtures/fake_channel.py` — `FakeChannel` implementing `Channel` Protocol with canned evidences + call tracking
- `tests/integration/test_pipeline_e2e.py` — full M0→M8 smoke with ScriptedProvider mock LLMClient; asserts markdown contains `## References` + `## Sources` + sections
- `tests/integration/test_pipeline_clarification_exit.py` — verifies early exit when M1 returns `need_clarification=True`

## Test plan
- [x] `pytest -x -q -m "not network"` — 41 passed (39 existing + 2 integration)
- [x] `ruff check .` — 0 issues
- [x] `ruff format --check .` — clean
- [x] 1:1 source comment on all new `.py`
- [x] PII scan clean

## Next (boss)
- Channel layer impl (real adapters for海外 P0 / 中文 P0)
- CLI wiring: `autosearch "query"` → `Pipeline.run()` → stdout markdown
- MCP Server (plan § 13.5 presentation)