### PR TITLE
feat: cli query → pipeline + demo channel

### DIFF
--- a/autosearch/channels/demo.py
+++ b/autosearch/channels/demo.py
@@ -14,7 +14,7 @@ class DemoChannel:
         encoded_query = quote_plus(query.text)
         return [
             Evidence(
-                url=f"https://demo.local/arxiv/{encoded_query}",
+                url=f"https://demo.example/arxiv/{encoded_query}",
                 title=f"{query.text}: retrieval benchmark survey",
                 snippet=(
                     f"An arXiv-style survey discussing {query.text} and why the benchmark "
@@ -28,7 +28,7 @@ class DemoChannel:
                 fetched_at=now,
             ),
             Evidence(
-                url=f"https://demo.local/blog/{encoded_query}",
+                url=f"https://demo.example/blog/{encoded_query}",
                 title=f"Practitioner notes on {query.text}",
                 snippet=(
                     f"A blog post summarizing implementation tradeoffs for {query.text} in "
@@ -42,7 +42,7 @@ class DemoChannel:
                 fetched_at=now,
             ),
             Evidence(
-                url=f"https://demo.local/github/{encoded_query}",
+                url=f"https://demo.example/github/{encoded_query}",
                 title=f"{query.text} reference implementation",
                 snippet=(
                     f"A repository README describing a sample implementation for {query.text} "
@@ -56,7 +56,7 @@ class DemoChannel:
                 fetched_at=now,
             ),
             Evidence(
-                url=f"https://demo.local/forum/{encoded_query}",
+                url=f"https://demo.example/forum/{encoded_query}",
                 title=f"Field report: teams evaluating {query.text}",
                 snippet=(
                     f"A discussion thread where practitioners compare results for {query.text} "

--- a/autosearch/channels/demo.py
+++ b/autosearch/channels/demo.py
@@ -1,0 +1,72 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import UTC, datetime
+from urllib.parse import quote_plus
+
+from autosearch.core.models import Evidence, SubQuery
+
+
+class DemoChannel:
+    def __init__(self, name: str = "demo") -> None:
+        self.name = name
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        now = datetime.now(UTC)
+        encoded_query = quote_plus(query.text)
+        return [
+            Evidence(
+                url=f"https://demo.local/arxiv/{encoded_query}",
+                title=f"{query.text}: retrieval benchmark survey",
+                snippet=(
+                    f"An arXiv-style survey discussing {query.text} and why the benchmark "
+                    "setup matters."
+                ),
+                content=(
+                    f"This demo evidence models an academic paper about {query.text}. "
+                    f"It uses the query text directly and explains the rationale: {query.rationale}."
+                ),
+                source_channel="demo:arxiv",
+                fetched_at=now,
+            ),
+            Evidence(
+                url=f"https://demo.local/blog/{encoded_query}",
+                title=f"Practitioner notes on {query.text}",
+                snippet=(
+                    f"A blog post summarizing implementation tradeoffs for {query.text} in "
+                    "production systems."
+                ),
+                content=(
+                    f"This demo blog post covers {query.text} with operational details, rollout "
+                    "pitfalls, and concrete observations that help lexical ranking."
+                ),
+                source_channel="demo:blog",
+                fetched_at=now,
+            ),
+            Evidence(
+                url=f"https://demo.local/github/{encoded_query}",
+                title=f"{query.text} reference implementation",
+                snippet=(
+                    f"A repository README describing a sample implementation for {query.text} "
+                    "with tests and examples."
+                ),
+                content=(
+                    f"This demo GitHub evidence mentions {query.text} in code comments, README "
+                    "notes, and issue discussions so reranking has strong term overlap."
+                ),
+                source_channel="demo:github",
+                fetched_at=now,
+            ),
+            Evidence(
+                url=f"https://demo.local/forum/{encoded_query}",
+                title=f"Field report: teams evaluating {query.text}",
+                snippet=(
+                    f"A discussion thread where practitioners compare results for {query.text} "
+                    "across several approaches."
+                ),
+                content=(
+                    f"This demo forum thread explicitly repeats {query.text} while contrasting "
+                    "evidence quality, confidence, and remaining gaps."
+                ),
+                source_channel="demo:forum",
+                fetched_at=now,
+            ),
+        ]

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -1,12 +1,31 @@
 # Source: gpt-researcher/cli.py:L28-L216 (adapted)
+import asyncio
+import json
 from typing import Annotated
 
+import click
 import typer
 
 from autosearch import __version__
+from autosearch.channels.demo import DemoChannel
 from autosearch.core.models import SearchMode
+from autosearch.core.pipeline import Pipeline
+from autosearch.llm.client import LLMClient
 
-app = typer.Typer(add_completion=False, no_args_is_help=False)
+
+class _DefaultQueryGroup(typer.core.TyperGroup):
+    default_command = "query"
+
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        if args and not args[0].startswith("-") and args[0] not in self.commands:
+            command = self.get_command(ctx, self.default_command)
+            return self.default_command, command, args
+        return super().resolve_command(ctx, args)
+
+
+app = typer.Typer(add_completion=False, no_args_is_help=False, cls=_DefaultQueryGroup)
 
 
 def _version_callback(value: bool) -> None:
@@ -34,11 +53,49 @@ def main(
 
 @app.command()
 def query(
-    text: str,
+    query: Annotated[str, typer.Argument(help="The research question to run through AutoSearch.")],
     mode: Annotated[
-        SearchMode,
+        SearchMode | None,
         typer.Option("--mode", case_sensitive=False, help="Execution depth for the query."),
-    ] = SearchMode.FAST,
+    ] = None,
+    top_k: Annotated[
+        int,
+        typer.Option("--top-k", min=1, help="Maximum number of evidences to keep after reranking."),
+    ] = 20,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit a machine-readable JSON response envelope."),
+    ] = False,
 ) -> None:
-    _ = mode
-    typer.echo(f"M1: {text}")
+    try:
+        result = asyncio.run(
+            Pipeline(
+                llm=LLMClient(),
+                channels=[DemoChannel()],
+                top_k_evidence=top_k,
+            ).run(query, mode_hint=mode)
+        )
+    except Exception as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    if result.status == "needs_clarification":
+        typer.echo(result.clarification.question or "More detail is required.", err=True)
+        raise typer.Exit(code=2)
+
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "status": result.status,
+                    "markdown": result.markdown,
+                    "iterations": result.iterations,
+                    "quality_grade": (
+                        result.quality.grade.value if result.quality is not None else None
+                    ),
+                }
+            )
+        )
+        return
+
+    typer.echo(result.markdown or "")

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -1,0 +1,119 @@
+# Self-written, plan v2.3 § 13.5
+import json
+
+from typer.testing import CliRunner
+
+from autosearch.cli.main import app
+from autosearch.core.models import (
+    ClarifyResult,
+    EvaluationResult,
+    GradeOutcome,
+    SearchMode,
+)
+from autosearch.core.pipeline import PipelineResult
+
+runner = CliRunner()
+
+
+def _ok_result() -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown="# Test\n\nBody",
+        quality=EvaluationResult(
+            grade=GradeOutcome.PASS,
+            follow_up_gaps=[],
+        ),
+        iterations=2,
+    )
+
+
+def _clarification_result() -> PipelineResult:
+    return PipelineResult(
+        status="needs_clarification",
+        clarification=ClarifyResult(
+            need_clarification=True,
+            question="Which deployment target do you care about?",
+            verification=None,
+            rubrics=[],
+            mode=SearchMode.DEEP,
+        ),
+        iterations=0,
+    )
+
+
+class _StubDemoChannel:
+    def __init__(self, name: str = "demo") -> None:
+        self.name = name
+
+
+class _StubLLMClient:
+    pass
+
+
+def _install_cli_stubs(monkeypatch, pipeline_result: PipelineResult) -> None:
+    import autosearch.cli.main as cli_main
+
+    class StubPipeline:
+        def __init__(self, llm, channels, top_k_evidence: int) -> None:
+            self.llm = llm
+            self.channels = channels
+            self.top_k_evidence = top_k_evidence
+
+        async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+            _ = query
+            _ = mode_hint
+            return pipeline_result
+
+    monkeypatch.setattr(cli_main, "Pipeline", StubPipeline)
+    monkeypatch.setattr(cli_main, "LLMClient", _StubLLMClient)
+    monkeypatch.setattr(cli_main, "DemoChannel", _StubDemoChannel)
+
+
+def test_cli_query_prints_markdown_for_ok_result(monkeypatch) -> None:
+    _install_cli_stubs(monkeypatch, _ok_result())
+
+    result = runner.invoke(app, ["query", "test"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "# Test\n\nBody\n"
+
+
+def test_cli_bare_query_routes_to_query_command(monkeypatch) -> None:
+    _install_cli_stubs(monkeypatch, _ok_result())
+
+    result = runner.invoke(app, ["test"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "# Test\n\nBody\n"
+
+
+def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
+    _install_cli_stubs(monkeypatch, _ok_result())
+
+    result = runner.invoke(app, ["query", "test", "--json"])
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == {
+        "status": "ok",
+        "markdown": "# Test\n\nBody",
+        "iterations": 2,
+        "quality_grade": "pass",
+    }
+
+
+def test_cli_query_exits_two_for_needs_clarification(monkeypatch) -> None:
+    _install_cli_stubs(monkeypatch, _clarification_result())
+
+    result = runner.invoke(app, ["query", "test"])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert result.stderr == "Which deployment target do you care about?\n"

--- a/tests/unit/test_demo_channel.py
+++ b/tests/unit/test_demo_channel.py
@@ -1,0 +1,40 @@
+# Self-written, plan v2.3 § 13.5
+import inspect
+
+import pytest
+
+from autosearch.channels.demo import DemoChannel
+from autosearch.core.models import Evidence, SubQuery
+
+
+@pytest.mark.asyncio
+async def test_demo_channel_search_matches_channel_contract() -> None:
+    channel = DemoChannel()
+
+    assert channel.name == "demo"
+    assert inspect.iscoroutinefunction(channel.search)
+
+    results = await channel.search(
+        SubQuery(text="vector database tuning", rationale="Need demo evidence for ranking")
+    )
+
+    assert isinstance(results, list)
+    assert results
+    assert all(isinstance(item, Evidence) for item in results)
+
+
+@pytest.mark.asyncio
+async def test_demo_channel_returns_multiple_query_aware_sources() -> None:
+    query = SubQuery(
+        text="vector database tuning",
+        rationale="Need multiple sources that retain lexical overlap for BM25",
+    )
+
+    results = await DemoChannel().search(query)
+
+    assert len(results) >= 3
+    assert all(
+        query.text in evidence.title or query.text in (evidence.content or "")
+        for evidence in results
+    )
+    assert len({evidence.source_channel for evidence in results}) >= 2


### PR DESCRIPTION
## Summary
`autosearch "query"` now runs the full M0-M8 pipeline end-to-end and emits a markdown report. Uses `DemoChannel` as placeholder until real channel adapters land.

- `autosearch/cli/main.py` — `query` command: positional query, `--mode fast|deep`, `--top-k`, `--json`. Exit 0 on success, 2 on `needs_clarification`, 1 on exception. Also accepts bare `autosearch "..."` routed to `query`. Preserves `--version`.
- `autosearch/channels/demo.py` — `DemoChannel` production-legit placeholder returning canned evidences across distinct `source_channel` labels (demo:arxiv, demo:blog, demo:github) so `Sources breakdown` renders a table.
- `tests/unit/test_demo_channel.py` — Channel Protocol conformance + diverse source_channel + query-in-title assertions.
- `tests/unit/test_cli_query.py` — Typer CliRunner with mocked `Pipeline`: stdout markdown / --json envelope / needs_clarification exit 2.

## Test plan
- [x] `pytest -x -q -m "not network"` — 47 passed (41 + 6 new)
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] Provenance + PII scan clean

## Note
Real LLM call from `autosearch "..."` still requires env keys (ANTHROPIC/OPENAI/GOOGLE). With `LLMClient` and `DemoChannel` defaults, piping through the pipeline is ready — you can run manually with an API key to see real markdown output.

## Next
- Channel layer (if boss un-pauses)
- MCP Server (plan § 13.5 NO 1:1 SOURCE, ~1d)
- `autosearch init` dep orchestration (plan § 4.5)