### PR TITLE
feat: real-time pipeline streaming (phase events + sse + cli stderr)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -1,6 +1,7 @@
 # Source: gpt-researcher/cli.py:L28-L216 (adapted)
 import asyncio
 import json
+import sys
 from typing import Annotated
 
 import click
@@ -67,13 +68,22 @@ def query(
         bool,
         typer.Option("--json", help="Emit a machine-readable JSON response envelope."),
     ] = False,
+    stream: Annotated[
+        bool,
+        typer.Option(
+            "--stream/--no-stream",
+            help="Emit newline-delimited progress events to stderr while the query runs.",
+        ),
+    ] = True,
 ) -> None:
+    stream_callback = _stderr_event_writer if stream and not json_output else None
     try:
         result = asyncio.run(
             Pipeline(
                 llm=LLMClient(),
                 channels=[DemoChannel()],
                 top_k_evidence=top_k,
+                on_event=stream_callback,
             ).run(query, mode_hint=mode)
         )
     except Exception as exc:
@@ -121,3 +131,8 @@ def serve(
     ] = 8080,
 ) -> None:
     uvicorn.run("autosearch.server.main:app", host=host, port=port)
+
+
+def _stderr_event_writer(event: dict[str, object]) -> None:
+    sys.stderr.write(json.dumps(event, ensure_ascii=False) + "\n")
+    sys.stderr.flush()

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -1,7 +1,9 @@
 # Self-written, plan v2.3 § 2
+from collections.abc import Awaitable, Callable
 import asyncio
 import re
 import uuid
+from typing import Any
 
 import structlog
 
@@ -29,6 +31,8 @@ from autosearch.synthesis.report import ReportSynthesizer
 
 _SECTION_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
+type PipelineEvent = dict[str, Any]
+type PipelineEventCallback = Callable[[PipelineEvent], Awaitable[None] | None]
 
 
 class Pipeline:
@@ -40,6 +44,7 @@ class Pipeline:
         top_k_evidence: int = 20,
         cost_tracker: CostTracker | None = None,
         session_store: SessionStore | None = None,
+        on_event: PipelineEventCallback | None = None,
     ) -> None:
         self.llm = llm or LLMClient(cost_tracker=cost_tracker)
         if cost_tracker is not None:
@@ -55,6 +60,7 @@ class Pipeline:
         self.evidence_processor = EvidenceProcessor()
         self.report_synthesizer = ReportSynthesizer()
         self.quality_gate = QualityGate()
+        self.on_event = on_event
         self.logger = structlog.get_logger(__name__).bind(component="pipeline")
 
     async def run(
@@ -66,14 +72,17 @@ class Pipeline:
             evidence_processor=self.evidence_processor,
             session_store=self.session_store,
             session_id=_new_session_id() if self.session_store is not None else None,
+            on_event=self._emit_event,
         )
         session_id = iteration_controller.session_id
         session_created = False
         session_mode = mode_hint.value if mode_hint is not None else None
         final_status = "error"
         final_markdown: str | None = None
+        current_phase = "M0"
 
         try:
+            await self._emit_phase_event(current_phase, "start")
             self.logger.info("pipeline_phase_started", phase="m0_recall", query=query)
             recall = await self.knowledge_recaller.recall(query, self.llm)
             self.logger.info(
@@ -82,7 +91,10 @@ class Pipeline:
                 known_facts=len(recall.known_facts),
                 gaps=len(recall.gaps),
             )
+            await self._emit_phase_event(current_phase, "complete")
 
+            current_phase = "M1"
+            await self._emit_phase_event(current_phase, "start")
             self.logger.info(
                 "pipeline_phase_started",
                 phase="m1_clarify",
@@ -99,6 +111,7 @@ class Pipeline:
                 rubrics=len(clarification.rubrics),
                 mode=clarification.mode.value,
             )
+            await self._emit_phase_event(current_phase, "complete")
 
             session_mode = clarification.mode.value
             await self._ensure_session_created(
@@ -120,6 +133,8 @@ class Pipeline:
                     cost=self._current_cost(),
                 )
 
+            current_phase = "M2"
+            await self._emit_phase_event(current_phase, "start")
             self.logger.info(
                 "pipeline_phase_started",
                 phase="m2_strategy",
@@ -136,7 +151,10 @@ class Pipeline:
                 phase="m2_strategy",
                 subqueries=len(initial_queries),
             )
+            await self._emit_phase_event(current_phase, "complete")
 
+            current_phase = "M3"
+            await self._emit_phase_event(current_phase, "start")
             self.logger.info(
                 "pipeline_phase_started",
                 phase="m3_iteration",
@@ -157,7 +175,10 @@ class Pipeline:
                 evidences=len(evidences),
                 iterations=iteration_controller.iterations_executed,
             )
+            await self._emit_phase_event(current_phase, "complete")
 
+            current_phase = "M5"
+            await self._emit_phase_event(current_phase, "start")
             self.logger.info(
                 "pipeline_phase_started",
                 phase="m5_evidence_processing",
@@ -170,7 +191,10 @@ class Pipeline:
                 phase="m5_evidence_processing",
                 evidences=len(processed_evidences),
             )
+            await self._emit_phase_event(current_phase, "complete")
 
+            current_phase = "M7"
+            await self._emit_phase_event(current_phase, "start")
             self.logger.info(
                 "pipeline_phase_started",
                 phase="m7_synthesis",
@@ -187,8 +211,11 @@ class Pipeline:
                 phase="m7_synthesis",
                 markdown_chars=len(markdown),
             )
+            await self._emit_phase_event(current_phase, "complete")
 
             first_section = _extract_first_section(markdown)
+            current_phase = "M8"
+            await self._emit_phase_event(current_phase, "start")
             self.logger.info(
                 "pipeline_phase_started",
                 phase="m8_quality_gate",
@@ -206,6 +233,14 @@ class Pipeline:
                 grade=quality.grade.value,
                 follow_up_gaps=len(quality.follow_up_gaps),
             )
+            await self._emit_phase_event(current_phase, "complete")
+            await self._emit_event(
+                {
+                    "type": "quality",
+                    "grade": quality.grade.value,
+                    "follow_up_count": len(quality.follow_up_gaps),
+                }
+            )
 
             if quality.grade is GradeOutcome.FAIL:
                 retry_queries = _subqueries_from_gaps(quality.follow_up_gaps)
@@ -214,6 +249,8 @@ class Pipeline:
                         max_iterations=1,
                         per_channel_rate_limit=self.budget.per_channel_rate_limit,
                     )
+                    current_phase = "M3"
+                    await self._emit_phase_event(current_phase, "start")
                     self.logger.info(
                         "pipeline_quality_retry_started",
                         retry_subqueries=len(retry_queries),
@@ -225,16 +262,20 @@ class Pipeline:
                         budget=retry_budget,
                         client=self.llm,
                     )
+                    await self._emit_phase_event(current_phase, "complete")
                     processed_evidences = self._finalize_evidences(
                         processed_evidences + retry_evidences,
                         query,
                     )
+                    current_phase = "M7"
+                    await self._emit_phase_event(current_phase, "start")
                     markdown = await self.report_synthesizer.synthesize(
                         query=query,
                         evidences=processed_evidences,
                         rubrics=clarification.rubrics,
                         client=self.llm,
                     )
+                    await self._emit_phase_event(current_phase, "complete")
                     self.logger.info(
                         "pipeline_quality_retry_completed",
                         retry_evidences=len(retry_evidences),
@@ -261,6 +302,20 @@ class Pipeline:
                 session_id=session_id,
                 cost=self._current_cost(),
             )
+        except Exception as exc:
+            self.logger.exception(
+                "pipeline_run_failed",
+                phase=current_phase,
+                error=str(exc),
+            )
+            await self._emit_event(
+                {
+                    "type": "error",
+                    "phase": current_phase,
+                    "message": str(exc),
+                }
+            )
+            raise
         finally:
             if session_id is not None:
                 if not session_created:
@@ -327,6 +382,30 @@ class Pipeline:
             return 0.0
         return self.cost_tracker.total()
 
+    async def _emit_phase_event(self, phase: str, status: str) -> None:
+        await self._emit_event(
+            {
+                "type": "phase",
+                "phase": phase,
+                "status": status,
+            }
+        )
+
+    async def _emit_event(self, event: PipelineEvent) -> None:
+        if self.on_event is None:
+            return
+        try:
+            maybe_coro = self.on_event(event)
+            if asyncio.iscoroutine(maybe_coro):
+                await maybe_coro
+        except Exception as exc:
+            self.logger.warning(
+                "pipeline_event_callback_failed",
+                event_type=event.get("type"),
+                phase=event.get("phase"),
+                error=str(exc),
+            )
+
 
 class _TrackingIterationController(IterationController):
     def __init__(
@@ -334,11 +413,14 @@ class _TrackingIterationController(IterationController):
         evidence_processor: EvidenceProcessor,
         session_store: SessionStore | None = None,
         session_id: str | None = None,
+        on_event: Callable[[PipelineEvent], Awaitable[None]] | None = None,
     ) -> None:
         super().__init__(evidence_processor=evidence_processor)
         self.iterations_executed = 0
         self.session_store = session_store
         self.session_id = session_id
+        self.on_event = on_event
+        self._latest_new_evidence_count = 0
 
     async def _search(
         self,
@@ -375,6 +457,7 @@ class _TrackingIterationController(IterationController):
                     result_count,
                 )
 
+        self._latest_new_evidence_count = len(evidences)
         return evidences
 
     async def _reflect(
@@ -387,7 +470,7 @@ class _TrackingIterationController(IterationController):
         client: LLMClient,
     ) -> list[Gap]:
         self.iterations_executed += 1
-        return await super()._reflect(
+        gaps = await super()._reflect(
             query=query,
             iteration=iteration,
             max_iterations=max_iterations,
@@ -395,6 +478,24 @@ class _TrackingIterationController(IterationController):
             evidences=evidences,
             client=client,
         )
+        if self.on_event is not None:
+            await self.on_event(
+                {
+                    "type": "iteration",
+                    "round": self.iterations_executed,
+                    "new_evidence": self._latest_new_evidence_count,
+                    "running_evidence": len(evidences),
+                }
+            )
+            for gap in gaps:
+                await self.on_event(
+                    {
+                        "type": "gap",
+                        "topic": gap.topic,
+                        "reason": gap.reason,
+                    }
+                )
+        return gaps
 
 
 def _initial_subquery_count(mode: SearchMode) -> int:

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -1,6 +1,7 @@
 # Source: openperplex_backend_os/main.py:L14-L77 (adapted)
+import asyncio
 import json
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 from fastapi import FastAPI
@@ -18,6 +19,9 @@ try:
     from sse_starlette.sse import EventSourceResponse
 except ImportError:
     EventSourceResponse = None
+
+type EventCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
+type PipelineFactory = Callable[[EventCallback | None], Pipeline]
 
 
 class SearchRequest(BaseModel):
@@ -43,28 +47,21 @@ app.add_middleware(
 )
 
 
-def _default_pipeline_factory() -> Pipeline:
-    return Pipeline(llm=LLMClient(), channels=[DemoChannel()])
-
-
-def _phase_sequence(result: PipelineResult) -> list[str]:
-    if result.status == "needs_clarification":
-        return ["M0", "M1"]
-    return ["M0", "M1", "M2", *(["M3"] * max(1, result.iterations)), "M5", "M7", "M8"]
+def _default_pipeline_factory(on_event: EventCallback | None = None) -> Pipeline:
+    return Pipeline(llm=LLMClient(), channels=[DemoChannel()], on_event=on_event)
 
 
 def _terminal_payload(result: PipelineResult) -> dict[str, Any]:
-    if result.status == "needs_clarification":
-        return {
-            "type": "needs_clarification",
-            "question": result.clarification.question or "More detail is required.",
-        }
-    return {
+    payload: dict[str, Any] = {
         "type": "finished",
-        "markdown": result.markdown or "",
         "iterations": result.iterations,
         "status": result.status,
     }
+    if result.status == "needs_clarification":
+        payload["question"] = result.clarification.question or "More detail is required."
+        return payload
+    payload["markdown"] = result.markdown or ""
+    return payload
 
 
 def _encode_sse(payload: dict[str, Any]) -> str:
@@ -74,24 +71,36 @@ def _encode_sse(payload: dict[str, Any]) -> str:
 async def _event_payloads(
     query: str,
     mode: SearchMode,
-    pipeline_factory: Callable[[], Pipeline],
+    pipeline_factory: PipelineFactory,
 ) -> AsyncIterator[dict[str, Any]]:
+    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
     yield {"type": "started", "query": query}
+    pipeline_task = asyncio.create_task(pipeline_factory(queue.put).run(query, mode_hint=mode))
+
+    while not pipeline_task.done():
+        try:
+            yield queue.get_nowait()
+        except asyncio.QueueEmpty:
+            await asyncio.sleep(0)
+
+    while not queue.empty():
+        yield queue.get_nowait()
+
     try:
-        result = await pipeline_factory().run(query, mode_hint=mode)
+        result = await pipeline_task
     except Exception as exc:
-        yield {"type": "error", "message": str(exc)}
+        if queue.empty():
+            yield {"type": "error", "message": str(exc)}
         return
 
-    for phase in _phase_sequence(result):
-        yield {"type": "progress", "phase": phase}
     yield _terminal_payload(result)
 
 
 async def _streaming_events(
     query: str,
     mode: SearchMode,
-    pipeline_factory: Callable[[], Pipeline],
+    pipeline_factory: PipelineFactory,
 ) -> AsyncIterator[str]:
     async for payload in _event_payloads(query, mode, pipeline_factory):
         yield _encode_sse(payload)
@@ -100,7 +109,7 @@ async def _streaming_events(
 async def _eventsource_events(
     query: str,
     mode: SearchMode,
-    pipeline_factory: Callable[[], Pipeline],
+    pipeline_factory: PipelineFactory,
 ) -> AsyncIterator[dict[str, str]]:
     async for payload in _event_payloads(query, mode, pipeline_factory):
         yield {"data": json.dumps(payload, ensure_ascii=False)}

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -1,4 +1,5 @@
 # Self-written, plan v2.3 § 13.5
+import asyncio
 import json
 
 from typer.testing import CliRunner
@@ -61,14 +62,19 @@ def _install_cli_stubs(monkeypatch, pipeline_result: PipelineResult) -> None:
     import autosearch.cli.main as cli_main
 
     class StubPipeline:
-        def __init__(self, llm, channels, top_k_evidence: int) -> None:
+        def __init__(self, llm, channels, top_k_evidence: int, on_event=None) -> None:
             self.llm = llm
             self.channels = channels
             self.top_k_evidence = top_k_evidence
+            self.on_event = on_event
 
         async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
             _ = query
             _ = mode_hint
+            if self.on_event is not None:
+                maybe_coro = self.on_event({"type": "phase", "phase": "M0", "status": "start"})
+                if asyncio.iscoroutine(maybe_coro):
+                    await maybe_coro
             return pipeline_result
 
     monkeypatch.setattr(cli_main, "Pipeline", StubPipeline)
@@ -79,19 +85,35 @@ def _install_cli_stubs(monkeypatch, pipeline_result: PipelineResult) -> None:
 def test_cli_query_prints_markdown_for_ok_result(monkeypatch) -> None:
     _install_cli_stubs(monkeypatch, _ok_result())
 
-    result = runner.invoke(app, ["query", "test"])
+    result = runner.invoke(app, ["query", "test", "--no-stream"])
 
     assert result.exit_code == 0
     assert result.stdout == "# Test\n\nBody\n"
+    assert result.stderr == ""
 
 
 def test_cli_bare_query_routes_to_query_command(monkeypatch) -> None:
     _install_cli_stubs(monkeypatch, _ok_result())
 
-    result = runner.invoke(app, ["test"])
+    result = runner.invoke(app, ["test", "--no-stream"])
 
     assert result.exit_code == 0
     assert result.stdout == "# Test\n\nBody\n"
+    assert result.stderr == ""
+
+
+def test_cli_query_stream_writes_event_json_to_stderr(monkeypatch) -> None:
+    _install_cli_stubs(monkeypatch, _ok_result())
+
+    result = runner.invoke(app, ["query", "test"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "# Test\n\nBody\n"
+    assert json.loads(result.stderr.strip().splitlines()[0]) == {
+        "type": "phase",
+        "phase": "M0",
+        "status": "start",
+    }
 
 
 def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
@@ -112,7 +134,7 @@ def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
 def test_cli_query_exits_two_for_needs_clarification(monkeypatch) -> None:
     _install_cli_stubs(monkeypatch, _clarification_result())
 
-    result = runner.invoke(app, ["query", "test"])
+    result = runner.invoke(app, ["query", "test", "--no-stream"])
 
     assert result.exit_code == 2
     assert result.stdout == ""

--- a/tests/unit/test_pipeline_events.py
+++ b/tests/unit/test_pipeline_events.py
@@ -1,0 +1,144 @@
+# Self-written, plan v2.3 § 13.5 Progress streaming
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from autosearch.core.models import Evidence, SearchMode, SubQuery
+from autosearch.core.pipeline import Pipeline
+
+NOW = datetime(2026, 4, 17, 12, 0, 0)
+
+
+class DummyClient:
+    def __init__(self, payloads: list[dict[str, object]]) -> None:
+        self.payloads = payloads
+        self.calls = 0
+        self.cost_tracker = None
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        _ = prompt
+        payload = self.payloads[self.calls]
+        self.calls += 1
+        return response_model.model_validate(payload)
+
+
+class FakeChannel:
+    name = "fake"
+
+    def __init__(self, responses: list[list[Evidence]]) -> None:
+        self.responses = list(responses)
+        self.queries: list[str] = []
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        self.queries.append(query.text)
+        return self.responses.pop(0)
+
+
+def make_evidence(url: str, title: str, content: str) -> Evidence:
+    return Evidence(
+        url=url,
+        title=title,
+        content=content,
+        source_channel="fake",
+        fetched_at=NOW,
+    )
+
+
+def make_pipeline(on_event=None) -> Pipeline:
+    client = DummyClient(
+        [
+            {
+                "known_facts": ["Typer is a Python CLI framework."],
+                "gaps": [{"topic": "Current feature coverage", "reason": "Needs fresh evidence"}],
+            },
+            {
+                "need_clarification": False,
+                "question": "",
+                "verification": "Research streaming progress coverage.",
+                "rubrics": [
+                    "Include current behavior",
+                    "Use evidence-backed claims",
+                    "Explain tradeoffs",
+                ],
+                "mode": "fast",
+            },
+            {
+                "subqueries": [
+                    {"text": "streaming progress status", "rationale": "baseline"},
+                    {"text": "pipeline callback events", "rationale": "coverage"},
+                    {"text": "sse event ordering", "rationale": "delivery"},
+                ]
+            },
+            {
+                "gaps": [
+                    {
+                        "topic": "CLI stderr behavior",
+                        "reason": "Need a concrete streamed output example",
+                    }
+                ]
+            },
+            {
+                "subqueries": [
+                    {
+                        "text": "cli stderr streamed event example",
+                        "rationale": "closes the stderr gap",
+                    }
+                ]
+            },
+            {"gaps": []},
+            {"headings": ["Overview"]},
+            {"content": "Streaming is available through the callback path [1].", "ref_ids": [1]},
+            {"grade": "pass", "follow_up_gaps": []},
+        ]
+    )
+    channel = FakeChannel(
+        [
+            [make_evidence("https://example.com/one", "Initial finding", "Callback overview")],
+            [make_evidence("https://example.com/two", "CLI notes", "stderr output details")],
+            [make_evidence("https://example.com/three", "SSE notes", "event order details")],
+            [make_evidence("https://example.com/four", "Follow-up", "async callback details")],
+        ]
+    )
+    return Pipeline(llm=client, channels=[channel], on_event=on_event)
+
+
+async def test_pipeline_emits_phase_iteration_gap_and_quality_events() -> None:
+    events: list[dict[str, object]] = []
+    pipeline = make_pipeline(on_event=events.append)
+
+    result = await pipeline.run("How does streaming progress work?", mode_hint=SearchMode.FAST)
+
+    phase_events = [event for event in events if event["type"] == "phase"]
+    phase_starts = {(event["phase"], event["status"]) for event in phase_events}
+    iteration_events = [event for event in events if event["type"] == "iteration"]
+
+    assert result.status == "ok"
+    assert len(phase_events) >= 10
+    assert {
+        ("M0", "start"),
+        ("M0", "complete"),
+        ("M1", "start"),
+        ("M1", "complete"),
+        ("M2", "start"),
+        ("M2", "complete"),
+        ("M3", "start"),
+        ("M3", "complete"),
+        ("M7", "start"),
+        ("M7", "complete"),
+    } <= phase_starts
+    assert iteration_events
+    assert events[-1] == {"type": "quality", "grade": "pass", "follow_up_count": 0}
+
+
+async def test_pipeline_awaits_async_event_callbacks() -> None:
+    recorded: list[dict[str, object]] = []
+
+    async def callback(event: dict[str, object]) -> None:
+        recorded.append(event)
+
+    pipeline = make_pipeline(on_event=callback)
+
+    await pipeline.run("How does streaming progress work?", mode_hint=SearchMode.FAST)
+
+    assert any(event["type"] == "phase" for event in recorded)
+    assert recorded[-1] == {"type": "quality", "grade": "pass", "follow_up_count": 0}

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,4 +1,5 @@
 # Self-written, plan v2.3 § 13.5 Presentation
+import asyncio
 import json
 
 from fastapi.testclient import TestClient
@@ -42,14 +43,24 @@ class _StubPipeline:
         self,
         result: PipelineResult | None = None,
         exc: Exception | None = None,
+        on_event=None,
+        emitted_events: list[dict[str, object]] | None = None,
     ) -> None:
         self.result = result
         self.exc = exc
+        self.on_event = on_event
+        self.emitted_events = emitted_events or []
         self.calls: list[tuple[str, SearchMode]] = []
 
     async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
         assert mode_hint is not None
         self.calls.append((query, mode_hint))
+        for event in self.emitted_events:
+            if self.on_event is None:
+                continue
+            maybe_coro = self.on_event(event)
+            if asyncio.iscoroutine(maybe_coro):
+                await maybe_coro
         if self.exc is not None:
             raise self.exc
         assert self.result is not None
@@ -57,7 +68,16 @@ class _StubPipeline:
 
 
 def _install_pipeline_factory(monkeypatch, pipeline: _StubPipeline) -> None:
-    monkeypatch.setattr(server_main, "_default_pipeline_factory", lambda: pipeline)
+    monkeypatch.setattr(
+        server_main,
+        "_default_pipeline_factory",
+        lambda on_event=None: _bind_pipeline_callback(pipeline, on_event),
+    )
+
+
+def _bind_pipeline_callback(pipeline: _StubPipeline, on_event) -> _StubPipeline:
+    pipeline.on_event = on_event
+    return pipeline
 
 
 def _parse_sse_events(body: str) -> list[dict[str, object]]:
@@ -90,7 +110,6 @@ def test_search_streams_started_and_finished_events(monkeypatch) -> None:
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/event-stream")
     assert events[0] == {"type": "started", "query": "test query"}
-    assert any(event == {"type": "progress", "phase": "M0"} for event in events)
     assert {
         "type": "finished",
         "markdown": "# Test\n\nBody",
@@ -111,7 +130,9 @@ def test_search_streams_needs_clarification_event(monkeypatch) -> None:
 
     assert response.status_code == 200
     assert {
-        "type": "needs_clarification",
+        "type": "finished",
+        "status": "needs_clarification",
+        "iterations": 0,
         "question": "Which deployment target do you care about?",
     } in events
     assert pipeline.calls == [("test query", SearchMode.DEEP)]

--- a/tests/unit/test_server_streaming.py
+++ b/tests/unit/test_server_streaming.py
@@ -1,0 +1,73 @@
+# Self-written, plan v2.3 § 13.5 Progress streaming
+import asyncio
+import json
+
+from fastapi.testclient import TestClient
+
+import autosearch.server.main as server_main
+from autosearch.core.models import ClarifyResult, SearchMode
+from autosearch.core.pipeline import PipelineResult
+
+
+def _ok_result() -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown="# Test\n\nBody",
+        iterations=1,
+    )
+
+
+class _StreamingStubPipeline:
+    def __init__(self, on_event=None) -> None:
+        self.on_event = on_event
+
+    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+        _ = query
+        _ = mode_hint
+        for event in [
+            {"type": "phase", "phase": "M0", "status": "start"},
+            {"type": "iteration", "round": 1, "new_evidence": 2, "running_evidence": 2},
+            {"type": "phase", "phase": "M0", "status": "complete"},
+        ]:
+            if self.on_event is None:
+                continue
+            maybe_coro = self.on_event(event)
+            if asyncio.iscoroutine(maybe_coro):
+                await maybe_coro
+        return _ok_result()
+
+
+def _parse_sse_events(body: str) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for line in body.splitlines():
+        if not line.startswith("data:"):
+            continue
+        events.append(json.loads(line.removeprefix("data:").strip()))
+    return events
+
+
+def test_search_streams_phase_events_before_finished(monkeypatch) -> None:
+    monkeypatch.setattr(
+        server_main,
+        "_default_pipeline_factory",
+        lambda on_event=None: _StreamingStubPipeline(on_event=on_event),
+    )
+    client = TestClient(server_main.app)
+
+    response = client.post("/search", json={"query": "test query"})
+
+    events = _parse_sse_events(response.text)
+    phase_index = next(index for index, event in enumerate(events) if event["type"] == "phase")
+    finished_index = next(
+        index for index, event in enumerate(events) if event["type"] == "finished"
+    )
+
+    assert response.status_code == 200
+    assert phase_index < finished_index


### PR DESCRIPTION
## Summary
Pipeline now emits structured progress events; consumers subscribe via a single callback.

- `Pipeline(on_event=...)` — sync or async callback; emits `{type: phase|iteration|gap|quality|error, ...}` at boundaries
- SSE `/search` — runs Pipeline in background task, drains `asyncio.Queue` to `data: {json}` events in real-time
- CLI `query --stream` (default) — writes events as NDJSON to stderr; `--no-stream` or `--json` suppresses

## Test plan
- [x] `pytest -x -q -m "not network"` — 73 passed (69 + 4 new)
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] Existing Pipeline callers without `on_event` still work
- [x] PII/codename/abs-path scan clean

## Known (non-blocking)
- `quality=fail` retry path emits only one `quality` event (matches existing Pipeline retry semantics)
- Event envelope is plain NDJSON (no schema version) — can version later if needed