### PR TITLE
docs: mark R1-R5 shipped + refresh test count and pre-push selector

### DIFF
--- a/docs/delivery-status.md
+++ b/docs/delivery-status.md
@@ -63,10 +63,10 @@ Planned roadmap (plan § 5):
 
 ## Test Coverage
 
-- 112 tests across 4 tiers: unit + integration (default CI), smoke (push-to-main), real_llm (nightly, needs secrets), perf (on-demand)
+- 131 tests across 4 tiers: unit + integration (default CI), smoke (push-to-main), real_llm (nightly, needs secrets), perf (on-demand)
 - 0 ruff issues, consistent ruff format
 - Pre-commit hook enforces author identity + PII/codename scan
-- Pre-push rebases on main and runs pytest before publishing
+- Pre-push rebases on main and runs the default selector (`not real_llm and not perf and not slow and not network`) in ~2 s
 - See [`docs/testing/TEST_PLAN.md`](testing/TEST_PLAN.md) for the full pyramid
 
 ## Related Docs

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,9 +30,11 @@ The items below are **not** on this roadmap:
 
 ## 3. Ranked follow-ups
 
+> **Status (2026-04-18):** R1 ✅, R2 ✅ (workflow shipped; first `v*` tag still boss action), R3 ✅, R4 ✅, R5 ✅. R6–R8 remain deferred.
+
 ### P0 — real bug, fast
 
-**R1. Pipeline channel-error event emission** — ~30 min
+**R1. Pipeline channel-error event emission** ✅ shipped — ~30 min
   - **Gap**: `Pipeline._TrackingIterationController._search` swallows `Channel.search()` exceptions via `try/except` + `structlog` log only. No `on_event({type:"error"})` emitted. Downstream consumers (CLI `--stream`, SSE `/search`, real users) see nothing when a channel breaks.
   - **Discovery**: W3 `test_pipeline_channel_error.py` had to downgrade its assertion to match current swallow-and-log behavior.
   - **Fix**: emit a structured error event from the catch block with `{channel: name, phase: "search", message: str(exc)}`. Keep the swallow (don't crash the pipeline) but surface visibility. Upgrade W3 test to assert the event is emitted.
@@ -40,13 +42,13 @@ The items below are **not** on this roadmap:
 
 ### P1 — make `pipx install autosearch` actually usable
 
-**R2. First v2 alpha release** — ~1 h
+**R2. First v2 alpha release** 🟡 workflow shipped, tag pending boss action — ~1 h
   - `pyproject.toml` already has `version = "0.0.1a1"` but there's no git tag, no GitHub Release, no PyPI artifact.
   - Deliver: `.github/workflows/release.yml` that triggers on `v*` tag → `python -m build` → `twine upload` to PyPI + creates GitHub Release with notes derived from commits since last tag.
   - Boss action: push a `v0.0.1a1` tag once the workflow lands.
   - **Why P1**: README's Quick Start says `pipx install autosearch`. Until this ships, that's a dead promise.
 
-**R3. `autosearch init` minimal version (channel-agnostic parts only)** — ~half day
+**R3. `autosearch init` minimal version (channel-agnostic parts only)** ✅ shipped — ~half day
   - Scope (excludes channel-dep installers):
     - Detect Python 3.12+ (error with message if older)
     - Probe each LLM provider: check env var set OR `claude` binary on PATH; print a summary table of which providers are available
@@ -61,12 +63,12 @@ The items below are **not** on this roadmap:
 
 ### P2 — polish / completeness
 
-**R4. OpenAI-compat metadata (visitedURLs / reasoning_content)** — ~1-2 h
+**R4. OpenAI-compat metadata (visitedURLs / reasoning_content)** ✅ shipped — ~1-2 h
   - node-deepresearch `src/app.ts:L387-L824` exposes `visitedURLs`, `readURLs`, `reasoning_content` (Claude-style) in the response. Our simplified port dropped them.
   - Fill them from `PipelineResult` (evidences → URLs; pipeline's `on_event` gap reflection → `reasoning_content` block).
   - Keep backwards-compatible — new fields optional in response schema.
 
-**R5. LLMClient provider fallback chain** — ~1 d
+**R5. LLMClient provider fallback chain** ✅ shipped — ~1 d
   - Today: `LLMClient` auto-detects the first available provider at init and sticks with it. If that provider's API is down mid-call, no recovery.
   - Add: ordered provider preference (config-driven), per-call fallback when primary raises `httpx.HTTPError` or times out, surface `fallback_count` in metrics.
   - Add cost-tracker notes when fallback used (different model → different token cost).
@@ -88,16 +90,16 @@ The items below are **not** on this roadmap:
 
 ## 4. Proposed wave order
 
-| Wave | Items | Cost | Gate |
-|---|---|---|---|
-| **R1** | Pipeline error-event emission + test upgrade | ~30 min | single PR |
-| **R2** | Release workflow + first alpha tag | ~1 h | single PR + boss pushes tag |
-| **R3** | `autosearch init` minimal | ~half day | single PR (one Codex wave) |
-| **R4** | OpenAI-compat metadata | ~1-2 h | single PR (small Codex wave) |
-| **R5** | LLMClient fallback chain | ~1 day | single PR (one Codex wave + new tests) |
-| **R6–R8** | deferred until signal | — | — |
+| Wave | Items | Cost | Gate | Status |
+|---|---|---|---|---|
+| **R1** | Pipeline error-event emission + test upgrade | ~30 min | single PR | ✅ merged |
+| **R2** | Release workflow + first alpha tag | ~1 h | single PR + boss pushes tag | 🟡 workflow merged, tag pending |
+| **R3** | `autosearch init` minimal | ~half day | single PR (one Codex wave) | ✅ merged |
+| **R4** | OpenAI-compat metadata | ~1-2 h | single PR (small Codex wave) | ✅ merged |
+| **R5** | LLMClient fallback chain | ~1 day | single PR (one Codex wave + new tests) | ✅ merged |
+| **R6–R8** | deferred until signal | — | — | defer |
 
-Recommended execution: **R1 → R2 → R3** in that order. R2 unblocks real install; R3 unblocks real first-run; R1 fixes known bug before either surfaces to users. R4/R5 land whenever; not on critical path.
+R1–R5 have all landed on main. Remaining gating action: boss pushes a `v0.0.1a1` tag to trigger the release workflow. R6/R7/R8 continue to wait for a user signal.
 
 ## 5. When channel layer unpauses
 


### PR DESCRIPTION
## Summary
- `docs/roadmap.md`: R1/R3/R4/R5 marked ✅ merged, R2 🟡 (workflow merged, tag push still boss action)
- `docs/delivery-status.md`: test count 112 → 131 (post R4/R5 + gemini auth test additions), pre-push description updated to reflect current selector

## Test plan
- [x] Doc-only — 114 default-tier tests still pass
- [x] Pre-push hook ran in 2.1s (vs 15min before #112)
- [ ] Reviewer sign-off