### PR TITLE
fix(hooks): pre-push selector skips real_llm/perf/slow

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -41,7 +41,8 @@ if [ -z "$PYTHON" ]; then
   exit 0
 fi
 
-PYTHONPATH="$REPO_ROOT" "$PYTHON" -m pytest tests/ -x -q -m "not network" 2>/dev/null \
+PYTHONPATH="$REPO_ROOT" "$PYTHON" -m pytest tests/ -x -q \
+  -m "not real_llm and not perf and not slow and not network" 2>/dev/null \
   || PYTHONPATH="$REPO_ROOT" "$PYTHON" -m unittest discover -s tests -q
 
 # --- Version bump check ---


### PR DESCRIPTION
## Summary
`.husky/pre-push` ran `pytest -m "not network"`, which still included `real_llm`, `perf`, and `slow` markers — each pre-push took ~15 minutes and prevented real_llm tests from staying nightly-only per the test pyramid.

Align with HANDOFF rule #8 and `docs/testing/TEST_PLAN.md` § 4: selector now excludes `real_llm`, `perf`, `slow`, and `network`.

## Evidence
- Before: 15 min per push (114 tests including spike-1-harness + pipeline_demo real_llm + perf/sse_concurrency)
- After: 1.8s per push (111 default-tier tests, 17 deselected)
- Side effect: push no longer races SSH connection timeout → SIGPIPE (hygiene branch had to retry 4× last session because hook held SSH idle > server keepalive)

## Test plan
- [x] `pytest tests/ -x -q -m "not real_llm and not perf and not slow and not network"` → 111 passed, 17 deselected, 2.5s
- [x] Hook itself verified on this PR's push — completed in 1.8s
- [ ] Reviewer sign-off

## Follow-ups (out of scope)
- The nightly workflow (`.github/workflows/nightly.yml`) is where real_llm + perf tests should run, gated by repo secrets. No change needed for this PR — nightly is already configured.