### PR TITLE
test(w5): perf / concurrency tests (on-demand)

### DIFF
--- a/tests/perf/__init__.py
+++ b/tests/perf/__init__.py
@@ -1,0 +1,2 @@
+# Self-written, plan v2.3 § 13.5
+# On-demand performance tests only.

--- a/tests/perf/test_mcp_rapid_calls.py
+++ b/tests/perf/test_mcp_rapid_calls.py
@@ -1,0 +1,63 @@
+# Self-written, plan v2.3 § 13.5
+import time
+
+import pytest
+
+import autosearch.mcp.server as mcp_server
+from autosearch.core.models import ClarifyResult, SearchMode
+from autosearch.core.pipeline import PipelineResult
+
+
+def _ok_result() -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown="# Perf\n\nRapid MCP response.",
+        iterations=1,
+    )
+
+
+class _ImmediatePipeline:
+    def __init__(self, result: PipelineResult) -> None:
+        self.result = result
+        self.calls: list[tuple[str, SearchMode | None]] = []
+
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+    ) -> PipelineResult:
+        self.calls.append((query, mode_hint))
+        return self.result
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_research_tool_handles_twenty_rapid_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _ImmediatePipeline(result=_ok_result())
+    monkeypatch.setattr(mcp_server, "_default_pipeline_factory", lambda: pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+
+    started_at = time.perf_counter()
+    outputs = [
+        await research_tool.run({"query": f"rapid call {index}", "mode": "fast"})
+        for index in range(20)
+    ]
+    elapsed = time.perf_counter() - started_at
+
+    assert len(outputs) == 20
+    assert all(output for output in outputs)
+    assert elapsed < 3.0
+    assert pipeline.calls == [(f"rapid call {index}", SearchMode.FAST) for index in range(20)]

--- a/tests/perf/test_pipeline_large_evidence.py
+++ b/tests/perf/test_pipeline_large_evidence.py
@@ -1,0 +1,173 @@
+# Self-written, plan v2.3 § 13.5
+import json
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import BaseModel
+
+from autosearch.core.clarify import _ClarifyCompletion
+from autosearch.core.iteration import _GapReflectionResponse
+from autosearch.core.models import (
+    EvaluationResult,
+    Evidence,
+    Gap,
+    GradeOutcome,
+    KnowledgeRecall,
+    SearchMode,
+)
+from autosearch.core.pipeline import Pipeline
+from autosearch.core.strategy import _SubQueryBatch
+from autosearch.llm.client import LLMClient
+from autosearch.synthesis.outline import OutlineResponse
+from autosearch.synthesis.section import _SectionWriteResponse
+from tests.fixtures.fake_channel import FakeChannel
+
+NOW = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
+QUERY = "querytoken framework scale check"
+
+
+@dataclass(frozen=True)
+class CompletionStep:
+    response_model: type[BaseModel]
+    payload: dict[str, object]
+
+
+class ScriptedProvider:
+    name = "scripted"
+
+    def __init__(self, steps: list[CompletionStep]) -> None:
+        self.steps = list(steps)
+        self.calls = 0
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> str:
+        _ = prompt
+        if self.calls >= len(self.steps):
+            raise AssertionError(f"Unexpected extra LLM call for {response_model.__name__}")
+
+        step = self.steps[self.calls]
+        self.calls += 1
+        if response_model is not step.response_model:
+            raise AssertionError(
+                f"Expected response model {step.response_model.__name__}, got {response_model.__name__}"
+            )
+        return json.dumps(step.payload)
+
+
+def _make_evidence(index: int) -> Evidence:
+    tokens = " ".join(
+        [
+            QUERY,
+            f"querytoken-{index}",
+            f"bucket-{index % 17}",
+            f"cluster-{index % 29}",
+            f"signal-{index % 37}",
+        ]
+    )
+    return Evidence(
+        url=f"https://example.com/querytoken-evidence-{index}",
+        title=f"Querytoken evidence {index} {QUERY}",
+        snippet=f"Synthetic snippet {index} {tokens}",
+        content=(
+            f"Synthetic content {index} for {QUERY}. "
+            f"This evidence includes {tokens} and distinct tail marker item-{index}."
+        ),
+        source_channel="web",
+        fetched_at=NOW,
+    )
+
+
+def _scripted_llm() -> LLMClient:
+    provider = ScriptedProvider(
+        [
+            CompletionStep(
+                response_model=KnowledgeRecall,
+                payload=KnowledgeRecall(
+                    known_facts=["The querytoken scenario needs a large-evidence scale check."],
+                    gaps=[Gap(topic="Framework overhead", reason="Need end-to-end scale coverage")],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_ClarifyCompletion,
+                payload=_ClarifyCompletion(
+                    need_clarification=False,
+                    question="",
+                    verification="Enough information to proceed with the scale check.",
+                    rubrics=[
+                        "Uses the provided evidence set",
+                        "Produces a cited report",
+                        "Completes without clarification",
+                    ],
+                    mode=SearchMode.FAST,
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_SubQueryBatch,
+                payload=_SubQueryBatch(
+                    subqueries=[
+                        {"text": f"{QUERY} overview", "rationale": "cover overall evidence"},
+                        {"text": f"{QUERY} scale", "rationale": "cover high-volume processing"},
+                        {"text": f"{QUERY} citations", "rationale": "cover synthesis output"},
+                    ]
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_GapReflectionResponse,
+                payload=_GapReflectionResponse(gaps=[]).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=OutlineResponse,
+                payload=OutlineResponse(headings=["Overview", "Operational Notes"]).model_dump(
+                    mode="json"
+                ),
+            ),
+            CompletionStep(
+                response_model=_SectionWriteResponse,
+                payload=_SectionWriteResponse(
+                    content=(
+                        "The pipeline handles the large evidence set and still produces a "
+                        "grounded report with consistent querytoken signal [1][2]."
+                    ),
+                    ref_ids=[1, 2],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=_SectionWriteResponse,
+                payload=_SectionWriteResponse(
+                    content=(
+                        "Operationally, the synthetic evidence remains attributable and the "
+                        "framework overhead stays bounded for this scale check [2][3]."
+                    ),
+                    ref_ids=[2, 3],
+                ).model_dump(mode="json"),
+            ),
+            CompletionStep(
+                response_model=EvaluationResult,
+                payload=EvaluationResult(
+                    grade=GradeOutcome.PASS,
+                    follow_up_gaps=[],
+                ).model_dump(mode="json"),
+            ),
+        ]
+    )
+    return LLMClient(provider_name="scripted", providers={"scripted": provider})
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_pipeline_handles_five_hundred_evidence_items_quickly() -> None:
+    channel = FakeChannel(
+        name="web",
+        evidences=[_make_evidence(index) for index in range(500)],
+    )
+    pipeline = Pipeline(llm=_scripted_llm(), channels=[channel])
+
+    started_at = time.perf_counter()
+    result = await pipeline.run(QUERY)
+    elapsed = time.perf_counter() - started_at
+
+    assert result.status == "ok"
+    assert result.markdown
+    assert elapsed < 15.0
+    assert channel.call_count == 3

--- a/tests/perf/test_sse_concurrency.py
+++ b/tests/perf/test_sse_concurrency.py
@@ -1,0 +1,92 @@
+# Self-written, plan v2.3 § 13.5
+import asyncio
+import time
+
+import httpx
+import pytest
+
+import autosearch.server.main as server_main
+from autosearch.core.models import ClarifyResult, SearchMode
+from autosearch.core.pipeline import PipelineResult
+
+
+def _ok_result() -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown="# Perf\n\nConcurrent stream response.",
+        iterations=1,
+    )
+
+
+class _ImmediatePipeline:
+    def __init__(
+        self,
+        call_log: list[tuple[str, SearchMode | None]],
+        result: PipelineResult,
+        on_event=None,
+    ) -> None:
+        self.call_log = call_log
+        self.result = result
+        self.on_event = on_event
+
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+    ) -> PipelineResult:
+        self.call_log.append((query, mode_hint))
+        await asyncio.sleep(0)
+        return self.result
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_chat_completion_stream_handles_ten_concurrent_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_log: list[tuple[str, SearchMode | None]] = []
+
+    monkeypatch.setattr(
+        server_main,
+        "_default_pipeline_factory",
+        lambda on_event=None: _ImmediatePipeline(call_log, _ok_result(), on_event=on_event),
+    )
+
+    async def send_stream_request(
+        client: httpx.AsyncClient,
+        index: int,
+    ) -> httpx.Response:
+        return await client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": f"concurrency test {index}"}],
+                "stream": True,
+            },
+        )
+
+    started_at = time.perf_counter()
+    transport = httpx.ASGITransport(app=server_main.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        responses = await asyncio.gather(
+            *(send_stream_request(client, index) for index in range(10))
+        )
+    elapsed = time.perf_counter() - started_at
+
+    assert len(responses) == 10
+    assert all(response.status_code == 200 for response in responses)
+    assert all(
+        response.headers["content-type"].startswith("text/event-stream") for response in responses
+    )
+    assert all("data: [DONE]\n\n" in response.text for response in responses)
+    assert elapsed < 5.0
+    assert len(call_log) == 10


### PR DESCRIPTION
## Summary
Wave 5 (final) of TEST_PLAN. All tests `@pytest.mark.perf` — deselected by default CI, local / on-demand only.

- `test_sse_concurrency.py` — 10 concurrent `POST /v1/chat/completions` streams complete < 5s (deadlock / starvation check)
- `test_mcp_rapid_calls.py` — 20 sequential `research` tool calls via MCP server handler, no state leak
- `test_pipeline_large_evidence.py` — 500 synthetic Evidence through dedup/SimHash/BM25/synthesis, end-to-end < 15s

## Test plan
- [x] Default CI: 87 passed (unchanged), 17 deselected
- [x] Perf selector: 3 passed locally
- [x] ruff clean / format clean / PII scan clean

## Closing note
TEST_PLAN 5 waves complete:
- W1: plan doc + markers
- W2: 5 smoke tests + dummy LLM provider + push-to-main gate
- W3: 6 failure-path + persistence tests (every PR)
- W4: 3 real_llm tests + nightly workflow (skip without keys)
- W5: 3 perf tests (on-demand)

Totals: **87 default CI tests**, 5 smoke (push-to-main), 9 real_llm (nightly), 3 perf (on-demand).