### PR TITLE
ci(r2): v2 release workflow (pypi + github release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,143 +1,99 @@
+# Self-written, plan v2.3 § 13.5 (v2 release pipeline)
+#
+# Triggered by pushing a tag matching `v*` (e.g. `v0.0.1a1`).
+# Replaces the v1 CalVer/npm pipeline — v2 ships via pipx/PyPI.
+
 name: Release
 
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (must already exist)"
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+          python-version: "3.12"
 
-      - name: Extract version from tag
-        id: version
-        env:
-          TAG_NAME: ${{ github.ref_name }}
+      - name: Resolve tag and version
+        id: tag
         run: |
-          TAG="$TAG_NAME"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Validate tag format
+      - name: Verify tag matches pyproject version
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          if [[ ! "$TAG" =~ ^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]]; then
-            echo "::error::Invalid tag format: $TAG (expected vYYYY.MM.DD.N)"
+          PY_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$PY_VERSION" != "${{ steps.tag.outputs.version }}" ]; then
+            echo "::error::tag ${{ steps.tag.outputs.tag }} implies version ${{ steps.tag.outputs.version }} but pyproject.toml is $PY_VERSION"
             exit 1
           fi
+          echo "Verified: pyproject.toml version = ${{ steps.tag.outputs.version }}"
 
-      - name: Validate tag matches source version
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
+      - name: Install build backend
+        run: pip install build twine
 
-          # Claude Code plugin manifest (primary)
-          if [ -f .claude-plugin/plugin.json ]; then
-            PLUGIN_VERSION=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")
-            if [ "$VERSION" != "$PLUGIN_VERSION" ]; then
-              echo "::error::Tag v$VERSION does not match plugin.json version $PLUGIN_VERSION"
-              echo "::error::Run: scripts/bump-version.sh $VERSION"
-              exit 1
-            fi
-            echo "Validated: tag matches plugin.json ($VERSION)"
+      - name: Build sdist + wheel
+        run: python -m build
 
-            # Also verify marketplace.json is in sync
-            if [ -f .claude-plugin/marketplace.json ]; then
-              MKT_VERSION=$(python3 -c "import json; print(json.load(open('.claude-plugin/marketplace.json'))['metadata']['version'])")
-              if [ "$VERSION" != "$MKT_VERSION" ]; then
-                echo "::error::marketplace.json version ($MKT_VERSION) out of sync with plugin.json ($PLUGIN_VERSION)"
-                exit 1
-              fi
-            fi
-            exit 0
-          fi
+      - name: Check wheel metadata
+        run: twine check dist/*
 
-          echo "::warning::No version file found — skipping version match validation"
+      - name: Publish to PyPI
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*
 
-      - name: Extract changelog
-        id: changelog
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          # Escape dots for awk regex (1.2.3 -> 1\.2\.3)
-          SAFE_VERSION="${VERSION//./\\.}"
-          NOTES=""
-          if [ -f CHANGELOG.md ]; then
-            # Match "## X.Y.Z" optionally followed by space+anything (date, dash, etc.) or end of line
-            NOTES=$(awk "/^## ${SAFE_VERSION}([[:space:]]|$)/{found=1; next} /^## [0-9]/{if(found) exit} found" CHANGELOG.md | awk 'NF{p=1} p')
-          fi
-          if [ -n "$NOTES" ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "$NOTES" > /tmp/release-notes.md
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Note PyPI skip
+        if: ${{ !secrets.PYPI_API_TOKEN }}
+        run: echo "PYPI_API_TOKEN secret not set — skipping PyPI publish, creating GitHub Release only."
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
-          if [ "${{ steps.changelog.outputs.found }}" == "true" ]; then
-            gh release create "$TAG" --title "${REPO_NAME} ${VERSION}" --notes-file /tmp/release-notes.md
-          else
-            gh release create "$TAG" --title "${REPO_NAME} ${VERSION}" --generate-notes
-          fi
-
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          cd npm
-          # Sync version from tag into npm package.json
-          node -e "
-            const pkg = require('./package.json');
-            pkg.version = '$VERSION';
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          npm publish --access public || true
-          rm -f .npmrc
-          echo "Published @0xmariowu/autosearch@${VERSION} to npm"
-
-      - name: Sync website
-        env:
-          GH_TOKEN: ${{ secrets.AUTOSEARCH_CROSS_REPO_TOKEN }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          CHANNEL_COUNT=$(python3 -c "import json; print(json.load(open('release-metadata.json'))['channel_count'])" 2>/dev/null || echo "34")
-          if [ -n "$GH_TOKEN" ]; then
-            gh workflow run sync-from-release.yml \
-              --repo 0xmariowu/autosearch-smart-search \
-              --field version="$VERSION" \
-              --field channel_count="$CHANNEL_COUNT" \
-              || echo "Warning: website sync failed (SYNC_TOKEN may not be configured)"
-          else
-            echo "Skipping website sync (SYNC_TOKEN not configured)"
-          fi
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --title "AutoSearch ${{ steps.tag.outputs.tag }}" \
+            --generate-notes \
+            dist/*
 
       - name: Summary
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
           {
-            echo "## Released ${VERSION}"
-            echo "- GitHub Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${TAG}"
-            echo "- npm: [@0xmariowu/autosearch@${VERSION}](https://www.npmjs.com/package/@0xmariowu/autosearch)"
+            echo "## Released ${{ steps.tag.outputs.version }}"
+            echo "- GitHub Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.tag.outputs.tag }}"
+            if [ -n "${{ secrets.PYPI_API_TOKEN }}" ]; then
+              echo "- PyPI: https://pypi.org/project/autosearch/${{ steps.tag.outputs.version }}/"
+            else
+              echo "- PyPI: skipped (no token)"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,15 +75,26 @@ jobs:
       - name: Check wheel metadata
         run: twine check dist/*
 
+      - name: Check PyPI token availability
+        id: pypi
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          if [ -n "$PYPI_TOKEN" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to PyPI
-        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        if: steps.pypi.outputs.has_token == 'true'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
 
       - name: Note PyPI skip
-        if: ${{ !secrets.PYPI_API_TOKEN }}
+        if: steps.pypi.outputs.has_token != 'true'
         run: echo "PYPI_API_TOKEN secret not set — skipping PyPI publish, creating GitHub Release only."
 
       - name: Create GitHub Release
@@ -100,7 +111,7 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           VERSION: ${{ steps.tag.outputs.version }}
-          PYPI_TOKEN_SET: ${{ secrets.PYPI_API_TOKEN != '' }}
+          PYPI_TOKEN_SET: ${{ steps.pypi.outputs.has_token }}
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,24 +38,33 @@ jobs:
 
       - name: Resolve tag and version
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$DISPATCH_TAG"
           else
-            TAG="${GITHUB_REF#refs/tags/}"
+            TAG="$REF_NAME"
           fi
           VERSION="${TAG#v}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify tag matches pyproject version
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
           PY_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          if [ "$PY_VERSION" != "${{ steps.tag.outputs.version }}" ]; then
-            echo "::error::tag ${{ steps.tag.outputs.tag }} implies version ${{ steps.tag.outputs.version }} but pyproject.toml is $PY_VERSION"
+          if [ "$PY_VERSION" != "$VERSION" ]; then
+            echo "::error::tag $TAG implies version $VERSION but pyproject.toml is $PY_VERSION"
             exit 1
           fi
-          echo "Verified: pyproject.toml version = ${{ steps.tag.outputs.version }}"
+          echo "Verified: pyproject.toml version = $VERSION"
 
       - name: Install build backend
         run: pip install build twine
@@ -80,20 +89,27 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          gh release create "${{ steps.tag.outputs.tag }}" \
-            --title "AutoSearch ${{ steps.tag.outputs.tag }}" \
+          gh release create "$TAG" \
+            --title "AutoSearch $TAG" \
             --generate-notes \
             dist/*
 
       - name: Summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          PYPI_TOKEN_SET: ${{ secrets.PYPI_API_TOKEN != '' }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
         run: |
           {
-            echo "## Released ${{ steps.tag.outputs.version }}"
-            echo "- GitHub Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.tag.outputs.tag }}"
-            if [ -n "${{ secrets.PYPI_API_TOKEN }}" ]; then
-              echo "- PyPI: https://pypi.org/project/autosearch/${{ steps.tag.outputs.version }}/"
+            echo "## Released $VERSION"
+            echo "- GitHub Release: $SERVER_URL/$REPO/releases/tag/$TAG"
+            if [ "$PYPI_TOKEN_SET" = "true" ]; then
+              echo "- PyPI: https://pypi.org/project/autosearch/$VERSION/"
             else
-              echo "- PyPI: skipped (no token)"
+              echo "- PyPI: skipped (no PYPI_API_TOKEN secret)"
             fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Closes roadmap R2. v1 release.yml was CalVer+npm; v2 ships via pipx / PyPI. Rewritten from scratch.

- Trigger: `push tags v*` + `workflow_dispatch` (manual)
- Verify tag matches `pyproject.toml` version (fails fast on drift)
- `python -m build` → sdist + wheel
- `twine check dist/*` (metadata validity)
- Publish to PyPI **only if `PYPI_API_TOKEN` secret set** — otherwise skip with note
- Always create GitHub Release with auto-generated notes + attach dist artifacts

## Test plan
- [x] `yaml.safe_load` parses workflow
- [x] No code changes (workflow only)
- [x] ruff / pytest unchanged (104 tests)

## Boss action to activate
1. Settings → Secrets → Actions → add `PYPI_API_TOKEN` (skip if OK with GitHub-only releases).
2. After this PR merges: `git tag v0.0.1a1 && git push --tags` to cut the first alpha release.