### PR TITLE
feat: wire cost + session into pipeline

### DIFF
--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -1,6 +1,8 @@
 # Self-written, plan v2.3 § 13.5
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -85,3 +87,15 @@ class EvaluationResult(BaseModel):
 
     grade: GradeOutcome
     follow_up_gaps: list[Gap]
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    status: Literal["ok", "needs_clarification"]
+    clarification: ClarifyResult
+    markdown: str | None = None
+    evidences: list[Evidence] = field(default_factory=list)
+    quality: EvaluationResult | None = None
+    iterations: int = 0
+    session_id: str | None = None
+    cost: float = 0.0

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -1,7 +1,7 @@
 # Self-written, plan v2.3 § 2
+import asyncio
 import re
-from dataclasses import dataclass, field
-from typing import Literal
+import uuid
 
 import structlog
 
@@ -12,17 +12,18 @@ from autosearch.core.iteration import IterationBudget, IterationController
 from autosearch.core.knowledge import KnowledgeRecaller
 from autosearch.core.models import (
     ClarifyRequest,
-    ClarifyResult,
-    EvaluationResult,
     Evidence,
     Gap,
     GradeOutcome,
+    PipelineResult,
     SearchMode,
     Section,
     SubQuery,
 )
 from autosearch.core.strategy import QueryStrategist
 from autosearch.llm.client import LLMClient
+from autosearch.observability.cost import CostTracker
+from autosearch.persistence.session_store import SessionStore
 from autosearch.quality.gate import QualityGate
 from autosearch.synthesis.report import ReportSynthesizer
 
@@ -30,28 +31,24 @@ _SECTION_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
 
 
-@dataclass(frozen=True)
-class PipelineResult:
-    status: Literal["ok", "needs_clarification"]
-    clarification: ClarifyResult
-    markdown: str | None = None
-    evidences: list[Evidence] = field(default_factory=list)
-    quality: EvaluationResult | None = None
-    iterations: int = 0
-
-
 class Pipeline:
     def __init__(
         self,
-        llm: LLMClient,
-        channels: list[Channel],
+        llm: LLMClient | None = None,
+        channels: list[Channel] | None = None,
         budget: IterationBudget = IterationBudget(),
         top_k_evidence: int = 20,
+        cost_tracker: CostTracker | None = None,
+        session_store: SessionStore | None = None,
     ) -> None:
-        self.llm = llm
-        self.channels = channels
+        self.llm = llm or LLMClient(cost_tracker=cost_tracker)
+        if cost_tracker is not None:
+            self.llm.cost_tracker = cost_tracker
+        self.cost_tracker = self.llm.cost_tracker
+        self.channels = list(channels or [])
         self.budget = budget
         self.top_k_evidence = top_k_evidence
+        self.session_store = session_store
         self.knowledge_recaller = KnowledgeRecaller()
         self.clarifier = Clarifier()
         self.query_strategist = QueryStrategist()
@@ -66,179 +63,219 @@ class Pipeline:
         mode_hint: SearchMode | None = None,
     ) -> PipelineResult:
         iteration_controller = _TrackingIterationController(
-            evidence_processor=self.evidence_processor
+            evidence_processor=self.evidence_processor,
+            session_store=self.session_store,
+            session_id=_new_session_id() if self.session_store is not None else None,
         )
+        session_id = iteration_controller.session_id
+        session_created = False
+        session_mode = mode_hint.value if mode_hint is not None else None
+        final_status = "error"
+        final_markdown: str | None = None
 
-        self.logger.info("pipeline_phase_started", phase="m0_recall", query=query)
-        recall = await self.knowledge_recaller.recall(query, self.llm)
-        self.logger.info(
-            "pipeline_phase_completed",
-            phase="m0_recall",
-            known_facts=len(recall.known_facts),
-            gaps=len(recall.gaps),
-        )
-
-        self.logger.info(
-            "pipeline_phase_started",
-            phase="m1_clarify",
-            mode_hint=mode_hint.value if mode_hint is not None else None,
-        )
-        clarification = await self.clarifier.clarify(
-            ClarifyRequest(query=query, mode_hint=mode_hint),
-            self.llm,
-        )
-        self.logger.info(
-            "pipeline_phase_completed",
-            phase="m1_clarify",
-            need_clarification=clarification.need_clarification,
-            rubrics=len(clarification.rubrics),
-            mode=clarification.mode.value,
-        )
-
-        if clarification.need_clarification:
-            self.logger.info("pipeline_run_completed", status="needs_clarification")
-            return PipelineResult(
-                status="needs_clarification",
-                clarification=clarification,
-                iterations=0,
+        try:
+            self.logger.info("pipeline_phase_started", phase="m0_recall", query=query)
+            recall = await self.knowledge_recaller.recall(query, self.llm)
+            self.logger.info(
+                "pipeline_phase_completed",
+                phase="m0_recall",
+                known_facts=len(recall.known_facts),
+                gaps=len(recall.gaps),
             )
 
-        self.logger.info(
-            "pipeline_phase_started",
-            phase="m2_strategy",
-            requested_subqueries=_initial_subquery_count(clarification.mode),
-        )
-        initial_queries = await self.query_strategist.generate_subqueries(
-            clarify=clarification,
-            recall=recall,
-            client=self.llm,
-            n=_initial_subquery_count(clarification.mode),
-        )
-        self.logger.info(
-            "pipeline_phase_completed",
-            phase="m2_strategy",
-            subqueries=len(initial_queries),
-        )
+            self.logger.info(
+                "pipeline_phase_started",
+                phase="m1_clarify",
+                mode_hint=mode_hint.value if mode_hint is not None else None,
+            )
+            clarification = await self.clarifier.clarify(
+                ClarifyRequest(query=query, mode_hint=mode_hint),
+                self.llm,
+            )
+            self.logger.info(
+                "pipeline_phase_completed",
+                phase="m1_clarify",
+                need_clarification=clarification.need_clarification,
+                rubrics=len(clarification.rubrics),
+                mode=clarification.mode.value,
+            )
 
-        self.logger.info(
-            "pipeline_phase_started",
-            phase="m3_iteration",
-            subqueries=len(initial_queries),
-            channels=len(self.channels),
-            max_iterations=self.budget.max_iterations,
-        )
-        evidences = await iteration_controller.run(
-            query=query,
-            initial_queries=initial_queries,
-            channels=self.channels,
-            budget=self.budget,
-            client=self.llm,
-        )
-        self.logger.info(
-            "pipeline_phase_completed",
-            phase="m3_iteration",
-            evidences=len(evidences),
-            iterations=iteration_controller.iterations_executed,
-        )
+            session_mode = clarification.mode.value
+            await self._ensure_session_created(
+                session_id=session_id,
+                query=query,
+                mode=session_mode,
+                session_created=session_created,
+            )
+            session_created = True
 
-        self.logger.info(
-            "pipeline_phase_started",
-            phase="m5_evidence_processing",
-            evidences=len(evidences),
-            top_k=self.top_k_evidence,
-        )
-        processed_evidences = self._finalize_evidences(evidences, query)
-        self.logger.info(
-            "pipeline_phase_completed",
-            phase="m5_evidence_processing",
-            evidences=len(processed_evidences),
-        )
-
-        self.logger.info(
-            "pipeline_phase_started",
-            phase="m7_synthesis",
-            evidences=len(processed_evidences),
-        )
-        markdown = await self.report_synthesizer.synthesize(
-            query=query,
-            evidences=processed_evidences,
-            rubrics=clarification.rubrics,
-            client=self.llm,
-        )
-        self.logger.info(
-            "pipeline_phase_completed",
-            phase="m7_synthesis",
-            markdown_chars=len(markdown),
-        )
-
-        first_section = _extract_first_section(markdown)
-        self.logger.info(
-            "pipeline_phase_started",
-            phase="m8_quality_gate",
-            section_heading=first_section.heading,
-        )
-        quality = await self.quality_gate.evaluate(
-            section=first_section,
-            rubrics=clarification.rubrics,
-            evidences=processed_evidences,
-            client=self.llm,
-        )
-        self.logger.info(
-            "pipeline_phase_completed",
-            phase="m8_quality_gate",
-            grade=quality.grade.value,
-            follow_up_gaps=len(quality.follow_up_gaps),
-        )
-
-        if quality.grade is GradeOutcome.FAIL:
-            retry_queries = _subqueries_from_gaps(quality.follow_up_gaps)
-            if retry_queries:
-                retry_budget = IterationBudget(
-                    max_iterations=1,
-                    per_channel_rate_limit=self.budget.per_channel_rate_limit,
-                )
-                self.logger.info(
-                    "pipeline_quality_retry_started",
-                    retry_subqueries=len(retry_queries),
-                )
-                retry_evidences = await iteration_controller.run(
-                    query=query,
-                    initial_queries=retry_queries,
-                    channels=self.channels,
-                    budget=retry_budget,
-                    client=self.llm,
-                )
-                processed_evidences = self._finalize_evidences(
-                    processed_evidences + retry_evidences,
-                    query,
-                )
-                markdown = await self.report_synthesizer.synthesize(
-                    query=query,
-                    evidences=processed_evidences,
-                    rubrics=clarification.rubrics,
-                    client=self.llm,
-                )
-                self.logger.info(
-                    "pipeline_quality_retry_completed",
-                    retry_evidences=len(retry_evidences),
-                    total_evidences=len(processed_evidences),
-                    markdown_chars=len(markdown),
+            if clarification.need_clarification:
+                final_status = "needs_clarification"
+                self.logger.info("pipeline_run_completed", status=final_status)
+                return PipelineResult(
+                    status=final_status,
+                    clarification=clarification,
+                    iterations=0,
+                    session_id=session_id,
+                    cost=self._current_cost(),
                 )
 
-        self.logger.info(
-            "pipeline_run_completed",
-            status="ok",
-            evidences=len(processed_evidences),
-            iterations=iteration_controller.iterations_executed,
-        )
-        return PipelineResult(
-            status="ok",
-            clarification=clarification,
-            markdown=markdown,
-            evidences=processed_evidences,
-            quality=quality,
-            iterations=iteration_controller.iterations_executed,
-        )
+            self.logger.info(
+                "pipeline_phase_started",
+                phase="m2_strategy",
+                requested_subqueries=_initial_subquery_count(clarification.mode),
+            )
+            initial_queries = await self.query_strategist.generate_subqueries(
+                clarify=clarification,
+                recall=recall,
+                client=self.llm,
+                n=_initial_subquery_count(clarification.mode),
+            )
+            self.logger.info(
+                "pipeline_phase_completed",
+                phase="m2_strategy",
+                subqueries=len(initial_queries),
+            )
+
+            self.logger.info(
+                "pipeline_phase_started",
+                phase="m3_iteration",
+                subqueries=len(initial_queries),
+                channels=len(self.channels),
+                max_iterations=self.budget.max_iterations,
+            )
+            evidences = await iteration_controller.run(
+                query=query,
+                initial_queries=initial_queries,
+                channels=self.channels,
+                budget=self.budget,
+                client=self.llm,
+            )
+            self.logger.info(
+                "pipeline_phase_completed",
+                phase="m3_iteration",
+                evidences=len(evidences),
+                iterations=iteration_controller.iterations_executed,
+            )
+
+            self.logger.info(
+                "pipeline_phase_started",
+                phase="m5_evidence_processing",
+                evidences=len(evidences),
+                top_k=self.top_k_evidence,
+            )
+            processed_evidences = self._finalize_evidences(evidences, query)
+            self.logger.info(
+                "pipeline_phase_completed",
+                phase="m5_evidence_processing",
+                evidences=len(processed_evidences),
+            )
+
+            self.logger.info(
+                "pipeline_phase_started",
+                phase="m7_synthesis",
+                evidences=len(processed_evidences),
+            )
+            markdown = await self.report_synthesizer.synthesize(
+                query=query,
+                evidences=processed_evidences,
+                rubrics=clarification.rubrics,
+                client=self.llm,
+            )
+            self.logger.info(
+                "pipeline_phase_completed",
+                phase="m7_synthesis",
+                markdown_chars=len(markdown),
+            )
+
+            first_section = _extract_first_section(markdown)
+            self.logger.info(
+                "pipeline_phase_started",
+                phase="m8_quality_gate",
+                section_heading=first_section.heading,
+            )
+            quality = await self.quality_gate.evaluate(
+                section=first_section,
+                rubrics=clarification.rubrics,
+                evidences=processed_evidences,
+                client=self.llm,
+            )
+            self.logger.info(
+                "pipeline_phase_completed",
+                phase="m8_quality_gate",
+                grade=quality.grade.value,
+                follow_up_gaps=len(quality.follow_up_gaps),
+            )
+
+            if quality.grade is GradeOutcome.FAIL:
+                retry_queries = _subqueries_from_gaps(quality.follow_up_gaps)
+                if retry_queries:
+                    retry_budget = IterationBudget(
+                        max_iterations=1,
+                        per_channel_rate_limit=self.budget.per_channel_rate_limit,
+                    )
+                    self.logger.info(
+                        "pipeline_quality_retry_started",
+                        retry_subqueries=len(retry_queries),
+                    )
+                    retry_evidences = await iteration_controller.run(
+                        query=query,
+                        initial_queries=retry_queries,
+                        channels=self.channels,
+                        budget=retry_budget,
+                        client=self.llm,
+                    )
+                    processed_evidences = self._finalize_evidences(
+                        processed_evidences + retry_evidences,
+                        query,
+                    )
+                    markdown = await self.report_synthesizer.synthesize(
+                        query=query,
+                        evidences=processed_evidences,
+                        rubrics=clarification.rubrics,
+                        client=self.llm,
+                    )
+                    self.logger.info(
+                        "pipeline_quality_retry_completed",
+                        retry_evidences=len(retry_evidences),
+                        total_evidences=len(processed_evidences),
+                        markdown_chars=len(markdown),
+                    )
+
+            await self._record_final_evidences(session_id, processed_evidences)
+            final_markdown = markdown
+            final_status = "ok"
+            self.logger.info(
+                "pipeline_run_completed",
+                status=final_status,
+                evidences=len(processed_evidences),
+                iterations=iteration_controller.iterations_executed,
+            )
+            return PipelineResult(
+                status=final_status,
+                clarification=clarification,
+                markdown=markdown,
+                evidences=processed_evidences,
+                quality=quality,
+                iterations=iteration_controller.iterations_executed,
+                session_id=session_id,
+                cost=self._current_cost(),
+            )
+        finally:
+            if session_id is not None:
+                if not session_created:
+                    fallback_mode = session_mode or _fallback_session_mode(mode_hint)
+                    await self._ensure_session_created(
+                        session_id=session_id,
+                        query=query,
+                        mode=fallback_mode,
+                        session_created=False,
+                    )
+                await self._finish_session(
+                    session_id=session_id,
+                    status=final_status,
+                    markdown=final_markdown,
+                )
 
     def _finalize_evidences(self, evidences: list[Evidence], query: str) -> list[Evidence]:
         deduped = self.evidence_processor.dedup_urls(evidences)
@@ -249,11 +286,96 @@ class Pipeline:
             top_k=self.top_k_evidence,
         )
 
+    async def _ensure_session_created(
+        self,
+        session_id: str | None,
+        query: str,
+        mode: str,
+        session_created: bool,
+    ) -> None:
+        if self.session_store is None or session_id is None or session_created:
+            return
+        await self.session_store.create_session(session_id, query, mode)
+
+    async def _record_final_evidences(
+        self,
+        session_id: str | None,
+        evidences: list[Evidence],
+    ) -> None:
+        if self.session_store is None or session_id is None:
+            return
+        for rank, evidence in enumerate(evidences, start=1):
+            await self.session_store.add_evidence(session_id, rank, evidence)
+
+    async def _finish_session(
+        self,
+        session_id: str,
+        status: str,
+        markdown: str | None,
+    ) -> None:
+        if self.session_store is None:
+            return
+        await self.session_store.finish_session(
+            session_id=session_id,
+            status=status,
+            markdown=markdown,
+            cost=self._current_cost(),
+        )
+
+    def _current_cost(self) -> float:
+        if self.cost_tracker is None:
+            return 0.0
+        return self.cost_tracker.total()
+
 
 class _TrackingIterationController(IterationController):
-    def __init__(self, evidence_processor: EvidenceProcessor) -> None:
+    def __init__(
+        self,
+        evidence_processor: EvidenceProcessor,
+        session_store: SessionStore | None = None,
+        session_id: str | None = None,
+    ) -> None:
         super().__init__(evidence_processor=evidence_processor)
         self.iterations_executed = 0
+        self.session_store = session_store
+        self.session_id = session_id
+
+    async def _search(
+        self,
+        subqueries: list[SubQuery],
+        channels: list[Channel],
+        iteration: int,
+    ) -> list[Evidence]:
+        tasks = [channel.search(subquery) for subquery in subqueries for channel in channels]
+        task_metadata = [
+            (channel.name, subquery.text) for subquery in subqueries for channel in channels
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        evidences: list[Evidence] = []
+        for (channel_name, query_text), result in zip(task_metadata, results, strict=True):
+            result_count = 0
+            if isinstance(result, Exception):
+                self.logger.warning(
+                    "channel_search_failed",
+                    iteration=iteration,
+                    channel=channel_name,
+                    subquery=query_text,
+                    error=str(result),
+                )
+            else:
+                result_count = len(result)
+                evidences.extend(result)
+
+            if self.session_store is not None and self.session_id is not None:
+                await self.session_store.add_query_log(
+                    self.session_id,
+                    query_text,
+                    channel_name,
+                    result_count,
+                )
+
+        return evidences
 
     async def _reflect(
         self,
@@ -279,6 +401,16 @@ def _initial_subquery_count(mode: SearchMode) -> int:
     if mode is SearchMode.FAST:
         return 3
     return 5
+
+
+def _fallback_session_mode(mode_hint: SearchMode | None) -> str:
+    if mode_hint is not None:
+        return mode_hint.value
+    return "unknown"
+
+
+def _new_session_id() -> str:
+    return uuid.uuid4().hex[:12]
 
 
 def _subqueries_from_gaps(gaps: list[Gap]) -> list[SubQuery]:

--- a/autosearch/llm/client.py
+++ b/autosearch/llm/client.py
@@ -8,6 +8,7 @@ from typing import Protocol, TypeVar, cast
 import structlog
 from pydantic import BaseModel
 
+from autosearch.observability.cost import CostTracker, estimate_tokens
 from autosearch.llm.providers.anthropic import AnthropicProvider
 from autosearch.llm.providers.claude_code import ClaudeCodeProvider
 from autosearch.llm.providers.gemini import GeminiProvider
@@ -27,10 +28,12 @@ class LLMClient:
         self,
         provider_name: str | None = None,
         providers: Mapping[str, ProviderProtocol] | None = None,
+        cost_tracker: CostTracker | None = None,
         max_parse_retries: int = 3,
         retry_backoff_seconds: float = 0.25,
     ) -> None:
         self.logger = structlog.get_logger(__name__).bind(component="llm_client")
+        self.cost_tracker = cost_tracker
         self.max_parse_retries = max_parse_retries
         self.retry_backoff_seconds = retry_backoff_seconds
         self.providers = dict(providers) if providers is not None else self._detect_providers()
@@ -41,11 +44,12 @@ class LLMClient:
             )
 
         preferred_provider = provider_name or os.getenv("AUTOSEARCH_LLM_PROVIDER")
-        self.provider_name = preferred_provider or next(iter(self.providers))
-        if self.provider_name not in self.providers:
-            raise ValueError(f"Unknown provider: {self.provider_name}")
+        provider_key = preferred_provider or next(iter(self.providers))
+        if provider_key not in self.providers:
+            raise ValueError(f"Unknown provider: {provider_key}")
 
-        self.provider = self.providers[self.provider_name]
+        self.provider = self.providers[provider_key]
+        self.provider_name = provider_key
         self.logger.info(
             "llm_provider_selected",
             provider=self.provider_name,
@@ -96,6 +100,12 @@ class LLMClient:
                 continue
 
             result = response_model.model_validate(payload)
+            if self.cost_tracker is not None:
+                self.cost_tracker.add_usage(
+                    model=self._cost_model_name(),
+                    input_tokens=estimate_tokens(prompt),
+                    output_tokens=estimate_tokens(raw_json),
+                )
             self.logger.info(
                 "llm_completion_validated",
                 provider=self.provider_name,
@@ -104,3 +114,9 @@ class LLMClient:
             return cast(ResponseModelT, result)
 
         raise RuntimeError("LLM completion exhausted retries without returning valid JSON.")
+
+    def _cost_model_name(self) -> str:
+        model_name = getattr(self.provider, "model", None)
+        if isinstance(model_name, str) and model_name:
+            return model_name
+        return self.provider_name

--- a/tests/integration/test_pipeline_with_session.py
+++ b/tests/integration/test_pipeline_with_session.py
@@ -1,0 +1,189 @@
+# Self-written, plan v2.3 § 11
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import BaseModel
+
+from autosearch.core.clarify import _ClarifyCompletion
+from autosearch.core.iteration import _GapReflectionResponse
+from autosearch.core.models import EvaluationResult, Gap, GradeOutcome, KnowledgeRecall, SearchMode
+from autosearch.core.pipeline import Pipeline
+from autosearch.core.strategy import _SubQueryBatch
+from autosearch.llm.client import LLMClient
+from autosearch.observability.cost import CostTracker
+from autosearch.persistence.session_store import SessionStore
+from autosearch.synthesis.outline import OutlineResponse
+from autosearch.synthesis.section import _SectionWriteResponse
+from tests.fixtures.fake_channel import FakeChannel
+
+NOW = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class CompletionStep:
+    response_model: type[BaseModel]
+    payload: dict[str, object]
+
+
+class ScriptedProvider:
+    name = "scripted"
+    model = "gpt-4o"
+
+    def __init__(self, steps: list[CompletionStep]) -> None:
+        self.steps = list(steps)
+        self.calls = 0
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> str:
+        _ = prompt
+        if self.calls >= len(self.steps):
+            raise AssertionError(f"Unexpected extra LLM call for {response_model.__name__}")
+
+        step = self.steps[self.calls]
+        self.calls += 1
+        if response_model is not step.response_model:
+            raise AssertionError(
+                f"Expected {step.response_model.__name__}, got {response_model.__name__}"
+            )
+        return json.dumps(step.payload)
+
+
+def _make_evidence(url: str, title: str, body: str) -> BaseModel:
+    from autosearch.core.models import Evidence
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=body[:80],
+        content=body,
+        source_channel="web",
+        fetched_at=NOW,
+        score=0.9,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_records_session_queries_evidence_and_cost() -> None:
+    store = await SessionStore.open(":memory:")
+    provider = ScriptedProvider(
+        [
+            CompletionStep(
+                response_model=KnowledgeRecall,
+                payload=KnowledgeRecall(
+                    known_facts=["BM25 is a lexical ranking method."],
+                    gaps=[Gap(topic="Current benchmarks", reason="Need fresh comparisons")],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_ClarifyCompletion,
+                payload=_ClarifyCompletion(
+                    need_clarification=False,
+                    question="",
+                    verification="Enough information to proceed.",
+                    rubrics=[
+                        "Includes current evidence",
+                        "Compares sources directly",
+                        "Provides cited conclusions",
+                    ],
+                    mode=SearchMode.FAST,
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_SubQueryBatch,
+                payload=_SubQueryBatch(
+                    subqueries=[
+                        {
+                            "text": "bm25 ranking benchmarks 2026",
+                            "rationale": "covers current benchmark evidence",
+                        },
+                        {
+                            "text": "bm25 retrieval tradeoffs comparison",
+                            "rationale": "covers direct tradeoff analysis",
+                        },
+                        {
+                            "text": "bm25 relevance evaluation sources",
+                            "rationale": "covers cited conclusions",
+                        },
+                    ]
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_GapReflectionResponse,
+                payload=_GapReflectionResponse(gaps=[]).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=OutlineResponse,
+                payload=OutlineResponse(headings=["Overview", "Practical Takeaways"]).model_dump(
+                    mode="json"
+                ),
+            ),
+            CompletionStep(
+                response_model=_SectionWriteResponse,
+                payload=_SectionWriteResponse(
+                    content=(
+                        "BM25 remains competitive for lexical retrieval and is easy to reason "
+                        "about in ranking pipelines [1][2]."
+                    ),
+                    ref_ids=[1, 2],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_SectionWriteResponse,
+                payload=_SectionWriteResponse(
+                    content=(
+                        "Operationally, transparent scoring and straightforward deployment "
+                        "remain the strongest reasons to use BM25 [2][3]."
+                    ),
+                    ref_ids=[2, 3],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=EvaluationResult,
+                payload=EvaluationResult(
+                    grade=GradeOutcome.PASS,
+                    follow_up_gaps=[],
+                ).model_dump(mode="json"),
+            ),
+        ]
+    )
+    llm = LLMClient(provider_name="scripted", providers={"scripted": provider})
+    tracker = CostTracker()
+    channel = FakeChannel(
+        name="web",
+        evidences=[
+            _make_evidence(
+                "https://example.com/benchmarks",
+                "BM25 benchmark summary",
+                "A benchmark summary comparing BM25 to related ranking approaches.",
+            ),
+            _make_evidence(
+                "https://example.com/tradeoffs",
+                "BM25 tradeoffs",
+                "Tradeoffs between BM25 and adjacent retrieval strategies in production.",
+            ),
+        ],
+    )
+
+    try:
+        result = await Pipeline(
+            llm=llm,
+            channels=[channel],
+            cost_tracker=tracker,
+            session_store=store,
+        ).run("Should I still use BM25 for lexical search?")
+        session = await store.fetch_session(result.session_id or "")
+    finally:
+        await store.close()
+
+    assert result.session_id is not None
+    assert re.fullmatch(r"[0-9a-f]{12}", result.session_id)
+    assert result.cost > 0.0
+    assert session is not None
+    assert session["id"] == result.session_id
+    assert session["markdown"]
+    assert session["finished_at"] is not None
+    assert session["cost"] == pytest.approx(result.cost)
+    assert session["evidence"]
+    assert session["query_log"]

--- a/tests/unit/test_llm_client.py
+++ b/tests/unit/test_llm_client.py
@@ -3,6 +3,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 import autosearch.llm.client as client_module
+from autosearch.observability.cost import CostTracker
 
 
 class DemoResponse(BaseModel):
@@ -11,6 +12,7 @@ class DemoResponse(BaseModel):
 
 class DummyProvider:
     name = "dummy"
+    model = "gpt-4o"
 
     def __init__(self, responses: list[str]) -> None:
         self.responses = responses
@@ -92,3 +94,18 @@ async def test_llm_client_raises_validation_error_on_schema_mismatch() -> None:
         await client.complete("test prompt", DemoResponse)
 
     assert provider.calls == 1
+
+
+async def test_llm_client_reports_cost_when_tracker_set() -> None:
+    provider = DummyProvider(['{"answer":"ok"}'])
+    cost_tracker = CostTracker()
+    client = client_module.LLMClient(
+        provider_name="dummy",
+        providers={"dummy": provider},
+        cost_tracker=cost_tracker,
+    )
+
+    result = await client.complete("test prompt", DemoResponse)
+
+    assert result.answer == "ok"
+    assert cost_tracker.total() > 0


### PR DESCRIPTION
## Summary
Connects the observability + persistence primitives (#92) to `Pipeline` + `LLMClient`. Default behavior unchanged when trackers aren't provided.

- `LLMClient(cost_tracker=...)` reports estimated token cost after each successful `complete()`
- `Pipeline(cost_tracker=..., session_store=...)` creates a session on `run()`, logs subqueries + evidences + finish status + total cost
- `PipelineResult` gains `session_id: str | None` + `cost: float = 0.0`
- Session ID = `uuid.uuid4().hex[:12]`

## Test plan
- [x] `pytest -x -q -m "not network"` — 69 passed (67 + 2 new)
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] Existing Pipeline tests (no tracker/store) still pass
- [x] New integration test verifies `fetch_session()` returns evidence + query_log after run

## Next candidates
- Real progress streaming (Pipeline phase callbacks → SSE)
- `autosearch init` (deferred pending channel unpause)