### PR TITLE
fix(gemini): move api key from URL param to x-goog-api-key header

### DIFF
--- a/autosearch/llm/providers/gemini.py
+++ b/autosearch/llm/providers/gemini.py
@@ -29,15 +29,18 @@ class GeminiProvider:
             },
         }
         url = (
-            "https://generativelanguage.googleapis.com/v1beta/models/"
-            f"{self.model}:generateContent?key={self.api_key}"
+            f"https://generativelanguage.googleapis.com/v1beta/models/{self.model}:generateContent"
         )
+        headers = {
+            "content-type": "application/json",
+            "x-goog-api-key": self.api_key,
+        }
 
         if self.http_client is not None:
-            response = await self.http_client.post(url, json=payload)
+            response = await self.http_client.post(url, json=payload, headers=headers)
         else:
             async with httpx.AsyncClient(timeout=60.0) as client:
-                response = await client.post(url, json=payload)
+                response = await client.post(url, json=payload, headers=headers)
 
         response.raise_for_status()
         data = response.json()

--- a/tests/unit/test_gemini_provider_auth.py
+++ b/tests/unit/test_gemini_provider_auth.py
@@ -1,0 +1,52 @@
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from autosearch.llm.providers.gemini import GeminiProvider
+
+
+class _Out(BaseModel):
+    answer: str
+
+
+def _handler(captured: dict[str, object]) -> httpx.MockTransport:
+    def respond(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={"candidates": [{"content": {"parts": [{"text": '{"answer":"ok"}'}]}}]},
+        )
+
+    return httpx.MockTransport(respond)
+
+
+async def test_api_key_sent_in_header_not_url() -> None:
+    captured: dict[str, object] = {}
+    async with httpx.AsyncClient(transport=_handler(captured)) as client:
+        provider = GeminiProvider(api_key="SECRET_SENTINEL", http_client=client)
+        await provider.complete("hi", _Out)
+
+    url = captured["url"]
+    headers = captured["headers"]
+    assert isinstance(url, str)
+    assert isinstance(headers, dict)
+    assert "SECRET_SENTINEL" not in url
+    assert "key=" not in url
+    assert headers.get("x-goog-api-key") == "SECRET_SENTINEL"
+
+
+async def test_request_targets_generate_content_endpoint() -> None:
+    captured: dict[str, object] = {}
+    async with httpx.AsyncClient(transport=_handler(captured)) as client:
+        provider = GeminiProvider(api_key="k", model="gemini-2.5-pro", http_client=client)
+        await provider.complete("hi", _Out)
+
+    url = captured["url"]
+    assert isinstance(url, str)
+    assert url.endswith("/v1beta/models/gemini-2.5-pro:generateContent")
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError, match="GOOGLE_API_KEY"):
+        GeminiProvider(api_key=None)


### PR DESCRIPTION
## Summary
`GeminiProvider` built its URL as `...:generateContent?key=\${api_key}`, which leaks the secret into:

1. **httpx exception messages** — `response.raise_for_status()` includes the full URL (with the key) when a 4xx/5xx surfaces. If that exception is logged, the key ends up in logs.
2. **Python tracebacks** — same URL appears in stack frames on any downstream failure.
3. **Google-side request logs** — URL-embedded keys show up in upstream access logs (not a direct Autosearch leak, but still a known anti-pattern).

Switch to the Google-supported `x-goog-api-key` request header. No behavioral change for successful calls; failure paths no longer leak the key.

## Test plan
- [x] 3 new unit tests in `tests/unit/test_gemini_provider_auth.py` — all pass
  - `SECRET_SENTINEL` never appears in request URL
  - `x-goog-api-key` header carries the key
  - URL targets the correct generateContent endpoint for the configured model
  - Missing `GOOGLE_API_KEY` still raises `ValueError`
- [x] 114 default-tier tests pass (no regressions)
- [x] `ruff check` + `ruff format` clean
- [ ] Reviewer sign-off

## References
- Google's Gemini API auth docs support both URL param and `x-goog-api-key` header; header form is the security-recommended variant.