### PR TITLE
test(w4): real_llm tests + nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,49 @@
+# Real LLM tests. Requires ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY secrets.
+# Tests skip gracefully if keys absent.
+name: Nightly Real LLM
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  real_llm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -e .
+
+      - name: Run real LLM tests
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        run: pytest -q -m real_llm
+
+      - name: Check for spike doc changes
+        if: always()
+        id: spike_doc
+        run: |
+          if git diff --quiet -- docs/spikes/spike-1-auto-detect.md; then
+            echo "modified=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "modified=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload spike doc artifact
+        if: always() && steps.spike_doc.outputs.modified == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: spike-1-auto-detect
+          path: docs/spikes/spike-1-auto-detect.md

--- a/tests/real_llm/__init__.py
+++ b/tests/real_llm/__init__.py
@@ -1,0 +1,2 @@
+# Self-written, plan v2.3 § 13.5
+# Marker package for env-gated real-LLM pytest coverage.

--- a/tests/real_llm/test_pipeline_demo.py
+++ b/tests/real_llm/test_pipeline_demo.py
@@ -1,0 +1,101 @@
+# Self-written, plan v2.3 § 13.5
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from autosearch.channels.demo import DemoChannel
+from autosearch.core.pipeline import Pipeline
+from autosearch.llm.client import LLMClient
+from autosearch.llm.providers.anthropic import AnthropicProvider
+from autosearch.llm.providers.claude_code import ClaudeCodeProvider
+from autosearch.llm.providers.gemini import GeminiProvider
+from autosearch.llm.providers.openai import OpenAIProvider
+from autosearch.observability.cost import CostTracker
+
+
+def _claude_code_available() -> bool:
+    if shutil.which("claude") is None:
+        return False
+
+    try:
+        result = subprocess.run(
+            ["claude", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except OSError:
+        return False
+
+    payload = result.stdout.strip() or result.stderr.strip()
+    if not payload:
+        return False
+
+    try:
+        auth_status = json.loads(payload)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(auth_status, dict) and auth_status.get("loggedIn") is True
+
+
+def _select_available_provider() -> str | None:
+    if _claude_code_available():
+        return "claude_code"
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return "anthropic"
+    if os.getenv("OPENAI_API_KEY"):
+        return "openai"
+    if os.getenv("GOOGLE_API_KEY"):
+        return "gemini"
+    return None
+
+
+def _build_provider(provider_name: str) -> object:
+    if provider_name == "claude_code":
+        return ClaudeCodeProvider()
+    if provider_name == "anthropic":
+        return AnthropicProvider()
+    if provider_name == "openai":
+        return OpenAIProvider()
+    if provider_name == "gemini":
+        return GeminiProvider()
+    raise ValueError(f"Unknown provider: {provider_name}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.real_llm
+async def test_pipeline_demo_roundtrip_uses_real_llm() -> None:
+    provider_name = _select_available_provider()
+    if provider_name is None:
+        pytest.skip("No real LLM provider available in this environment")
+
+    cost_tracker = CostTracker()
+    llm = LLMClient(
+        provider_name=provider_name,
+        providers={provider_name: _build_provider(provider_name)},
+        cost_tracker=cost_tracker,
+    )
+    pipeline = Pipeline(llm=llm, channels=[DemoChannel()])
+
+    async with asyncio.timeout(60):
+        result = await pipeline.run("retrieval augmented generation")
+        if result.status == "needs_clarification":
+            # Some providers treat the bare phrase as underspecified. Retry once with an explicit
+            # report request instead of looping indefinitely.
+            result = await pipeline.run(
+                "Write a concise research report about retrieval augmented generation, "
+                "covering what it is, key architecture tradeoffs, and cited sources."
+            )
+
+    assert result.status == "ok"
+    assert result.markdown is not None
+    assert "## References" in result.markdown
+    assert "## Sources" in result.markdown
+    assert any(line.startswith("#") for line in result.markdown.splitlines())
+    assert result.cost >= 0.0
+    assert result.prompt_tokens + result.completion_tokens > 0

--- a/tests/real_llm/test_provider_roundtrip.py
+++ b/tests/real_llm/test_provider_roundtrip.py
@@ -1,0 +1,106 @@
+# Self-written, plan v2.3 § 13.5
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+from pydantic import BaseModel
+
+from autosearch.llm.client import LLMClient
+from autosearch.llm.providers.anthropic import AnthropicProvider
+from autosearch.llm.providers.claude_code import ClaudeCodeProvider
+from autosearch.llm.providers.gemini import GeminiProvider
+from autosearch.llm.providers.openai import OpenAIProvider
+
+
+class Greeting(BaseModel):
+    text: str
+    score: int
+
+
+def _claude_code_unavailable_reason() -> str | None:
+    if shutil.which("claude") is None:
+        return "claude binary not found on PATH"
+
+    try:
+        result = subprocess.run(
+            ["claude", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except OSError as exc:
+        return f"claude auth status unavailable: {exc}"
+
+    payload = result.stdout.strip() or result.stderr.strip()
+    if payload:
+        try:
+            auth_status = json.loads(payload)
+        except json.JSONDecodeError:
+            auth_status = None
+        if isinstance(auth_status, dict) and auth_status.get("loggedIn") is True:
+            return None
+        if isinstance(auth_status, dict) and auth_status.get("loggedIn") is False:
+            return "claude auth status reports loggedIn=false"
+
+    return "claude auth status unavailable"
+
+
+def _require_provider(provider_name: str) -> None:
+    if provider_name == "claude_code":
+        unavailable_reason = _claude_code_unavailable_reason()
+        if unavailable_reason is not None:
+            pytest.skip(unavailable_reason)
+        return
+
+    requirements = {
+        "anthropic": "ANTHROPIC_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "gemini": "GOOGLE_API_KEY",
+    }
+    env_var = requirements[provider_name]
+    if not os.getenv(env_var):
+        pytest.skip(f"{env_var} not set")
+
+
+def _build_provider(provider_name: str) -> object:
+    if provider_name == "claude_code":
+        return ClaudeCodeProvider()
+    if provider_name == "anthropic":
+        return AnthropicProvider()
+    if provider_name == "openai":
+        return OpenAIProvider()
+    if provider_name == "gemini":
+        return GeminiProvider()
+    raise ValueError(f"Unknown provider: {provider_name}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.real_llm
+@pytest.mark.parametrize(
+    "provider_name",
+    ["claude_code", "anthropic", "openai", "gemini"],
+)
+async def test_provider_roundtrip_structured_output(provider_name: str) -> None:
+    _require_provider(provider_name)
+    client = LLMClient(
+        provider_name=provider_name,
+        providers={provider_name: _build_provider(provider_name)},
+    )
+
+    async with asyncio.timeout(30):
+        result = await client.complete(
+            (
+                "Return JSON only. "
+                "Set text to a short greeting for the AutoSearch test harness and score to an "
+                "integer confidence score."
+            ),
+            Greeting,
+        )
+
+    assert isinstance(result, Greeting)
+    assert result.text.strip()
+    assert isinstance(result.score, int)

--- a/tests/real_llm/test_spike_1_harness.py
+++ b/tests/real_llm/test_spike_1_harness.py
@@ -1,0 +1,163 @@
+# Self-written, plan v2.3 § 13.5
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autosearch.core.models import ClarifyResult
+from autosearch.llm.client import LLMClient
+from autosearch.llm.providers.anthropic import AnthropicProvider
+from autosearch.llm.providers.claude_code import ClaudeCodeProvider
+from autosearch.llm.providers.gemini import GeminiProvider
+from autosearch.llm.providers.openai import OpenAIProvider
+
+RUNS = 30
+SPIKE_DOC_PATH = Path("docs/spikes/spike-1-auto-detect.md")
+PROMPT = (
+    "You are the M1 clarify step. Return JSON only. "
+    "Decide whether the query 'best AI coding setup for a solo founder' needs clarification. "
+    "Always include rubrics and a mode recommendation."
+)
+
+
+def _claude_code_unavailable_reason() -> str | None:
+    if shutil.which("claude") is None:
+        return "claude binary not found on PATH"
+
+    try:
+        result = subprocess.run(
+            ["claude", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except OSError as exc:
+        return f"claude auth status unavailable: {exc}"
+
+    payload = result.stdout.strip() or result.stderr.strip()
+    if payload:
+        try:
+            auth_status = json.loads(payload)
+        except json.JSONDecodeError:
+            auth_status = None
+        if isinstance(auth_status, dict) and auth_status.get("loggedIn") is True:
+            return None
+        if isinstance(auth_status, dict) and auth_status.get("loggedIn") is False:
+            return "claude auth status reports loggedIn=false"
+
+    return "claude auth status unavailable"
+
+
+def _require_provider(provider_name: str) -> None:
+    if provider_name == "claude_code":
+        unavailable_reason = _claude_code_unavailable_reason()
+        if unavailable_reason is not None:
+            pytest.skip(unavailable_reason)
+        return
+
+    requirements = {
+        "anthropic": "ANTHROPIC_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "gemini": "GOOGLE_API_KEY",
+    }
+    env_var = requirements[provider_name]
+    if not os.getenv(env_var):
+        pytest.skip(f"{env_var} not set")
+
+
+def _build_provider(provider_name: str) -> object:
+    if provider_name == "claude_code":
+        return ClaudeCodeProvider()
+    if provider_name == "anthropic":
+        return AnthropicProvider()
+    if provider_name == "openai":
+        return OpenAIProvider()
+    if provider_name == "gemini":
+        return GeminiProvider()
+    raise ValueError(f"Unknown provider: {provider_name}")
+
+
+def _format_notes(notes: list[str]) -> str:
+    if not notes:
+        return "ok"
+    return "<br>".join(_sanitize_cell(note) for note in notes[:3])
+
+
+def _sanitize_cell(value: str) -> str:
+    return " ".join(value.replace("|", "/").split())
+
+
+def _write_result_row(
+    provider_name: str,
+    *,
+    fail_count: int,
+    fail_rate: float,
+    notes: list[str],
+) -> bool:
+    if not SPIKE_DOC_PATH.exists():
+        return False
+
+    content = SPIKE_DOC_PATH.read_text(encoding="utf-8")
+    if "## Result Table" not in content:
+        return False
+
+    lines = content.splitlines()
+    replacement = f"| {provider_name} | {fail_count} | {fail_rate:.4f} | {_format_notes(notes)} |"
+
+    updated = False
+    for index, line in enumerate(lines):
+        if line.startswith(f"| {provider_name} |"):
+            lines[index] = replacement
+            updated = True
+            break
+
+    if not updated:
+        return False
+
+    SPIKE_DOC_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True
+
+
+@pytest.mark.asyncio
+@pytest.mark.real_llm
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "provider_name",
+    ["claude_code", "anthropic", "openai", "gemini"],
+)
+async def test_spike_1_provider_fail_rate_under_five_percent(provider_name: str) -> None:
+    _require_provider(provider_name)
+    client = LLMClient(
+        provider_name=provider_name,
+        providers={provider_name: _build_provider(provider_name)},
+    )
+
+    failures = 0
+    notes: list[str] = []
+
+    async with asyncio.timeout(600):
+        for index in range(RUNS):
+            try:
+                result = await client.complete(PROMPT, ClarifyResult)
+                assert isinstance(result, ClarifyResult)
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                notes.append(f"run {index + 1}: {type(exc).__name__}: {exc}")
+
+    fail_rate = failures / RUNS
+    _write_result_row(
+        provider_name,
+        fail_count=failures,
+        fail_rate=fail_rate,
+        notes=notes,
+    )
+
+    assert fail_rate < 0.05, (
+        f"{provider_name} fail rate {fail_rate:.4f} exceeded threshold with {failures}/{RUNS} "
+        "failures"
+    )


### PR DESCRIPTION
## Summary
Wave 4 of TEST_PLAN. Adds live-LLM tests that exercise real providers plus the nightly workflow that runs them when secrets are set.

### Tests (all `@pytest.mark.real_llm`; skip gracefully when keys absent)
- `test_provider_roundtrip.py` — parametrized over 4 providers (claude_code / anthropic / openai / gemini); each does one minimal structured-output call, parses result
- `test_pipeline_demo.py` — full `Pipeline(llm, DemoChannel())` run, asserts real markdown with `## References` + `## Sources` + non-zero tokens
- `test_spike_1_harness.py` — implements the design in `docs/spikes/spike-1-auto-detect.md`: 30 calls × available providers, asserts fail rate < 5%, writes result table back to the doc when the placeholder is found

### Workflow `.github/workflows/nightly.yml`
- `schedule: cron "0 6 * * *"` (06:00 UTC daily) + `workflow_dispatch` (manual)
- Installs deps, runs `pytest -m real_llm`, uploads updated `spike-1-auto-detect.md` as artifact
- Env from repo secrets: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` (claude CLI login is a runner-level prerequisite, separate from env)

## Test plan
- [x] Default CI (PR gate): **87 passed** (unchanged), 14 deselected
- [x] Real LLM selector (sandbox, no keys): 9 skipped, 0 failed
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] PII scan clean
- [x] `yaml.safe_load(nightly.yml)` — valid

## Boss action required to activate W4
Add 3 secrets in GitHub → Settings → Secrets → Actions:
- `ANTHROPIC_API_KEY`
- `OPENAI_API_KEY`
- `GOOGLE_API_KEY`

Once set, the 06:00 UTC cron starts producing real pass/fail numbers. Before that, tests skip — no harm.

## Next (W5, optional)
Perf / concurrency tests — local-only, on-demand, no CI gating.