### PR TITLE
fix(r1): emit error event on channel.search failure

### DIFF
--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -462,6 +462,16 @@ class _TrackingIterationController(IterationController):
                     subquery=query_text,
                     error=str(result),
                 )
+                if self.on_event is not None:
+                    await self.on_event(
+                        {
+                            "type": "error",
+                            "channel": channel_name,
+                            "phase": "search",
+                            "subquery": query_text,
+                            "message": str(result),
+                        }
+                    )
             else:
                 result_count = len(result)
                 evidences.extend(result)

--- a/tests/unit/test_pipeline_channel_error.py
+++ b/tests/unit/test_pipeline_channel_error.py
@@ -59,8 +59,9 @@ def _make_evidence(url: str, title: str, content: str) -> Evidence:
     )
 
 
-async def test_pipeline_continues_after_channel_error_without_emitting_error_event() -> None:
-    """Current behavior logs channel failures and keeps running with the remaining channels."""
+async def test_pipeline_continues_after_channel_error_and_emits_error_event() -> None:
+    """A channel raising in search() is logged, does not abort the run, and surfaces
+    as an `on_event({type: "error", ...})` envelope so consumers (CLI stream, SSE) see it."""
 
     llm = DummyClient(
         [
@@ -108,4 +109,10 @@ async def test_pipeline_continues_after_channel_error_without_emitting_error_eve
     assert working_channel.calls == 1
     assert working_channel.queries == ["working query"]
     assert any(event["type"] == "iteration" for event in events)
-    assert not any(event["type"] == "error" for event in events)
+    error_events = [event for event in events if event["type"] == "error"]
+    assert len(error_events) == 1
+    err = error_events[0]
+    assert err["channel"] == "failing"
+    assert err["phase"] == "search"
+    assert err["subquery"] == "working query"
+    assert "channel boom" in err["message"]


### PR DESCRIPTION
## Summary
Closes roadmap R1. W3 testing found Pipeline silently swallows `Channel.search()` exceptions — only `structlog.warning("channel_search_failed", ...)`, no `on_event` emission. Consumers (CLI `--stream`, SSE `/search`, any subscriber) see nothing when a channel breaks.

### Fix
In `_TrackingIterationController._search` (`autosearch/core/pipeline.py`), after logging the failure, emit:
```json
{"type": "error", "channel": "<name>", "phase": "search", "subquery": "<text>", "message": "<str(exc)>"}
```
Keep the swallow — Pipeline still continues with other channels, preserving "one bad channel doesn't kill the run" behavior.

### Test update
`tests/unit/test_pipeline_channel_error.py` was written in W3 to assert swallow-and-no-event (matched current code). Upgraded to assert exactly one `error`-type event with populated `channel` / `phase` / `subquery` / `message`.

## Test plan
- [x] `pytest -x -q -m "not real_llm and not perf and not slow"` — 87 passed
- [x] `ruff check .` / `ruff format --check .` — clean