### PR TITLE
feat(skills): add SKILL.md loader + frontmatter schema (F001-A)

### DIFF
--- a/autosearch/skills/__init__.py
+++ b/autosearch/skills/__init__.py
@@ -1,0 +1,20 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from autosearch.skills.loader import (
+    MethodSpec,
+    QualityHint,
+    SkillLoadError,
+    SkillSpec,
+    WhenToUse,
+    load_all,
+    load_skill,
+)
+
+__all__ = [
+    "MethodSpec",
+    "QualityHint",
+    "SkillLoadError",
+    "SkillSpec",
+    "WhenToUse",
+    "load_all",
+    "load_skill",
+]

--- a/autosearch/skills/loader.py
+++ b/autosearch/skills/loader.py
@@ -1,0 +1,143 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Literal
+
+import structlog
+import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+SKILL_FILENAME = "SKILL.md"
+REQUIRES_TOKEN_PATTERN = re.compile(r"^(cookie|mcp|env|binary):[a-zA-Z_][a-zA-Z0-9_-]*$")
+LOGGER = structlog.get_logger(__name__).bind(component="skill_loader")
+
+
+class SkillLoadError(ValueError):
+    """Raised when a skill directory cannot be loaded into a validated spec."""
+
+
+class MethodSpec(BaseModel):
+    id: str
+    impl: str
+    requires: list[str] = Field(default_factory=list)
+    rate_limit: dict[str, object] | None = None
+
+    @field_validator("requires")
+    @classmethod
+    def validate_requires(cls, value: list[str]) -> list[str]:
+        invalid = [token for token in value if not REQUIRES_TOKEN_PATTERN.fullmatch(token)]
+        if invalid:
+            invalid_tokens = ", ".join(invalid)
+            raise ValueError(f"requires contains invalid token(s): {invalid_tokens}")
+        return value
+
+
+class WhenToUse(BaseModel):
+    query_languages: list[Literal["zh", "en", "mixed"]] = Field(default_factory=list)
+    query_types: list[str] = Field(default_factory=list)
+    avoid_for: list[str] = Field(default_factory=list)
+
+
+class QualityHint(BaseModel):
+    typical_yield: Literal["low", "medium", "medium-high", "high", "unknown"] = "unknown"
+    chinese_native: bool = False
+
+
+class SkillSpec(BaseModel):
+    name: str
+    description: str
+    version: int = 1
+    languages: list[Literal["zh", "en", "mixed"]] = Field(default_factory=list)
+    methods: list[MethodSpec] = Field(default_factory=list)
+    fallback_chain: list[str] = Field(default_factory=list)
+    when_to_use: WhenToUse | None = None
+    quality_hint: QualityHint | None = None
+    skill_dir: Path
+
+    @model_validator(mode="after")
+    def validate_relationships(self) -> SkillSpec:
+        method_ids = {method.id for method in self.methods}
+        missing_methods = [
+            method_id for method_id in self.fallback_chain if method_id not in method_ids
+        ]
+        if missing_methods:
+            joined = ", ".join(missing_methods)
+            raise ValueError(f"fallback_chain references unknown method id(s): {joined}")
+
+        if self.name != self.skill_dir.name:
+            raise ValueError(
+                f"name '{self.name}' must match directory name '{self.skill_dir.name}'"
+            )
+
+        return self
+
+
+def _extract_frontmatter(raw_text: str, skill_path: Path) -> dict[str, object]:
+    lines = raw_text.splitlines()
+    start_index = next((index for index, line in enumerate(lines) if line.strip() == "---"), None)
+    if start_index is None:
+        raise SkillLoadError(f"{skill_path} is missing a YAML frontmatter start delimiter")
+
+    end_index = next(
+        (index for index in range(start_index + 1, len(lines)) if lines[index].strip() == "---"),
+        None,
+    )
+    if end_index is None:
+        raise SkillLoadError(f"{skill_path} is missing a YAML frontmatter end delimiter")
+
+    frontmatter_text = "\n".join(lines[start_index + 1 : end_index]).strip()
+    if not frontmatter_text:
+        raise SkillLoadError(f"{skill_path} has empty YAML frontmatter")
+
+    try:
+        payload = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as exc:
+        raise SkillLoadError(f"Invalid YAML frontmatter in {skill_path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise SkillLoadError(f"YAML frontmatter in {skill_path} must be a mapping")
+
+    return payload
+
+
+def load_skill(skill_dir: Path) -> SkillSpec:
+    skill_dir = Path(skill_dir)
+    skill_path = skill_dir / SKILL_FILENAME
+    if not skill_path.is_file():
+        raise SkillLoadError(f"Expected {SKILL_FILENAME} in {skill_dir}")
+
+    try:
+        raw_text = skill_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillLoadError(f"Failed to read {skill_path}: {exc}") from exc
+
+    payload = _extract_frontmatter(raw_text, skill_path)
+    payload["skill_dir"] = skill_dir
+
+    try:
+        return SkillSpec.model_validate(payload)
+    except ValidationError as exc:
+        raise SkillLoadError(f"Invalid skill spec in {skill_path}: {exc}") from exc
+
+
+def load_all(root: Path) -> list[SkillSpec]:
+    root = Path(root)
+    if not root.is_dir():
+        raise SkillLoadError(f"Skill root does not exist or is not a directory: {root}")
+
+    specs: list[SkillSpec] = []
+    for skill_dir in sorted(
+        (path for path in root.iterdir() if path.is_dir()), key=lambda path: path.name
+    ):
+        if not (skill_dir / SKILL_FILENAME).is_file():
+            LOGGER.info(
+                "skill_dir_skipped",
+                skill_dir=str(skill_dir),
+                reason="missing_skill_md",
+            )
+            continue
+        specs.append(load_skill(skill_dir))
+
+    return sorted(specs, key=lambda spec: spec.name)

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -1,0 +1,275 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+# Skill Format
+
+## Overview
+
+`SKILL.md` is the source file for AutoSearch skill metadata.
+Each skill lives in its own directory and declares validated frontmatter plus human-readable body prose.
+The loader reads the frontmatter at compile time and turns it into typed Python models.
+The prose body remains documentation for maintainers and operators.
+
+AutoSearch uses three skill categories:
+
+1. `skills/meta/` for runtime agent behavior that may be compiled into pipeline prompts.
+2. `skills/tools/` for reusable primitives such as cookie access, rate limiting, or fetch helpers.
+3. `skills/channels/` for per-channel search capabilities compiled at startup.
+
+The important split is compile time versus runtime:
+
+- Compile time means startup code reads `SKILL.md`, validates it, and constructs runtime metadata.
+- Runtime means the pipeline executes Python channel and tool code that was selected from that metadata.
+- `SKILL.md` is not executable logic.
+
+This document defines the F001 format described in plan `autosearch-0418-channels-and-skills.md`, section `F001`.
+
+## File Layout
+
+Each skill directory should contain:
+
+- `SKILL.md` as the source of truth for metadata and prose guidance.
+- Optional Python modules or method files referenced by the frontmatter.
+- No generated state files.
+
+Typical channel layout:
+
+```text
+skills/channels/arxiv/
+├── SKILL.md
+└── methods/
+    ├── api_search.py
+    └── api_detail.py
+```
+
+## Frontmatter Rules
+
+Frontmatter is YAML placed between two lines containing only `---`.
+The loader scans the file for the first such delimiter pair and parses the YAML between them.
+Content before the first delimiter may exist only for non-runtime comments such as a repository ownership header.
+Content after the closing delimiter is free-form prose.
+
+The frontmatter must parse to a YAML mapping.
+Unknown fields are currently passed through pydantic's default behavior for the declared model shape, so authors should stay within the documented schema.
+Validation errors stop startup for that skill.
+
+Example frontmatter shell:
+
+```yaml
+---
+name: example-skill
+description: Use for example queries that need one search method.
+version: 1
+methods:
+  - id: search
+    impl: methods/search.py
+fallback_chain: [search]
+---
+```
+
+## Field Reference
+
+### `name`
+
+`name` is the canonical skill identifier.
+It is required.
+It must match the directory name that contains the `SKILL.md`.
+This prevents drift between filesystem layout and runtime references.
+
+### `description`
+
+`description` is required.
+Keep it short and operational.
+It should explain when the skill should be used, not implementation details.
+
+### `version`
+
+`version` is optional and defaults to `1`.
+Use it when the schema or intended contract needs an explicit revision marker.
+F001 only supports versioned metadata as a numeric field.
+
+### `languages`
+
+`languages` is optional and defaults to an empty list.
+Allowed values are `zh`, `en`, and `mixed`.
+Tool skills often leave this empty.
+Channel skills use it to express language coverage.
+
+### `methods`
+
+`methods` is optional and defaults to an empty list.
+Each entry follows the `MethodSpec` schema.
+Method order matters because authors usually place the primary method first.
+
+`MethodSpec` fields:
+
+- `id`: required stable identifier for the method.
+- `impl`: required relative module path or implementation reference.
+- `requires`: optional list of runtime requirements.
+- `rate_limit`: optional free-form mapping for channel-specific rate metadata.
+
+### `fallback_chain`
+
+`fallback_chain` is optional and defaults to an empty list.
+Each entry must match a method `id` declared in `methods`.
+Use it to define preferred fallback order when multiple methods exist.
+Validation fails if any fallback entry references a missing method.
+
+### `when_to_use`
+
+`when_to_use` is optional.
+It groups routing hints for the planner or future selection logic.
+The nested fields are:
+
+- `query_languages`: list of `zh`, `en`, or `mixed`.
+- `query_types`: free-form list of query categories.
+- `avoid_for`: free-form list of cases where the skill should not be selected.
+
+Tool skills can omit this section.
+
+### `quality_hint`
+
+`quality_hint` is optional.
+It records expectation metadata instead of hard behavior.
+The nested fields are:
+
+- `typical_yield`: one of `low`, `medium`, `medium-high`, `high`, or `unknown`.
+- `chinese_native`: boolean flag that marks strong native Chinese coverage.
+
+### `skill_dir`
+
+`skill_dir` is part of the runtime `SkillSpec` model but is not written in frontmatter.
+The loader injects it from the filesystem path after parsing the YAML.
+This field lets later code locate implementation files relative to the skill directory.
+
+## Body Convention
+
+Everything after the closing `---` delimiter is prose.
+Keep it human-readable and declarative.
+Do not place executable logic, shell pipelines, or hidden machine directives in the body.
+Good body content includes:
+
+- Search strategy notes.
+- Operational caveats.
+- Data quality expectations.
+- Known failure modes.
+
+The loader in F001 ignores the body completely.
+That is intentional.
+The body exists for maintainers, future compilers, and review context.
+
+## `requires` Token Syntax
+
+Each `requires` entry must match this pattern:
+
+```text
+^(cookie|mcp|env|binary):[a-zA-Z_][a-zA-Z0-9_-]*$
+```
+
+Supported prefixes:
+
+- `cookie:` for channel cookies or session artifacts.
+- `mcp:` for named MCP servers.
+- `env:` for environment variables or capability flags.
+- `binary:` for required executables on `PATH`.
+
+Valid examples:
+
+- `cookie:zhihu`
+- `mcp:mcporter`
+- `env:GITHUB_TOKEN`
+- `binary:curl`
+
+Invalid examples:
+
+- `cookie:`
+- `http:curl`
+- `cookie:123bad`
+- `invalid-token`
+
+## Full Example
+
+The following example shows a valid channel skill with two methods, a fallback chain, bilingual routing hints, and quality metadata.
+
+```yaml
+---
+name: arxiv
+description: Use for paper searches and follow-up detail fetches across English or Chinese queries.
+version: 1
+languages: [zh, en]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: [env:ARXIV_TOKEN]
+    rate_limit:
+      per_min: 30
+      per_hour: 500
+  - id: api_detail
+    impl: methods/api_detail.py
+    requires: [binary:curl]
+    rate_limit:
+      per_min: 10
+fallback_chain: [api_search, api_detail]
+when_to_use:
+  query_languages: [zh, en]
+  query_types: [academic-papers, literature-review]
+  avoid_for: [real-time-news]
+quality_hint:
+  typical_yield: medium-high
+  chinese_native: false
+---
+
+Prefer API search for discovery and use the detail endpoint only after ranking likely matches.
+```
+
+## Loader Discovery And Validation
+
+The F001 loader discovers skills by scanning one directory level under a supplied root.
+For each child directory:
+
+- If `SKILL.md` exists, the loader reads and validates it.
+- If `SKILL.md` is missing, the loader skips the directory and emits a structlog event.
+- Returned specs are sorted by `name`.
+
+Validation covers:
+
+- Required fields such as `name` and `description`.
+- Literal values for `languages` and `quality_hint.typical_yield`.
+- `requires` token syntax.
+- `fallback_chain` references that must point at declared method ids.
+- Directory name alignment between `name` and the containing folder.
+
+Illustrative usage:
+
+```python
+from pathlib import Path
+
+from autosearch.skills.loader import load_all, load_skill
+
+channels_root = Path("skills/channels")
+channel_specs = load_all(channels_root)
+one_tool = load_skill(Path("skills/tools/fetch-webpage"))
+```
+
+The loader raises `SkillLoadError` with a clear message when validation fails.
+This keeps startup failures local to the broken skill source.
+
+## Authoring Checklist
+
+- Put one skill in one directory.
+- Start with a repository ownership comment if required by repo rules.
+- Add YAML frontmatter between `---` lines.
+- Keep `name` identical to the directory name.
+- Keep method ids stable once referenced by code.
+- Use only supported `requires` token prefixes.
+- Write prose after the frontmatter, not executable instructions.
+- Validate with loader tests before wiring a skill into runtime code.
+
+## Related Files
+
+- `autosearch/skills/loader.py` implements parsing and validation.
+- `skills/meta/README.md` describes runtime behavior skills.
+- `skills/tools/README.md` describes reusable primitive skills.
+- `skills/channels/README.md` describes per-channel search skills.
+- Plan reference: `~/.claude/plans/autosearch-0418-channels-and-skills.md` section `F001`.
+
+This document is intentionally compile-time focused.
+Later features can extend runtime behavior, registry compilation, and health tracking without changing the core frontmatter contract introduced here.

--- a/skills/channels/README.md
+++ b/skills/channels/README.md
@@ -1,0 +1,16 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+# Channel Skills
+
+This directory holds per-channel search skill sources.
+Each child directory represents one search surface such as a site, platform, or API.
+Startup code compiles these `SKILL.md` files into runtime channel objects and metadata.
+Use this layer for channel-specific descriptions, routing hints, and method declarations.
+
+Expected contents:
+- One subdirectory per channel.
+- Each channel directory contains a `SKILL.md`.
+- Method implementation modules usually live under `methods/`.
+- Frontmatter defines languages, methods, fallback chains, and selection hints.
+- Body prose records search strategy and operator notes only.
+
+Format and validation rules live in [docs/skill-format.md](../../docs/skill-format.md).

--- a/skills/meta/README.md
+++ b/skills/meta/README.md
@@ -1,0 +1,16 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+# Meta Skills
+
+This directory holds source skills that describe runtime agent behavior.
+These files are not invoked like user-facing channels.
+Instead, startup code compiles selected metadata and instructions into pipeline prompts.
+Use this layer for behaviors that shape routing, iteration, and environment discovery.
+
+Expected contents:
+- One subdirectory per meta skill.
+- Each meta skill directory contains a `SKILL.md`.
+- Supporting modules may live next to the markdown when compile-time code needs them.
+- Frontmatter stays schema-driven and is validated by the skill loader.
+- Body prose documents intent, constraints, and quality expectations only.
+
+Format and field requirements live in [docs/skill-format.md](../../docs/skill-format.md).

--- a/skills/tools/README.md
+++ b/skills/tools/README.md
@@ -1,0 +1,16 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+# Tool Skills
+
+This directory holds reusable primitives shared by channels and pipeline stages.
+Tool skills describe capabilities such as cookie access, rate limiting, fetch helpers, or normalization.
+They are compiled or imported as building blocks instead of being routed to directly as channels.
+Use this layer when logic should be reusable across multiple channel skills.
+
+Expected contents:
+- One subdirectory per tool skill.
+- Each tool skill directory contains a `SKILL.md`.
+- Optional implementation modules can live beside the markdown source.
+- Frontmatter captures method metadata, requirements, and fallback ordering.
+- Body prose explains operator guidance without embedding executable logic.
+
+Format and validation rules live in [docs/skill-format.md](../../docs/skill-format.md).

--- a/tests/fixtures/skills/bad_fallback/SKILL.md
+++ b/tests/fixtures/skills/bad_fallback/SKILL.md
@@ -1,0 +1,12 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+---
+name: bad_fallback
+description: Contains a fallback reference that does not exist.
+version: 1
+methods:
+  - id: primary
+    impl: impl.py
+fallback_chain: [primary, secondary]
+---
+
+The loader should reject unknown fallback method ids.

--- a/tests/fixtures/skills/bad_requires_token/SKILL.md
+++ b/tests/fixtures/skills/bad_requires_token/SKILL.md
@@ -1,0 +1,13 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+---
+name: bad_requires_token
+description: Contains an invalid requires token on purpose.
+version: 1
+methods:
+  - id: api
+    impl: impl.py
+    requires: [cookie:valid_cookie, invalid-token]
+fallback_chain: [api]
+---
+
+The loader should reject malformed `requires` entries.

--- a/tests/fixtures/skills/missing_required/SKILL.md
+++ b/tests/fixtures/skills/missing_required/SKILL.md
@@ -1,0 +1,11 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+---
+description: Missing the required name field on purpose.
+version: 1
+methods:
+  - id: primary
+    impl: impl.py
+fallback_chain: [primary]
+---
+
+The loader should reject this frontmatter because `name` is required.

--- a/tests/fixtures/skills/valid_channel/SKILL.md
+++ b/tests/fixtures/skills/valid_channel/SKILL.md
@@ -1,0 +1,30 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+---
+name: valid_channel
+description: Use for bilingual paper-style searches that may need a detail lookup.
+version: 1
+languages: [zh, en]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: [env:ARXIV_TOKEN]
+    rate_limit:
+      per_min: 30
+      per_hour: 500
+  - id: api_detail
+    impl: methods/api_detail.py
+    requires: [cookie:arxiv_session]
+    rate_limit:
+      per_min: 10
+fallback_chain: [api_search, api_detail]
+when_to_use:
+  query_languages: [zh, en]
+  query_types: [academic-papers, literature-review]
+  avoid_for: [real-time-news]
+quality_hint:
+  typical_yield: medium-high
+  chinese_native: false
+---
+
+Prefer the search endpoint first, then hydrate selected records with the detail method.
+Keep body prose descriptive only.

--- a/tests/fixtures/skills/valid_tool/SKILL.md
+++ b/tests/fixtures/skills/valid_tool/SKILL.md
@@ -1,0 +1,16 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+---
+name: valid_tool
+description: Use for reusable HTTP fetch helpers shared across channels.
+version: 1
+methods:
+  - id: fetch_json
+    impl: impl.py
+    requires: [binary:curl]
+fallback_chain: [fetch_json]
+quality_hint:
+  typical_yield: unknown
+  chinese_native: false
+---
+
+This tool skill exposes a single primitive and does not need routing hints.

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -1,0 +1,106 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from pathlib import Path
+
+import pytest
+
+import autosearch.skills.loader as loader_module
+from autosearch.skills import SkillLoadError, load_all, load_skill
+
+
+def _fixture_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "fixtures" / "skills"
+
+
+def _fixture_text(name: str) -> str:
+    return (_fixture_root() / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _write_skill(tmp_path: Path, directory_name: str, content: str) -> Path:
+    skill_dir = tmp_path / directory_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def test_load_valid_channel_skill() -> None:
+    spec = load_skill(_fixture_root() / "valid_channel")
+
+    assert spec.name == "valid_channel"
+    assert spec.languages == ["zh", "en"]
+    assert [method.id for method in spec.methods] == ["api_search", "api_detail"]
+    assert spec.fallback_chain == ["api_search", "api_detail"]
+    assert spec.when_to_use is not None
+    assert spec.when_to_use.query_types == ["academic-papers", "literature-review"]
+    assert spec.quality_hint is not None
+    assert spec.quality_hint.typical_yield == "medium-high"
+    assert spec.skill_dir.name == "valid_channel"
+
+
+def test_load_valid_tool_skill() -> None:
+    spec = load_skill(_fixture_root() / "valid_tool")
+
+    assert spec.name == "valid_tool"
+    assert spec.languages == []
+    assert len(spec.methods) == 1
+    assert spec.methods[0].requires == ["binary:curl"]
+    assert spec.when_to_use is None
+    assert spec.fallback_chain == ["fetch_json"]
+
+
+def test_load_missing_required_raises() -> None:
+    with pytest.raises(SkillLoadError, match="name"):
+        load_skill(_fixture_root() / "missing_required")
+
+
+def test_load_bad_fallback_raises() -> None:
+    with pytest.raises(SkillLoadError, match="fallback_chain"):
+        load_skill(_fixture_root() / "bad_fallback")
+
+
+def test_load_bad_requires_token_raises() -> None:
+    with pytest.raises(SkillLoadError, match="requires"):
+        load_skill(_fixture_root() / "bad_requires_token")
+
+
+def test_load_all_sorts_by_name(tmp_path: Path) -> None:
+    _write_skill(tmp_path, "valid_tool", _fixture_text("valid_tool"))
+    _write_skill(tmp_path, "valid_channel", _fixture_text("valid_channel"))
+
+    specs = load_all(tmp_path)
+
+    assert [spec.name for spec in specs] == ["valid_channel", "valid_tool"]
+
+
+def test_load_all_skips_dirs_without_skill_md(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_skill(tmp_path, "valid_channel", _fixture_text("valid_channel"))
+    missing_dir = tmp_path / "no_skill_here"
+    missing_dir.mkdir()
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    class _Logger:
+        def info(self, event: str, **kwargs: object) -> None:
+            events.append((event, kwargs))
+
+    monkeypatch.setattr(loader_module, "LOGGER", _Logger())
+
+    specs = load_all(tmp_path)
+
+    assert [spec.name for spec in specs] == ["valid_channel"]
+    assert events == [
+        (
+            "skill_dir_skipped",
+            {"reason": "missing_skill_md", "skill_dir": str(missing_dir)},
+        )
+    ]
+
+
+def test_load_all_validates_name_matches_dirname(tmp_path: Path) -> None:
+    content = _fixture_text("valid_tool").replace("name: valid_tool", "name: bar", 1)
+    _write_skill(tmp_path, "foo", content)
+
+    with pytest.raises(SkillLoadError, match="directory name"):
+        load_all(tmp_path)


### PR DESCRIPTION
## Summary

F001-A of plan `autosearch-0418-channels-and-skills.md` — first half of Channel Skill foundation. This PR adds the SKILL.md loader + schema; F001-B (channel registry extension + ChannelHealth) comes next in a separate PR.

- `autosearch/skills/loader.py` (143 LOC) — pydantic v2 schema (`MethodSpec` / `WhenToUse` / `QualityHint` / `SkillSpec`) + `load_skill()` + `load_all()` + `SkillLoadError`
- `skills/{meta,tools,channels}/README.md` — scaffold with descriptions
- `tests/fixtures/skills/` — 5 fixtures (valid_channel / valid_tool / missing_required / bad_fallback / bad_requires_token)
- `tests/unit/test_skill_loader.py` — 8 cases, all green
- `docs/skill-format.md` (275 LOC) — frontmatter reference + example + loader semantics

## Validation

- **8/8 new tests pass** (`pytest tests/unit/test_skill_loader.py`)
- **Full suite: 122 passed, 17 deselected in 2.07s** (pre-push hook)
- ruff check clean, ruff format clean

## Scope this PR does NOT cover (F001-B)

- Extending `autosearch/channels/base.py` with `ChannelMetadata` / `compile_from_skills` / `available`
- `autosearch/observability/channel_health.py`

Those land in the next PR.

## Schema shape

```yaml
---
name: arxiv
description: "Academic preprints..."
version: 1
languages: [en]
methods:
  - id: api_query
    impl: methods/api.py
    requires: []
    rate_limit: {per_min: 30}
fallback_chain: [api_query]
when_to_use:
  query_languages: [en]
  query_types: [academic]
quality_hint:
  typical_yield: medium-high
  chinese_native: false
---
```

Validates: `name` matches dir name, `fallback_chain` ⊆ `methods` ids, `requires` tokens match `^(cookie|mcp|env|binary):[a-zA-Z_][\w-]*\$`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a skill definition and loading system with standardized metadata format.

* **Documentation**
  * Added skill format specification and guidance for skill directory organization across channel, meta, and tool skill categories.

* **Tests**
  * Added test coverage for skill validation, loading, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->