### PR TITLE
feat: mcp server exposing research tool (plan § 13.5)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -99,3 +99,10 @@ def query(
         return
 
     typer.echo(result.markdown or "")
+
+
+@app.command()
+def mcp() -> None:
+    from autosearch.mcp.cli import main as mcp_main
+
+    mcp_main()

--- a/autosearch/mcp/__init__.py
+++ b/autosearch/mcp/__init__.py
@@ -1,0 +1,2 @@
+# Self-written, plan v2.3 § 13.5 MCP
+# Package marker for AutoSearch MCP server entry points.

--- a/autosearch/mcp/cli.py
+++ b/autosearch/mcp/cli.py
@@ -1,0 +1,6 @@
+# Self-written, plan v2.3 § 13.5
+from autosearch.mcp.server import create_server
+
+
+def main() -> None:
+    create_server().run(transport="stdio")

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -1,0 +1,46 @@
+# Self-written, plan v2.3 § 13.5 MCP Server (~1 day per plan)
+from collections.abc import Callable
+from typing import Literal
+
+from mcp.server.fastmcp import FastMCP
+
+from autosearch.channels.demo import DemoChannel
+from autosearch.core.models import SearchMode
+from autosearch.core.pipeline import Pipeline
+from autosearch.llm.client import LLMClient
+
+
+def _default_pipeline_factory() -> Pipeline:
+    return Pipeline(llm=LLMClient(), channels=[DemoChannel()])
+
+
+def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> FastMCP:
+    factory = pipeline_factory or _default_pipeline_factory
+    server = FastMCP(
+        name="autosearch",
+        instructions=(
+            "Deep research tool that runs the AutoSearch pipeline and returns "
+            "markdown reports or clarification prompts."
+        ),
+    )
+
+    @server.tool()
+    async def research(query: str, mode: Literal["fast", "deep"] = "fast") -> str:
+        """Run an AutoSearch research query and return the report text."""
+        try:
+            result = await factory().run(query, mode_hint=SearchMode(mode))
+        except Exception as exc:
+            return f"[error] {exc}"
+
+        if result.status == "needs_clarification":
+            question = result.clarification.question or "More detail is required."
+            return f"[clarification needed] {question}"
+
+        return result.markdown or ""
+
+    @server.tool()
+    def health() -> str:
+        """Return a cheap liveness indicator for MCP clients."""
+        return "ok"
+
+    return server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
   "fastapi",
   "httpx",
+  "mcp",
   "pydantic",
   "pytest",
   "pytest-asyncio",
@@ -26,6 +27,7 @@ dependencies = [
 
 [project.scripts]
 autosearch = "autosearch.cli.main:app"
+autosearch-mcp = "autosearch.mcp.cli:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,142 @@
+# Self-written, plan v2.3 § 13.5
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+import autosearch.mcp.server as mcp_server
+from autosearch.core.models import ClarifyResult, SearchMode
+from autosearch.core.pipeline import PipelineResult
+
+
+def _ok_result() -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown="# Test\n\nBody",
+        iterations=1,
+    )
+
+
+def _clarification_result() -> PipelineResult:
+    return PipelineResult(
+        status="needs_clarification",
+        clarification=ClarifyResult(
+            need_clarification=True,
+            question="Which deployment target matters most?",
+            verification=None,
+            rubrics=[],
+            mode=SearchMode.DEEP,
+        ),
+        iterations=0,
+    )
+
+
+class _StubPipeline:
+    def __init__(
+        self,
+        result: PipelineResult | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        self.result = result
+        self.exc = exc
+        self.calls: list[tuple[str, SearchMode | None]] = []
+
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+    ) -> PipelineResult:
+        self.calls.append((query, mode_hint))
+        if self.exc is not None:
+            raise self.exc
+        assert self.result is not None
+        return self.result
+
+
+def _install_default_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    pipeline: _StubPipeline,
+) -> None:
+    monkeypatch.setattr(
+        mcp_server,
+        "_default_pipeline_factory",
+        lambda: pipeline,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_server_returns_fastmcp_named_autosearch() -> None:
+    server = mcp_server.create_server()
+
+    assert isinstance(server, FastMCP)
+    assert server.name == "autosearch"
+
+
+@pytest.mark.asyncio
+async def test_create_server_registers_research_tool() -> None:
+    server = mcp_server.create_server()
+
+    tools = await server.list_tools()
+
+    assert {tool.name for tool in tools} >= {"research", "health"}
+
+
+@pytest.mark.asyncio
+async def test_research_tool_returns_markdown_for_ok_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _StubPipeline(result=_ok_result())
+    _install_default_factory(monkeypatch, pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+    assert await research_tool.run({"query": "test query", "mode": "fast"}) == "# Test\n\nBody"
+    assert pipeline.calls == [("test query", SearchMode.FAST)]
+
+
+@pytest.mark.asyncio
+async def test_research_tool_returns_clarification_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _StubPipeline(result=_clarification_result())
+    _install_default_factory(monkeypatch, pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+    result = await research_tool.run({"query": "test query", "mode": "deep"})
+    assert result.startswith("[clarification needed]")
+    assert pipeline.calls == [("test query", SearchMode.DEEP)]
+
+
+@pytest.mark.asyncio
+async def test_research_tool_returns_error_prefix_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _StubPipeline(exc=RuntimeError("boom"))
+    _install_default_factory(monkeypatch, pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+    assert await research_tool.run({"query": "test query", "mode": "fast"}) == "[error] boom"
+    assert pipeline.calls == [("test query", SearchMode.FAST)]
+
+
+@pytest.mark.asyncio
+async def test_health_tool_returns_ok() -> None:
+    server = mcp_server.create_server()
+
+    health_tool = server._tool_manager.get_tool("health")
+
+    assert health_tool is not None
+    assert await health_tool.run({}) == "ok"


### PR DESCRIPTION
## Summary
Adds MCP (Model Context Protocol) server so Claude Code / Cursor / other MCP clients can call autosearch's pipeline as a tool.

- `autosearch/mcp/server.py` — `FastMCP`-based server with two tools: **`research(query, mode)`** runs `Pipeline.run()` and returns markdown; **`health()`** for liveness
- `autosearch/mcp/cli.py` — stdio entry point (`autosearch-mcp` console script)
- `autosearch/cli/main.py` — new `autosearch mcp` subcommand (lazy import) alongside existing `query` + `--version`
- `pyproject.toml` — adds `mcp` SDK dep + `autosearch-mcp` console script
- `tests/unit/test_mcp_server.py` — 6 tests covering server creation / tool registration / ok / needs_clarification / error / health

## Test plan
- [x] `pytest -x -q -m "not network"` — 53 passed (47 existing + 6 new)
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `python -c "from autosearch.mcp.server import create_server"` succeeds
- [x] Provenance + PII/codename/abs-path scan clean

## Usage
MCP clients can launch with:
```json
{
  "mcpServers": {
    "autosearch": { "command": "autosearch-mcp" }
  }
}
```
Or `autosearch mcp` from a venv shell.

## Note
Codex sandbox couldn't `uv pip install` the new `mcp` SDK; testing ran via PYTHONPATH shim there. Local (this machine) confirmed all 53 tests green against the real SDK.

## Next
- `autosearch init` dep orchestration (plan § 4.5)
- Channel layer impls (when unpaused)
- plan update to record spike 2 findings