### PR TITLE
docs: rewrite readme + add delivery-status for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,178 +5,87 @@
 <h1 align="center">AutoSearch</h1>
 
 <p align="center">
-  <strong>Research that gets smarter every time you use it.</strong><br>
-  34 search channels. Self-evolving queries. Cited reports. Zero API keys.
+  <strong>Open-source deep research tool for AI coding developers.</strong><br>
+  Structured coverage across English and Chinese sources, cited markdown reports.
 </p>
 
 <p align="center">
   <a href="https://github.com/0xmariowu/Autosearch/releases"><img src="https://img.shields.io/github/v/release/0xmariowu/Autosearch?style=flat-square" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/0xmariowu/Autosearch?style=flat-square" alt="License"></a>
   <a href="https://github.com/0xmariowu/Autosearch/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/0xmariowu/Autosearch/ci.yml?style=flat-square&label=CI" alt="CI"></a>
-  <img src="https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square" alt="Python">
-  <img src="https://img.shields.io/badge/channels-34-green?style=flat-square" alt="Channels">
+  <img src="https://img.shields.io/badge/python-3.12%2B-blue?style=flat-square" alt="Python">
+  <img src="https://img.shields.io/badge/status-v2%20alpha-orange?style=flat-square" alt="Status">
 </p>
 
 <p align="center">
-  <a href="https://www.autosearch.dev">Website</a> &bull;
-  <a href="https://docs.autosearch.dev">Documentation</a> &bull;
+  <a href="#status">Status</a> &bull;
   <a href="#quick-start">Quick Start</a> &bull;
-  <a href="#what-makes-it-different">What Makes It Different</a> &bull;
-  <a href="#self-evolution">Self-Evolution</a> &bull;
-  <a href="#how-it-works">How It Works</a> &bull;
-  <a href="#channels">Channels</a> &bull;
-  <a href="#contributing">Contributing</a>
+  <a href="#architecture">Architecture</a> &bull;
+  <a href="#interfaces">Interfaces</a> &bull;
+  <a href="docs/delivery-status.md">Delivery Status</a>
 </p>
 
 ---
 
+## Status
+
+AutoSearch is undergoing a full **v2 rewrite** (`legacy-v1` tag preserves the v1 state). v2 replaces the monolithic v1 with a modular pipeline (M0–M8) behind strict source-mapped reuse of proven deep-research projects. Channel adapters (the real data sources) are on the roadmap — the current release ships a `DemoChannel` placeholder so the end-to-end pipeline is exercisable.
+
+See [`docs/delivery-status.md`](docs/delivery-status.md) for a module-by-module checklist.
+
 ## Quick Start
 
 ```bash
-npm install -g @0xmariowu/autosearch
+pipx install autosearch       # (after first tagged v2 release)
+autosearch query "your topic"
 ```
 
-Then start a new Claude Code session and run:
+Requirements: Python 3.12+. Set one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or have the `claude` CLI on `PATH` — the LLM layer auto-detects the first available provider.
 
-```
-/autosearch "compare vector databases for RAG applications"
-```
-
-<details>
-<summary>Alternative install (no npm)</summary>
+Streaming progress to stderr is default (`--stream`); suppress with `--no-stream` or use `--json` for a machine-readable envelope:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/0xmariowu/autosearch/main/scripts/install.sh | bash
+autosearch query "retrieval-augmented generation survey" --json
 ```
-</details>
-
-AutoSearch asks two questions — how deep and what format — then searches, evaluates, and delivers a cited report with real-time progress:
-
-```
-[Phase 1/6] Recall     — 25 rubrics, 47 items recalled, 15 queries planned
-[Phase 2/6] Search     — 62 results from 12 channels
-[Phase 3/6] Evaluate   — 54 relevant, 3 gap queries
-[Phase 4/6] Synthesize — report ready (38 citations)
-[Phase 5/6] Rubrics    — 23/25 rubrics passed
-[Phase 6/6] Evolve     — 4 patterns saved
-```
-
-## What Makes It Different
-
-| | AutoSearch | Perplexity | Native Claude |
-|---|---|---|---|
-| **Search channels** | 34 dedicated connectors | ~3 web engines | 1 (WebSearch) |
-| **Chinese sources** | 12 native (zhihu, bilibili, 36kr, csdn...) | 0 | 0 |
-| **Academic sources** | 6 (arXiv, Semantic Scholar, OpenReview, Papers with Code...) | 1 | 0 |
-| **Gets smarter over time** | Yes — learns which queries and channels work | No | No |
-| **Every result cited** | Yes (two-stage citation lock) | Yes (URL-level) | No |
-| **Reports** | Markdown / Rich HTML / Slides | Web page | Plain text |
-| **Cost** | Free (Claude Code plugin) | $20/month | Free |
-| **Integration** | Native inside Claude Code | Separate tool | Built-in but limited |
-
-## Self-Evolution
-
-This is the core idea. Most search tools run the same strategy every time. AutoSearch learns from every session and gets measurably better.
-
-**How it works**: after each search, AutoSearch records which queries found relevant results and which returned nothing. Next time, it skips what failed and doubles down on what worked. Over sessions, it builds a profile of which channels are useful for which types of topics.
-
-**What it looks like in practice**:
-
-```
-Session 1: "vector databases for RAG"
-  → Searched 15 channels, 8 had results
-  → Learned: arxiv + github-repos are high-yield for this topic
-  → Learned: producthunt and crunchbase returned nothing useful
-  → Saved 3 winning query patterns
-
-Session 2: same topic, 2 weeks later
-  → Auto-skipped channels that failed last time
-  → Reused winning query patterns, added freshness filter
-  → Found 12 new results the first session missed
-  → Score improved: 0.65 → 0.78
-
-Session 3: different topic ("AI agent frameworks")
-  → Applied cross-topic patterns (arxiv query structure, github star filter)
-  → Reached 0.71 on first attempt (vs 0.58 baseline)
-```
-
-**The safety mechanism**: the evaluator (`judge.py`) is fixed and cannot be modified by evolution. Only search strategy evolves — not the scoring. This prevents the system from gaming its own metrics.
-
-## How It Works
-
-```
-You: /autosearch "topic"
- │
- ▼
-[1] Claude recalls what it already knows → maps 9 knowledge dimensions
- │
-[2] Identifies gaps → generates queries ONLY for what Claude doesn't know
- │
-[3] Searches 34 channels in parallel (10-30 seconds)
- │
-[4] LLM evaluates each result for relevance, filters noise
- │
-[5] Synthesizes report with two-stage citation lock
- │
-[6] Checks quality rubrics → evolves strategy → commits improvements
-```
-
-**The key insight**: Claude already knows 60-70% of most research topics from training data. AutoSearch doesn't waste time re-searching what Claude already knows. It maps gaps first, then searches specifically for fresh data, community voice, Chinese sources, and niche repositories that Claude's training missed.
-
-## Channels
-
-34 channels. No API keys required. Every channel has a dedicated search connector — not just web search with `site:` filters.
-
-| Category | Channels | Why it matters |
-|---|---|---|
-| **Code** | github-repos, github-issues, npm-pypi, stackoverflow | Find actual implementations, not just articles about them |
-| **Academic** | arxiv, semantic-scholar, google-scholar, citation-graph, papers-with-code, huggingface | Latest papers + code, conference proceedings, models and datasets |
-| **Community** | reddit, hn, twitter/x, devto | Real user experiences, not marketing |
-| **Chinese** | zhihu, bilibili, csdn, juejin, 36kr, wechat, weibo, xiaohongshu, douyin, xiaoyuzhou, xueqiu, infoq-cn | 12 platforms. No other research tool covers the Chinese internet like this |
-| **Video** | youtube, bilibili, conference-talks | Tutorials, demos, conference keynotes with transcript extraction |
-| **Business** | producthunt, crunchbase, g2, linkedin | Startup discovery, funding data, real user reviews |
-| **General** | web-ddgs, rss | Broad web coverage as a baseline |
-
-Optional: add Exa or Tavily API keys for semantic search capabilities.
-
-## Why I Built This
-
-I kept doing the same research workflow manually: search Google, then Reddit, then GitHub, then arXiv, then three Chinese platforms — 30 minutes per topic, and I'd always miss something. The worst part: every session started from zero. I'd forget which queries worked last time.
-
-AutoSearch automates the multi-platform search I was already doing. But the part that actually matters is that it learns. After 10 sessions on AI topics, it stopped wasting queries on channels that never returned relevant results for that domain and started using query patterns that consistently found what I needed.
-
-## Update
-
-```bash
-claude plugin update autosearch@autosearch
-```
-
-Or re-run the install script. To enable auto-updates: `/plugin` > Marketplaces > autosearch > Enable auto-update.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, PR rules, and how to add a channel.
 
 ## Architecture
 
-<details>
-<summary>Directory structure</summary>
-
 ```
-autosearch/
-  .claude-plugin/     Plugin manifest (version, metadata)
-  commands/           /autosearch entry point + setup
-  agents/             Researcher agent definition
-  skills/             54 skills (pipeline, synthesis, evaluation, evolution)
-  channels/           34 channel plugins (SKILL.md + search.py each)
-    _engines/         Shared backends (baidu, ddgs)
-  lib/                search_runner.py, judge.py (fixed evaluator)
-  state/              Append-only learning data
-  scripts/            Setup, install, version management
+query
+  ↓
+M0 Knowledge Recall (known facts + gaps)
+M1 Goal Crystallization + Clarify (rubrics + mode)
+M2 Search Strategy (subqueries)
+M3 Iteration Controller (reflect-on-gaps loop across channels)
+M4 Material Cleaner (trafilatura)
+M5 Evidence Processor (URL dedup + SimHash + BM25)
+M7 Report Synthesizer (outline + per-section + citation remap)
+M8 Quality Gate (rubric evaluation, one retry on fail)
+  ↓
+markdown + References + Sources breakdown
 ```
 
-</details>
+Observability (`CostTracker`) and persistence (`SessionStore`, three-table SQLite schema) are available as Pipeline constructor args.
+
+Each module traces to a 1:1 source in a well-known deep-research project — see `docs/delivery-status.md` for the mapping.
+
+## Interfaces
+
+AutoSearch runs as:
+
+- **CLI**: `autosearch query "..."`
+- **HTTP + SSE**: `autosearch serve` — `POST /search` streams typed events (`phase` / `iteration` / `gap` / `quality` / `finished`)
+- **MCP server**: `autosearch mcp` (or `autosearch-mcp` console script) — exposes a `research` tool to Claude Code, Cursor, and other MCP clients
+- **Claude Code slash command**: `/autosearch` (ships in `commands/autosearch.md`)
+
+## Channels
+
+v2 currently ships `DemoChannel` as a placeholder. Real channel adapters (arxiv, GitHub, HackerNews, Reddit, StackOverflow, YouTube, ProductHunt, DDGS, Semantic Scholar, HuggingFace, npm/PyPI — plus 中文 sources: 小红书 / B 站 / 微信 / 知乎 / 抖音 / 微博) are on the roadmap. See plan roadmap in `docs/delivery-status.md`.
+
+## Contributing
+
+The v1 architecture (`skills/`, `channels/*/SKILL.md`, AVO self-evolution loop) was retired in v2. Contributions targeting the v2 architecture are welcome — the module map in `docs/delivery-status.md` is the starting point.
 
 ## License
 
-MIT
+[MIT](LICENSE).

--- a/docs/delivery-status.md
+++ b/docs/delivery-status.md
@@ -1,0 +1,74 @@
+---
+title: "Delivery Status"
+description: "Module-by-module status of the v2 rewrite"
+---
+
+# v2 Delivery Status
+
+Snapshot of which modules from `plan v2.3 § 13.5` have landed. All shipped modules have unit or integration tests and a 1:1 source comment on each file.
+
+## Pipeline (M0–M8)
+
+| Module | Status | Source |
+|---|---|---|
+| M0 Knowledge Recall | ✅ shipped | Self-written (node-deepresearch semantics) |
+| M1 Clarify | ✅ shipped | open_deep_research/src/open_deep_research/prompts.py:L3-L41 |
+| M2 Search Strategy | ✅ shipped | gpt-researcher/gpt_researcher/prompts.py:L213-L255 |
+| M3 Iteration Controller | ✅ shipped | open_deep_research/src/legacy/graph.py:L235-L354 |
+| M4 Trafilatura Cleaner | ✅ shipped | storm/knowledge_storm/utils.py:L685-L711 |
+| M4 per-source cleaner framework | 🟡 Protocol only; real cleaners pending channel layer | Self-written |
+| M5 Evidence Processor (URL dedup + BM25 + SimHash) | ✅ shipped | deer-flow infoquest_client.py:L183-L230 + rank-bm25 + simhash |
+| M7 Report Synthesizer | ✅ shipped | storm outline_generation / article_generation + open_deep_research citation rules |
+| M8 Quality Gate | ✅ shipped | open_deep_research/src/legacy/prompts.py:L168-L198 |
+
+`Pipeline` orchestrator composes the above with a clarification early-exit and one quality-gate retry. Phase events are emitted through a user-supplied callback.
+
+## Presentation
+
+| Surface | Status | Notes |
+|---|---|---|
+| CLI `autosearch query` | ✅ shipped | `--mode fast\|deep`, `--top-k`, `--stream`, `--json` |
+| CLI `autosearch mcp` | ✅ shipped | Alias for `autosearch-mcp` stdio server |
+| CLI `autosearch serve` | ✅ shipped | `--host`, `--port` for FastAPI SSE |
+| HTTP `/health` | ✅ shipped | JSON liveness |
+| HTTP `/search` SSE | ✅ shipped | Streams `phase` / `iteration` / `gap` / `quality` / `finished` events |
+| MCP server (FastMCP stdio) | ✅ shipped | Tools: `research(query, mode)`, `health()` |
+| Claude Code `/autosearch` slash command | ✅ shipped | `commands/autosearch.md` |
+| Citation rendering | ✅ shipped | Inline `[n]` + `## References` + `## Sources` breakdown |
+| Progress streaming | ✅ shipped | Callback → stderr NDJSON (CLI) + SSE (HTTP) |
+| OpenAI-compat `/v1/chat/completions` | ❌ pending | Plan § 13.5 HIGH — node-deepresearch port (~1.5d) |
+
+## Observability & Persistence
+
+| Module | Status | Notes |
+|---|---|---|
+| Cost Tracker | ✅ shipped + wired into `LLMClient` and `Pipeline` | gpt-researcher utils/costs.py |
+| Session SQLite store (3-table schema) | ✅ shipped + wired into `Pipeline` | crawl4ai async_database.py pattern + self-written schema |
+
+## Channels
+
+Deferred — real adapters will land after the channel layer unpauses. `DemoChannel` ships today as a placeholder implementing the `Channel` Protocol so the pipeline runs end-to-end.
+
+Planned roadmap (plan § 5):
+
+- Overseas P0 (12–15): arxiv / DDGS / GitHub repos+issues / Reddit / HackerNews / StackOverflow / YouTube / ProductHunt / Semantic Scholar / HuggingFace / npm / PyPI
+- Chinese P0 (6): 小红书 / B 站 / 微信公众号 / 知乎 / 抖音 / 微博
+- Chinese P1 (4–6): CSDN / 掘金 / 36kr / 雪球 / 小宇宙 / 快手
+
+## Known Deferred Items
+
+- `autosearch init` dependency orchestrator (plan § 4.5) — channel-dep-heavy, deferred until channel layer unpauses
+- Per-source HTML cleaners for specific Chinese sites — deferred (channel layer owns the fetch path)
+- Plan v2.3 itself — spike 2 findings suggested the plan initially tested the wrong fetch paths (HTML direct scrape for zhihu/csdn/juejin where the plan always intended API + cookie per § 5 中文 P0). No structural plan revision needed; the spike retrospectively validated plan § 5's path choices.
+
+## Test Coverage
+
+- 73 passing tests (unit + integration), 0 ruff issues, consistent ruff format
+- Pre-commit hook enforces author identity + PII/codename scan
+- Pre-push rebases on main and runs pytest before publishing
+
+## Related Docs
+
+- Plan: `~/.claude/plans/autosearch-v2-dev.md` (v2.3)
+- Research mapping: `~/.claude/plans/research/module-map-*.md`
+- Spike results: `docs/spikes/`


### PR DESCRIPTION
## Summary
v1 README was still advertising "34 channels, self-evolution, npm install, Python 3.10+" — none of which matches the v2 codebase. Replaced with an accurate v2 overview and added a module-by-module delivery checklist.

- `README.md` — v2 intro, architecture diagram, interfaces (CLI / HTTP+SSE / MCP / Claude Code slash), channel status (placeholder only), Python 3.12+
- `docs/delivery-status.md` — shipped/pending table for Pipeline (M0-M8), Presentation surfaces, Observability+Persistence, Channels roadmap, test coverage

## Test plan
- [x] No code changes (docs only)
- [x] PII/codename/abs-path scan clean
- [x] Mintlify docs.json already references `introduction`; delivery-status is documented but not yet in nav (can be added later if we want it surfaced in the docs site)