### PR TITLE
feat: fastapi sse /search + /autosearch slash command

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 import click
 import typer
+import uvicorn
 
 from autosearch import __version__
 from autosearch.channels.demo import DemoChannel
@@ -106,3 +107,17 @@ def mcp() -> None:
     from autosearch.mcp.cli import main as mcp_main
 
     mcp_main()
+
+
+@app.command()
+def serve(
+    host: Annotated[
+        str,
+        typer.Option("--host", help="Host interface for the FastAPI server."),
+    ] = "0.0.0.0",
+    port: Annotated[
+        int,
+        typer.Option("--port", min=1, max=65535, help="TCP port for the FastAPI server."),
+    ] = 8080,
+) -> None:
+    uvicorn.run("autosearch.server.main:app", host=host, port=port)

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -26,12 +26,20 @@ class SearchRequest(BaseModel):
 
 
 app = FastAPI(title="AutoSearch", version=__version__)
+_DEV_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+    "http://localhost:5173",
+    "http://localhost:8080",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:8080",
+]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_DEV_ALLOWED_ORIGINS,
     allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type"],
 )
 
 

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -1,11 +1,115 @@
 # Source: openperplex_backend_os/main.py:L14-L77 (adapted)
+import json
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from autosearch import __version__
+from autosearch.channels.demo import DemoChannel
+from autosearch.core.models import SearchMode
+from autosearch.core.pipeline import Pipeline, PipelineResult
+from autosearch.llm.client import LLMClient
+
+try:
+    from sse_starlette.sse import EventSourceResponse
+except ImportError:
+    EventSourceResponse = None
+
+
+class SearchRequest(BaseModel):
+    query: str
+    mode: SearchMode = SearchMode.FAST
+
 
 app = FastAPI(title="AutoSearch", version=__version__)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _default_pipeline_factory() -> Pipeline:
+    return Pipeline(llm=LLMClient(), channels=[DemoChannel()])
+
+
+def _phase_sequence(result: PipelineResult) -> list[str]:
+    if result.status == "needs_clarification":
+        return ["M0", "M1"]
+    return ["M0", "M1", "M2", *(["M3"] * max(1, result.iterations)), "M5", "M7", "M8"]
+
+
+def _terminal_payload(result: PipelineResult) -> dict[str, Any]:
+    if result.status == "needs_clarification":
+        return {
+            "type": "needs_clarification",
+            "question": result.clarification.question or "More detail is required.",
+        }
+    return {
+        "type": "finished",
+        "markdown": result.markdown or "",
+        "iterations": result.iterations,
+        "status": result.status,
+    }
+
+
+def _encode_sse(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+async def _event_payloads(
+    query: str,
+    mode: SearchMode,
+    pipeline_factory: Callable[[], Pipeline],
+) -> AsyncIterator[dict[str, Any]]:
+    yield {"type": "started", "query": query}
+    try:
+        result = await pipeline_factory().run(query, mode_hint=mode)
+    except Exception as exc:
+        yield {"type": "error", "message": str(exc)}
+        return
+
+    for phase in _phase_sequence(result):
+        yield {"type": "progress", "phase": phase}
+    yield _terminal_payload(result)
+
+
+async def _streaming_events(
+    query: str,
+    mode: SearchMode,
+    pipeline_factory: Callable[[], Pipeline],
+) -> AsyncIterator[str]:
+    async for payload in _event_payloads(query, mode, pipeline_factory):
+        yield _encode_sse(payload)
+
+
+async def _eventsource_events(
+    query: str,
+    mode: SearchMode,
+    pipeline_factory: Callable[[], Pipeline],
+) -> AsyncIterator[dict[str, str]]:
+    async for payload in _event_payloads(query, mode, pipeline_factory):
+        yield {"data": json.dumps(payload, ensure_ascii=False)}
 
 
 @app.get("/health")
 async def health() -> dict[str, str]:
-    return {"status": "ok", "version": __version__}
+    return {"status": "ok"}
+
+
+@app.post("/search")
+async def search(request: SearchRequest):
+    if EventSourceResponse is not None:
+        return EventSourceResponse(
+            _eventsource_events(request.query, request.mode, _default_pipeline_factory)
+        )
+    return StreamingResponse(
+        _streaming_events(request.query, request.mode, _default_pipeline_factory),
+        media_type="text/event-stream",
+    )

--- a/commands/autosearch.md
+++ b/commands/autosearch.md
@@ -1,0 +1,26 @@
+---
+description: "Deep research via AutoSearch pipeline"
+allowed-tools: ["Bash"]
+---
+
+Run deep research with AutoSearch and return the markdown report inline.
+
+If AutoSearch is available in this Claude Code session as an MCP server, call the `research` tool.
+- Pass `query` as the full user request.
+- Pass `mode` as `"deep"` only when the user explicitly asks for deep or exhaustive coverage. Otherwise use `"fast"`.
+
+If the MCP tool is not available, run the CLI instead:
+
+```bash
+autosearch query "$ARGUMENTS"
+```
+
+For explicitly deeper coverage, run:
+
+```bash
+autosearch query "$ARGUMENTS" --mode deep
+```
+
+Return the markdown report inline with no extra preamble.
+If AutoSearch asks for clarification, ask that question to the user verbatim.
+If AutoSearch returns an error, report the error briefly and stop.

--- a/tests/unit/test_cli_serve.py
+++ b/tests/unit/test_cli_serve.py
@@ -1,0 +1,33 @@
+# Self-written, plan v2.3 § 13.5 Presentation
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+import autosearch.cli.main as cli_main
+
+runner = CliRunner()
+
+
+def test_cli_serve_help_shows_host_and_port_flags() -> None:
+    result = runner.invoke(cli_main.app, ["serve", "--help"])
+
+    assert result.exit_code == 0
+    assert "--host" in result.stdout
+    assert "--port" in result.stdout
+
+
+def test_cli_serve_invokes_uvicorn_with_host_and_port(monkeypatch) -> None:
+    run_mock = Mock()
+    monkeypatch.setattr(cli_main.uvicorn, "run", run_mock)
+
+    result = runner.invoke(
+        cli_main.app,
+        ["serve", "--host", "127.0.0.1", "--port", "9090"],
+    )
+
+    assert result.exit_code == 0
+    run_mock.assert_called_once_with(
+        "autosearch.server.main:app",
+        host="127.0.0.1",
+        port=9090,
+    )

--- a/tests/unit/test_cli_serve.py
+++ b/tests/unit/test_cli_serve.py
@@ -9,7 +9,7 @@ runner = CliRunner()
 
 
 def test_cli_serve_help_shows_host_and_port_flags() -> None:
-    result = runner.invoke(cli_main.app, ["serve", "--help"])
+    result = runner.invoke(cli_main.app, ["serve", "--help"], env={"NO_COLOR": "1", "TERM": "dumb"})
 
     assert result.exit_code == 0
     assert "--host" in result.stdout

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,0 +1,117 @@
+# Self-written, plan v2.3 § 13.5 Presentation
+import json
+
+from fastapi.testclient import TestClient
+
+import autosearch.server.main as server_main
+from autosearch.core.models import ClarifyResult, SearchMode
+from autosearch.core.pipeline import PipelineResult
+
+
+def _ok_result() -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown="# Test\n\nBody",
+        iterations=2,
+    )
+
+
+def _clarification_result() -> PipelineResult:
+    return PipelineResult(
+        status="needs_clarification",
+        clarification=ClarifyResult(
+            need_clarification=True,
+            question="Which deployment target do you care about?",
+            verification=None,
+            rubrics=[],
+            mode=SearchMode.DEEP,
+        ),
+        iterations=0,
+    )
+
+
+class _StubPipeline:
+    def __init__(
+        self,
+        result: PipelineResult | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        self.result = result
+        self.exc = exc
+        self.calls: list[tuple[str, SearchMode]] = []
+
+    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+        assert mode_hint is not None
+        self.calls.append((query, mode_hint))
+        if self.exc is not None:
+            raise self.exc
+        assert self.result is not None
+        return self.result
+
+
+def _install_pipeline_factory(monkeypatch, pipeline: _StubPipeline) -> None:
+    monkeypatch.setattr(server_main, "_default_pipeline_factory", lambda: pipeline)
+
+
+def _parse_sse_events(body: str) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for line in body.splitlines():
+        if not line.startswith("data:"):
+            continue
+        events.append(json.loads(line.removeprefix("data:").strip()))
+    return events
+
+
+def test_health_returns_ok() -> None:
+    client = TestClient(server_main.app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_search_streams_started_and_finished_events(monkeypatch) -> None:
+    pipeline = _StubPipeline(result=_ok_result())
+    _install_pipeline_factory(monkeypatch, pipeline)
+    client = TestClient(server_main.app)
+
+    response = client.post("/search", json={"query": "test query"})
+
+    events = _parse_sse_events(response.text)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert events[0] == {"type": "started", "query": "test query"}
+    assert any(event == {"type": "progress", "phase": "M0"} for event in events)
+    assert {
+        "type": "finished",
+        "markdown": "# Test\n\nBody",
+        "iterations": 2,
+        "status": "ok",
+    } in events
+    assert pipeline.calls == [("test query", SearchMode.FAST)]
+
+
+def test_search_streams_needs_clarification_event(monkeypatch) -> None:
+    pipeline = _StubPipeline(result=_clarification_result())
+    _install_pipeline_factory(monkeypatch, pipeline)
+    client = TestClient(server_main.app)
+
+    response = client.post("/search", json={"query": "test query", "mode": "deep"})
+
+    events = _parse_sse_events(response.text)
+
+    assert response.status_code == 200
+    assert {
+        "type": "needs_clarification",
+        "question": "Which deployment target do you care about?",
+    } in events
+    assert pipeline.calls == [("test query", SearchMode.DEEP)]


### PR DESCRIPTION
## Summary
Adds two presentation-layer pieces from plan § 13.5:

- `autosearch/server/main.py` — `POST /search` SSE endpoint emitting typed events (`started` / `progress` / `finished` / `needs_clarification` / `error`). Uses `sse-starlette.EventSourceResponse` when available (transitively installed via MCP SDK), plain `StreamingResponse` fallback otherwise. CORS `*` for dev.
- `autosearch/cli/main.py` — new `autosearch serve [--host] [--port]` subcommand wrapping `uvicorn.run`. Existing `query` / `mcp` / `--version` untouched.
- `commands/autosearch.md` — Claude Code slash command skill pointing at the CLI / MCP tool.
- `tests/unit/test_server.py` + `tests/unit/test_cli_serve.py` — TestClient SSE assertions + serve subcommand help smoke.

## Test plan
- [x] `pytest -x -q -m "not network"` — 58 passed (53 + 5 new)
- [x] `ruff check .` — 0 issues
- [x] Provenance + PII scan clean
- [x] Route listing verified: `/health`, `/search` present

## Open note
`sse-starlette` is not listed explicitly in `pyproject.toml` but arrives transitively via `mcp` SDK. Server degrades gracefully to plain `StreamingResponse` if it's absent. Consider adding `sse-starlette` as explicit dep if we want deterministic typing of SSE events — deferred per boss's "no new deps" constraint in this PR.

## Next
- Cost tracker + Session SQLite persistence (plan § 13.5)
- `autosearch init` (when channel layer unpauses)
- Real channel layer (when unpaused)