### PR TITLE
feat: cost tracker + session sqlite store (plan § 13.5)

### DIFF
--- a/autosearch/observability/__init__.py
+++ b/autosearch/observability/__init__.py
@@ -1,0 +1,1 @@
+# Self-written, plan v2.3 § 13.5

--- a/autosearch/observability/cost.py
+++ b/autosearch/observability/cost.py
@@ -1,0 +1,122 @@
+# Source: gpt-researcher/gpt_researcher/utils/costs.py:L1-L51 (adapted)
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+try:
+    import tiktoken
+except ImportError:  # pragma: no cover - exercised via fallback path
+    tiktoken = None
+
+_DEFAULT_PRICING: dict[str, dict[str, float]] = {
+    "claude-3.5-sonnet": {"input_per_1k": 0.003, "output_per_1k": 0.015},
+    "claude-3-5-sonnet": {"input_per_1k": 0.003, "output_per_1k": 0.015},
+    "claude-code-local": {"input_per_1k": 0.0, "output_per_1k": 0.0},
+    "gemini-2.5-pro": {"input_per_1k": 0.00125, "output_per_1k": 0.01},
+    "gpt-4o": {"input_per_1k": 0.005, "output_per_1k": 0.015},
+}
+
+
+def estimate_tokens(text: str, model: str = "cl100k_base") -> int:
+    if not text:
+        return 0
+
+    if tiktoken is not None:
+        try:
+            encoding = tiktoken.get_encoding(model)
+        except Exception:
+            pass
+        else:
+            return len(encoding.encode(text))
+
+    return max(len(text.split()), 1)
+
+
+class CostTracker:
+    def __init__(
+        self,
+        pricing: Mapping[str, Mapping[str, float]] | None = None,
+        config_env_var: str = "AUTOSEARCH_COST_CONFIG",
+    ) -> None:
+        self._pricing = {model: price.copy() for model, price in _DEFAULT_PRICING.items()}
+        self._pricing.update(self._load_config_from_env(config_env_var))
+        if pricing is not None:
+            self._pricing.update(_normalize_pricing(pricing))
+        self._running_total = 0.0
+        self._model_totals: dict[str, dict[str, int | float]] = {}
+
+    def add_usage(self, model: str, input_tokens: int, output_tokens: int) -> float:
+        pricing = self._lookup_pricing(model)
+        input_cost = (input_tokens / 1000) * pricing["input_per_1k"]
+        output_cost = (output_tokens / 1000) * pricing["output_per_1k"]
+        call_cost = input_cost + output_cost
+
+        totals = self._model_totals.setdefault(
+            model,
+            {"input_tokens": 0, "output_tokens": 0, "cost": 0.0},
+        )
+        totals["input_tokens"] = int(totals["input_tokens"]) + input_tokens
+        totals["output_tokens"] = int(totals["output_tokens"]) + output_tokens
+        totals["cost"] = float(totals["cost"]) + call_cost
+
+        self._running_total += call_cost
+        return call_cost
+
+    def total(self) -> float:
+        return self._running_total
+
+    def breakdown(self) -> dict[str, dict[str, int | float]]:
+        return {model: values.copy() for model, values in self._model_totals.items()}
+
+    def _load_config_from_env(self, env_var: str) -> dict[str, dict[str, float]]:
+        config_path = os.getenv(env_var)
+        if not config_path:
+            return {}
+        payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
+        if not isinstance(payload, Mapping):
+            raise ValueError(f"{env_var} must point to a JSON object.")
+        return _normalize_pricing(payload)
+
+    def _lookup_pricing(self, model: str) -> dict[str, float]:
+        if model in self._pricing:
+            return self._pricing[model]
+
+        prefix_matches = [
+            (key, price)
+            for key, price in self._pricing.items()
+            if model.startswith(key) or key.startswith(model)
+        ]
+        if prefix_matches:
+            _, price = max(prefix_matches, key=lambda item: len(item[0]))
+            return price
+
+        return {"input_per_1k": 0.0, "output_per_1k": 0.0}
+
+
+def _normalize_pricing(
+    pricing: Mapping[str, Mapping[str, float] | dict[str, Any]],
+) -> dict[str, dict[str, float]]:
+    normalized: dict[str, dict[str, float]] = {}
+    for model, raw_value in pricing.items():
+        if not isinstance(raw_value, Mapping):
+            raise ValueError(f"Pricing entry for {model!r} must be a JSON object.")
+        normalized[model] = {
+            "input_per_1k": float(
+                raw_value.get(
+                    "input_per_1k",
+                    raw_value.get("input", raw_value.get("input_cost_per_1k", 0.0)),
+                )
+            ),
+            "output_per_1k": float(
+                raw_value.get(
+                    "output_per_1k",
+                    raw_value.get("output", raw_value.get("output_cost_per_1k", 0.0)),
+                )
+            ),
+        }
+    return normalized
+
+
+__all__ = ["CostTracker", "estimate_tokens"]

--- a/autosearch/persistence/__init__.py
+++ b/autosearch/persistence/__init__.py
@@ -1,0 +1,1 @@
+# Self-written, plan v2.3 § 13.5

--- a/autosearch/persistence/session_store.py
+++ b/autosearch/persistence/session_store.py
@@ -1,0 +1,297 @@
+# Source: crawl4ai/crawl4ai/async_database.py:L230-L249 (adapted)
+import asyncio
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Self
+
+from autosearch.core.models import Evidence
+
+try:
+    import aiosqlite
+except ImportError:  # pragma: no cover - compatibility path for blocked installs
+
+    class _FallbackCursor:
+        def __init__(self, cursor: sqlite3.Cursor) -> None:
+            self._cursor = cursor
+
+        async def fetchone(self) -> sqlite3.Row | None:
+            return self._cursor.fetchone()
+
+        async def fetchall(self) -> list[sqlite3.Row]:
+            return self._cursor.fetchall()
+
+        async def close(self) -> None:
+            self._cursor.close()
+
+    class _FallbackConnection:
+        def __init__(self, database: str) -> None:
+            self._connection = sqlite3.connect(database, check_same_thread=False)
+
+        @property
+        def row_factory(self) -> Any:
+            return self._connection.row_factory
+
+        @row_factory.setter
+        def row_factory(self, value: Any) -> None:
+            self._connection.row_factory = value
+
+        async def execute(
+            self,
+            query: str,
+            params: tuple[Any, ...] = (),
+        ) -> _FallbackCursor:
+            return _FallbackCursor(self._connection.execute(query, params))
+
+        async def executescript(self, script: str) -> None:
+            self._connection.executescript(script)
+
+        async def commit(self) -> None:
+            self._connection.commit()
+
+        async def close(self) -> None:
+            self._connection.close()
+
+    class _FallbackAioSqliteModule:
+        Connection = _FallbackConnection
+        Row = sqlite3.Row
+
+        @staticmethod
+        async def connect(database: str) -> _FallbackConnection:
+            return _FallbackConnection(database)
+
+    aiosqlite = _FallbackAioSqliteModule()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class SessionStore:
+    def __init__(self, connection: aiosqlite.Connection, db_path: str | Path) -> None:
+        self._connection: aiosqlite.Connection | None = connection
+        self.db_path = db_path
+        self._write_lock = asyncio.Lock()
+
+    @classmethod
+    async def open(cls, db_path: str | Path) -> Self:
+        database = str(db_path)
+        if database != ":memory:":
+            Path(database).parent.mkdir(parents=True, exist_ok=True)
+
+        connection = await aiosqlite.connect(database)
+        connection.row_factory = aiosqlite.Row
+
+        store = cls(connection=connection, db_path=db_path)
+        await store._initialize()
+        return store
+
+    async def close(self) -> None:
+        if self._connection is None:
+            return
+        await self._connection.close()
+        self._connection = None
+
+    async def create_session(self, session_id: str, query: str, mode: str) -> None:
+        async with self._write_lock:
+            await self._connection_or_raise().execute(
+                """
+                INSERT INTO sessions (
+                    id,
+                    query,
+                    mode,
+                    started_at,
+                    finished_at,
+                    status,
+                    markdown,
+                    cost
+                ) VALUES (?, ?, ?, ?, NULL, ?, NULL, 0.0)
+                """,
+                (session_id, query, mode, _utc_now().isoformat(), "started"),
+            )
+            await self._connection_or_raise().commit()
+
+    async def finish_session(
+        self,
+        session_id: str,
+        status: str,
+        markdown: str | None,
+        cost: float,
+    ) -> None:
+        async with self._write_lock:
+            await self._connection_or_raise().execute(
+                """
+                UPDATE sessions
+                SET finished_at = ?, status = ?, markdown = ?, cost = ?
+                WHERE id = ?
+                """,
+                (_utc_now().isoformat(), status, markdown, cost, session_id),
+            )
+            await self._connection_or_raise().commit()
+
+    async def add_evidence(self, session_id: str, rank: int, evidence: Evidence) -> None:
+        async with self._write_lock:
+            await self._connection_or_raise().execute(
+                """
+                INSERT OR REPLACE INTO evidence (
+                    session_id,
+                    rank,
+                    url,
+                    title,
+                    snippet,
+                    source_channel,
+                    score
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    rank,
+                    evidence.url,
+                    evidence.title,
+                    evidence.snippet,
+                    evidence.source_channel,
+                    evidence.score,
+                ),
+            )
+            await self._connection_or_raise().commit()
+
+    async def add_query_log(
+        self,
+        session_id: str,
+        subquery: str,
+        channel: str,
+        results: int,
+    ) -> None:
+        async with self._write_lock:
+            await self._connection_or_raise().execute(
+                """
+                INSERT INTO query_log (session_id, subquery, issued_at, channel, results)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (session_id, subquery, _utc_now().isoformat(), channel, results),
+            )
+            await self._connection_or_raise().commit()
+
+    async def fetch_session(self, session_id: str) -> dict[str, Any] | None:
+        connection = self._connection_or_raise()
+        session = await self._fetch_one(
+            connection,
+            """
+            SELECT id, query, mode, started_at, finished_at, status, markdown, cost
+            FROM sessions
+            WHERE id = ?
+            """,
+            (session_id,),
+        )
+        if session is None:
+            return None
+
+        evidence_rows = await self._fetch_all(
+            connection,
+            """
+            SELECT session_id, rank, url, title, snippet, source_channel, score
+            FROM evidence
+            WHERE session_id = ?
+            ORDER BY rank ASC
+            """,
+            (session_id,),
+        )
+        query_log_rows = await self._fetch_all(
+            connection,
+            """
+            SELECT session_id, subquery, issued_at, channel, results
+            FROM query_log
+            WHERE session_id = ?
+            ORDER BY issued_at ASC
+            """,
+            (session_id,),
+        )
+
+        payload = dict(session)
+        payload["evidence"] = [dict(row) for row in evidence_rows]
+        payload["query_log"] = [dict(row) for row in query_log_rows]
+        return payload
+
+    async def list_recent(self, limit: int = 20) -> list[dict[str, Any]]:
+        rows = await self._fetch_all(
+            self._connection_or_raise(),
+            """
+            SELECT id, query, mode, started_at, finished_at, status, markdown, cost
+            FROM sessions
+            ORDER BY started_at DESC, id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        return [dict(row) for row in rows]
+
+    async def _initialize(self) -> None:
+        async with self._write_lock:
+            connection = self._connection_or_raise()
+            await connection.execute("PRAGMA foreign_keys = ON")
+            await connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY,
+                    query TEXT NOT NULL,
+                    mode TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    finished_at TEXT NULL,
+                    status TEXT NOT NULL,
+                    markdown TEXT NULL,
+                    cost REAL DEFAULT 0.0
+                );
+
+                CREATE TABLE IF NOT EXISTS evidence (
+                    session_id TEXT NOT NULL,
+                    rank INTEGER NOT NULL,
+                    url TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    snippet TEXT NULL,
+                    source_channel TEXT NOT NULL,
+                    score REAL NULL,
+                    PRIMARY KEY (session_id, rank),
+                    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS query_log (
+                    session_id TEXT NOT NULL,
+                    subquery TEXT NOT NULL,
+                    issued_at TEXT NOT NULL,
+                    channel TEXT NOT NULL,
+                    results INTEGER NOT NULL,
+                    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+                );
+                """
+            )
+            await connection.commit()
+
+    def _connection_or_raise(self) -> aiosqlite.Connection:
+        if self._connection is None:
+            raise RuntimeError("SessionStore is not open.")
+        return self._connection
+
+    async def _fetch_one(
+        self,
+        connection: aiosqlite.Connection,
+        query: str,
+        params: tuple[Any, ...],
+    ) -> aiosqlite.Row | None:
+        cursor = await connection.execute(query, params)
+        try:
+            return await cursor.fetchone()
+        finally:
+            await cursor.close()
+
+    async def _fetch_all(
+        self,
+        connection: aiosqlite.Connection,
+        query: str,
+        params: tuple[Any, ...],
+    ) -> list[aiosqlite.Row]:
+        cursor = await connection.execute(query, params)
+        try:
+            rows = await cursor.fetchall()
+        finally:
+            await cursor.close()
+        return list(rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "AutoSearch v2 M1 skeleton"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+  "aiosqlite",
   "fastapi",
   "httpx",
   "mcp",
@@ -20,6 +21,7 @@ dependencies = [
   "ruff",
   "simhash",
   "structlog",
+  "tiktoken",
   "trafilatura",
   "typer",
   "uvicorn",

--- a/tests/unit/test_cost_tracker.py
+++ b/tests/unit/test_cost_tracker.py
@@ -1,0 +1,56 @@
+# Self-written, plan v2.3 § 13.5
+import pytest
+
+import autosearch.observability.cost as cost_module
+from autosearch.observability.cost import CostTracker, estimate_tokens
+
+
+def test_add_usage_returns_expected_cost_for_known_price_table() -> None:
+    tracker = CostTracker()
+
+    cost = tracker.add_usage("gpt-4o", input_tokens=1000, output_tokens=500)
+
+    assert cost == pytest.approx(0.0125)
+
+
+def test_total_sums_costs_across_multiple_models() -> None:
+    tracker = CostTracker()
+
+    tracker.add_usage("gpt-4o", input_tokens=1000, output_tokens=1000)
+    tracker.add_usage("claude-3.5-sonnet", input_tokens=500, output_tokens=500)
+
+    assert tracker.total() == pytest.approx(0.029)
+
+
+def test_breakdown_returns_per_model_totals() -> None:
+    tracker = CostTracker()
+
+    tracker.add_usage("gpt-4o", input_tokens=100, output_tokens=200)
+    tracker.add_usage("gpt-4o", input_tokens=50, output_tokens=25)
+    tracker.add_usage("claude-code-local", input_tokens=200, output_tokens=200)
+
+    breakdown = tracker.breakdown()
+
+    assert set(breakdown) == {"gpt-4o", "claude-code-local"}
+    assert breakdown["gpt-4o"]["input_tokens"] == 150
+    assert breakdown["gpt-4o"]["output_tokens"] == 225
+    assert breakdown["gpt-4o"]["cost"] == pytest.approx(0.004125)
+    assert breakdown["claude-code-local"]["input_tokens"] == 200
+    assert breakdown["claude-code-local"]["output_tokens"] == 200
+    assert breakdown["claude-code-local"]["cost"] == pytest.approx(0.0)
+
+
+def test_estimate_tokens_falls_back_when_tiktoken_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingTiktoken:
+        @staticmethod
+        def get_encoding(name: str) -> None:
+            raise KeyError(name)
+
+    monkeypatch.setattr(cost_module, "tiktoken", FailingTiktoken())
+
+    estimated = estimate_tokens("one two three", model="cl100k_base")
+
+    assert isinstance(estimated, int)
+    assert estimated > 0

--- a/tests/unit/test_session_store.py
+++ b/tests/unit/test_session_store.py
@@ -1,0 +1,135 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import UTC, datetime
+
+import autosearch.persistence.session_store as session_store_module
+from autosearch.core.models import Evidence
+from autosearch.persistence.session_store import SessionStore
+
+
+def _make_evidence(url: str, title: str) -> Evidence:
+    return Evidence(
+        url=url,
+        title=title,
+        snippet="Short snippet",
+        content="Full content",
+        source_channel="web",
+        fetched_at=datetime(2026, 4, 17, 9, 0, tzinfo=UTC),
+        score=0.9,
+    )
+
+
+async def test_create_session_fetches_started_row() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "find sqlite patterns", "deep")
+
+        session = await store.fetch_session("session-1")
+    finally:
+        await store.close()
+
+    assert session is not None
+    assert session["id"] == "session-1"
+    assert session["query"] == "find sqlite patterns"
+    assert session["mode"] == "deep"
+    assert session["status"] == "started"
+    assert session["finished_at"] is None
+    assert session["markdown"] is None
+    assert session["cost"] == 0.0
+
+
+async def test_finish_session_updates_markdown_cost_and_finished_at(
+    monkeypatch,
+) -> None:
+    timestamps = iter(
+        [
+            datetime(2026, 4, 17, 9, 0, tzinfo=UTC),
+            datetime(2026, 4, 17, 9, 5, tzinfo=UTC),
+        ]
+    )
+    monkeypatch.setattr(session_store_module, "_utc_now", lambda: next(timestamps))
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "fast")
+        await store.finish_session("session-1", "completed", "# Report", 1.75)
+
+        session = await store.fetch_session("session-1")
+    finally:
+        await store.close()
+
+    assert session is not None
+    assert session["status"] == "completed"
+    assert session["markdown"] == "# Report"
+    assert session["cost"] == 1.75
+    assert session["finished_at"] == "2026-04-17T09:05:00+00:00"
+
+
+async def test_add_evidence_is_retrievable_from_session() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        await store.add_evidence(
+            "session-1",
+            1,
+            _make_evidence("https://example.com/evidence", "Evidence Title"),
+        )
+
+        session = await store.fetch_session("session-1")
+    finally:
+        await store.close()
+
+    assert session is not None
+    assert session["evidence"] == [
+        {
+            "session_id": "session-1",
+            "rank": 1,
+            "url": "https://example.com/evidence",
+            "title": "Evidence Title",
+            "snippet": "Short snippet",
+            "source_channel": "web",
+            "score": 0.9,
+        }
+    ]
+
+
+async def test_list_recent_returns_reverse_chronological_order(monkeypatch) -> None:
+    timestamps = iter(
+        [
+            datetime(2026, 4, 17, 9, 0, tzinfo=UTC),
+            datetime(2026, 4, 17, 9, 10, tzinfo=UTC),
+        ]
+    )
+    monkeypatch.setattr(session_store_module, "_utc_now", lambda: next(timestamps))
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "earlier", "fast")
+        await store.create_session("session-2", "later", "deep")
+
+        recent = await store.list_recent()
+    finally:
+        await store.close()
+
+    assert [item["id"] for item in recent] == ["session-2", "session-1"]
+
+
+async def test_add_query_log_is_retrievable_from_session() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        await store.add_query_log("session-1", "sqlite async pool", "web", 7)
+
+        session = await store.fetch_session("session-1")
+    finally:
+        await store.close()
+
+    assert session is not None
+    assert len(session["query_log"]) == 1
+    assert session["query_log"][0]["session_id"] == "session-1"
+    assert session["query_log"][0]["subquery"] == "sqlite async pool"
+    assert session["query_log"][0]["channel"] == "web"
+    assert session["query_log"][0]["results"] == 7
+    assert session["query_log"][0]["issued_at"]


### PR DESCRIPTION
## Summary
Two plan § 13.5 observability/persistence primitives; not yet wired into `Pipeline` (separate PR).

- `autosearch/observability/cost.py` — `CostTracker`: per-call LLM cost via tiktoken (with split-count fallback), per-model price table, override via `AUTOSEARCH_COST_CONFIG` JSON
- `autosearch/persistence/session_store.py` — `SessionStore`: async aiosqlite pool, three-table schema (`sessions / evidence / query_log`), stdlib sqlite fallback

## Test plan
- [x] `pytest -x -q -m "not network"` — 67 passed (58 + 9 new)
- [x] `ruff check .` — 0 issues
- [x] Provenance + PII scan clean
- [x] deps added: `aiosqlite`, `tiktoken`

## Next
- Wire `CostTracker` into `LLMClient.complete` hook + `SessionStore` into `Pipeline` orchestrator (separate PR)