### PR TITLE
feat(channels): compile channel registry from SKILL.md + ChannelHealth (F001-B)

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -1,7 +1,79 @@
-# Source: agent-reach/channels/base.py:L1-L37 (adapted)
-from typing import Protocol
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Awaitable, Callable, Protocol, Self
+
+import structlog
 
 from autosearch.core.models import Evidence, SubQuery
+from autosearch.skills.loader import MethodSpec, QualityHint, WhenToUse, load_all
+
+if TYPE_CHECKING:
+    from autosearch.observability.channel_health import ChannelHealth
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel_registry")
+
+
+class ChannelRegistryError(ValueError):
+    """Raised when a channel skill cannot be compiled into a runtime channel."""
+
+
+class MethodUnavailable(Exception):
+    """Raised when a method is unavailable in the current environment."""
+
+
+class RateLimited(Exception):
+    """Raised when a channel method hits a retryable rate limit."""
+
+
+class TransientError(Exception):
+    """Raised when a channel method fails in a retryable way."""
+
+
+class PermanentError(Exception):
+    """Raised when a channel method fails in a non-retryable way."""
+
+
+@dataclass(slots=True)
+class Environment:
+    """Runtime probe result: what credentials/servers/binaries are available."""
+
+    cookies: set[str] = field(default_factory=set)
+    mcp_servers: set[str] = field(default_factory=set)
+    env_keys: set[str] = field(default_factory=set)
+    binaries: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class CompiledMethod:
+    """One method of a channel, compiled from SKILL.md + imported from methods/*.py."""
+
+    id: str
+    skill_method: MethodSpec
+    callable: Callable[..., Awaitable[list[Evidence]]]
+    available: bool
+    unmet_requires: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ChannelMetadata:
+    """Compiled from SKILL.md frontmatter — runtime view."""
+
+    name: str
+    description: str
+    languages: list[str]
+    when_to_use: WhenToUse | None
+    quality_hint: QualityHint | None
+    methods: list[CompiledMethod]
+    fallback_chain: list[str]
+
+    def available_methods(self) -> list[CompiledMethod]:
+        return [method for method in self.methods if method.available]
 
 
 class Channel(Protocol):
@@ -10,9 +82,215 @@ class Channel(Protocol):
     async def search(self, query: SubQuery) -> list[Evidence]: ...
 
 
+class _CompiledChannel:
+    def __init__(
+        self,
+        metadata: ChannelMetadata,
+        health_provider: Callable[[], ChannelHealth | None],
+    ) -> None:
+        self.name = metadata.name
+        self._metadata = metadata
+        self._health_provider = health_provider
+        self._methods_by_id = {method.id: method for method in metadata.methods}
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        last_retryable: Exception | None = None
+        attempted = False
+        method_ids = self._metadata.fallback_chain or [
+            method.id for method in self._metadata.methods
+        ]
+
+        for method_id in method_ids:
+            method = self._methods_by_id[method_id]
+            if not method.available:
+                continue
+
+            health = self._health_provider()
+            if health is not None and health.is_in_cooldown(self.name, method.id):
+                continue
+
+            attempted = True
+            started_at = time.monotonic()
+            try:
+                results = await method.callable(query)
+            except (MethodUnavailable, RateLimited, TransientError) as exc:
+                self._record_health(
+                    method=method.id,
+                    success=False,
+                    started_at=started_at,
+                    error=type(exc).__name__,
+                )
+                last_retryable = exc
+                continue
+            except PermanentError as exc:
+                self._record_health(
+                    method=method.id,
+                    success=False,
+                    started_at=started_at,
+                    error=type(exc).__name__,
+                )
+                raise
+            except Exception as exc:
+                self._record_health(
+                    method=method.id,
+                    success=False,
+                    started_at=started_at,
+                    error=type(exc).__name__,
+                )
+                raise
+
+            self._record_health(method=method.id, success=True, started_at=started_at)
+            return results
+
+        if last_retryable is not None:
+            raise last_retryable
+
+        if not attempted:
+            raise MethodUnavailable(f"Channel '{self.name}' has no available search methods")
+
+        raise MethodUnavailable(f"Channel '{self.name}' exhausted all fallback methods")
+
+    def _record_health(
+        self,
+        *,
+        method: str,
+        success: bool,
+        started_at: float,
+        error: str | None = None,
+    ) -> None:
+        health = self._health_provider()
+        if health is None:
+            return
+
+        latency_ms = (time.monotonic() - started_at) * 1000
+        health.record(
+            self.name,
+            method,
+            success=success,
+            latency_ms=latency_ms,
+            error=error,
+        )
+
+
 class ChannelRegistry:
     def __init__(self) -> None:
         self._channels: dict[str, Channel] = {}
+        self._metadata: dict[str, ChannelMetadata] = {}
+        self._health: ChannelHealth | None = None
+
+    @classmethod
+    def compile_from_skills(cls, channels_root: Path, env: Environment) -> Self:
+        registry = cls()
+        for skill in load_all(channels_root):
+            methods = [
+                cls._compile_method(
+                    channel_name=skill.name,
+                    skill_dir=skill.skill_dir,
+                    method=method,
+                    env=env,
+                )
+                for method in skill.methods
+            ]
+            metadata = ChannelMetadata(
+                name=skill.name,
+                description=skill.description,
+                languages=list(skill.languages),
+                when_to_use=skill.when_to_use,
+                quality_hint=skill.quality_hint,
+                methods=methods,
+                fallback_chain=list(skill.fallback_chain),
+            )
+            registry._metadata[skill.name] = metadata
+            registry.register(_CompiledChannel(metadata, lambda: registry._health))
+
+        return registry
+
+    @staticmethod
+    def _compile_method(
+        *,
+        channel_name: str,
+        skill_dir: Path,
+        method: MethodSpec,
+        env: Environment,
+    ) -> CompiledMethod:
+        impl_path = skill_dir / method.impl
+        if not impl_path.is_file():
+            LOGGER.info(
+                "channel_method_impl_missing",
+                channel=channel_name,
+                method=method.id,
+                impl=str(impl_path),
+            )
+            return CompiledMethod(
+                id=method.id,
+                skill_method=method,
+                callable=_build_missing_impl_stub(channel_name, method.id, impl_path),
+                available=False,
+                unmet_requires=["impl_missing"],
+            )
+
+        search_callable = ChannelRegistry._load_search_callable(
+            channel_name=channel_name,
+            method_id=method.id,
+            impl_path=impl_path,
+        )
+        unmet_requires = ChannelRegistry._resolve_requires(method.requires, env)
+        return CompiledMethod(
+            id=method.id,
+            skill_method=method,
+            callable=search_callable,
+            available=not unmet_requires,
+            unmet_requires=unmet_requires,
+        )
+
+    @staticmethod
+    def _load_search_callable(
+        *,
+        channel_name: str,
+        method_id: str,
+        impl_path: Path,
+    ) -> Callable[..., Awaitable[list[Evidence]]]:
+        module_name = f"autosearch_skill_{channel_name}_{method_id}"
+        spec = importlib.util.spec_from_file_location(module_name, impl_path)
+        if spec is None or spec.loader is None:
+            raise ChannelRegistryError(
+                f"Failed to create import spec for channel '{channel_name}' "
+                f"method '{method_id}' from {impl_path}"
+            )
+
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:
+            raise ChannelRegistryError(
+                f"Failed to import channel '{channel_name}' method '{method_id}' "
+                f"from {impl_path}: {exc}"
+            ) from exc
+
+        search_callable = getattr(module, "search", None)
+        if not callable(search_callable) or not inspect.iscoroutinefunction(search_callable):
+            raise ChannelRegistryError(
+                f"Channel '{channel_name}' method '{method_id}' must export "
+                "an async callable named 'search'"
+            )
+
+        return search_callable
+
+    @staticmethod
+    def _resolve_requires(requires: list[str], env: Environment) -> list[str]:
+        unmet: list[str] = []
+        for token in requires:
+            kind, value = token.split(":", maxsplit=1)
+            if kind == "cookie" and value not in env.cookies:
+                unmet.append(token)
+            elif kind == "mcp" and value not in env.mcp_servers:
+                unmet.append(token)
+            elif kind == "env" and value not in env.env_keys:
+                unmet.append(token)
+            elif kind == "binary" and value not in env.binaries:
+                unmet.append(token)
+
+        return unmet
 
     def register(self, channel: Channel) -> None:
         self._channels[channel.name] = channel
@@ -22,3 +300,42 @@ class ChannelRegistry:
 
     def all_channels(self) -> list[Channel]:
         return list(self._channels.values())
+
+    def available(self) -> list[Channel]:
+        available_channels: list[Channel] = []
+        for channel in self._channels.values():
+            metadata = self._metadata.get(channel.name)
+            if metadata is None:
+                if self._health is None or not self._health.is_in_cooldown(channel.name):
+                    available_channels.append(channel)
+                continue
+
+            if not metadata.available_methods():
+                continue
+
+            if self._health is not None and self._health.is_in_cooldown(channel.name):
+                continue
+
+            available_channels.append(channel)
+
+        return available_channels
+
+    def metadata(self, name: str) -> ChannelMetadata:
+        return self._metadata[name]
+
+    def attach_health(self, health: ChannelHealth) -> None:
+        self._health = health
+
+
+def _build_missing_impl_stub(
+    channel_name: str,
+    method_id: str,
+    impl_path: Path,
+) -> Callable[[SubQuery], Awaitable[list[Evidence]]]:
+    async def _search(_: SubQuery) -> list[Evidence]:
+        raise NotImplementedError(
+            f"Channel '{channel_name}' method '{method_id}' is missing its implementation "
+            f"at {impl_path}"
+        )
+
+    return _search

--- a/autosearch/observability/channel_health.py
+++ b/autosearch/observability/channel_health.py
@@ -1,0 +1,117 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class _MethodHealthState:
+    success_count: int = 0
+    fail_count: int = 0
+    cooldown_until: float | None = None
+    history: deque[tuple[float, bool]] = field(default_factory=deque)
+    consecutive_failures: deque[float] = field(default_factory=deque)
+    last_error: str | None = None
+    last_latency_ms: float | None = None
+
+
+class ChannelHealth:
+    """Per-(channel, method) success rate + cooldown tracker.
+
+    Failure threshold: 3 consecutive failures within 5 min → cooldown for 5 min.
+    Success resets the failure streak.
+    """
+
+    _failure_window_seconds = 300
+
+    def __init__(
+        self,
+        fail_threshold: int = 3,
+        cooldown_seconds: int = 300,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._fail_threshold = fail_threshold
+        self._cooldown_seconds = cooldown_seconds
+        self._now = now
+        self._states: dict[str, dict[str, _MethodHealthState]] = defaultdict(dict)
+
+    def record(
+        self,
+        channel: str,
+        method: str,
+        success: bool,
+        latency_ms: float,
+        error: str | None = None,
+    ) -> None:
+        state = self._states[channel].setdefault(method, _MethodHealthState())
+        now = self._now()
+
+        state.history.append((now, success))
+        state.last_latency_ms = latency_ms
+        state.last_error = error
+
+        if success:
+            state.success_count += 1
+            state.consecutive_failures.clear()
+            return
+
+        state.fail_count += 1
+        state.consecutive_failures.append(now)
+        while (
+            state.consecutive_failures
+            and now - state.consecutive_failures[0] > self._failure_window_seconds
+        ):
+            state.consecutive_failures.popleft()
+
+        if len(state.consecutive_failures) >= self._fail_threshold:
+            state.cooldown_until = now + self._cooldown_seconds
+            state.consecutive_failures.clear()
+
+    def is_in_cooldown(self, channel: str, method: str | None = None) -> bool:
+        now = self._now()
+        if method is not None:
+            return self._method_in_cooldown(channel, method, now)
+
+        return any(
+            self._method_in_cooldown(channel, method_name, now)
+            for method_name in self._states.get(channel, {})
+        )
+
+    def success_rate(self, channel: str, method: str, window_seconds: int = 3600) -> float:
+        state = self._states.get(channel, {}).get(method)
+        if state is None:
+            return 0.0
+
+        cutoff = self._now() - window_seconds
+        window = [success for ts, success in state.history if ts >= cutoff]
+        if not window:
+            return 0.0
+
+        return sum(1 for success in window if success) / len(window)
+
+    def snapshot(self) -> dict[str, dict]:
+        now = self._now()
+        snapshot: dict[str, dict] = {}
+        for channel, methods in self._states.items():
+            snapshot[channel] = {}
+            for method, state in methods.items():
+                cooldown_until = state.cooldown_until
+                in_cooldown = cooldown_until is not None and cooldown_until > now
+                snapshot[channel][method] = {
+                    "success_count": state.success_count,
+                    "fail_count": state.fail_count,
+                    "in_cooldown": in_cooldown,
+                    "cooldown_until": cooldown_until if in_cooldown else None,
+                }
+
+        return snapshot
+
+    def _method_in_cooldown(self, channel: str, method: str, now: float) -> bool:
+        state = self._states.get(channel, {}).get(method)
+        if state is None or state.cooldown_until is None:
+            return False
+
+        return state.cooldown_until > now

--- a/tests/fixtures/skills/channels/stub_cookie/SKILL.md
+++ b/tests/fixtures/skills/channels/stub_cookie/SKILL.md
@@ -1,0 +1,19 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+---
+name: stub_cookie
+description: "Stub channel whose only method requires a cookie."
+version: 1
+languages: [en]
+methods:
+  - id: fake
+    impl: methods/fake.py
+    requires: [cookie:stub_cookie]
+fallback_chain: [fake]
+when_to_use:
+  query_languages: [en]
+  query_types: [experience-report]
+  avoid_for: []
+quality_hint:
+  typical_yield: low
+  chinese_native: false
+---

--- a/tests/fixtures/skills/channels/stub_cookie/methods/fake.py
+++ b/tests/fixtures/skills/channels/stub_cookie/methods/fake.py
@@ -1,0 +1,16 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from datetime import UTC, datetime
+
+from autosearch.core.models import Evidence, SubQuery
+
+
+async def search(query: SubQuery) -> list[Evidence]:
+    return [
+        Evidence(
+            url=f"https://example.com/stub-cookie/{query.text.replace(' ', '-')}",
+            title=f"stub_cookie result for {query.text}",
+            snippet=query.rationale,
+            source_channel="stub_cookie:fake",
+            fetched_at=datetime.now(UTC),
+        )
+    ]

--- a/tests/fixtures/skills/channels/stub_ok/SKILL.md
+++ b/tests/fixtures/skills/channels/stub_ok/SKILL.md
@@ -1,0 +1,19 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+---
+name: stub_ok
+description: "Stub channel with one always-available echo method."
+version: 1
+languages: [en]
+methods:
+  - id: echo
+    impl: methods/echo.py
+    requires: []
+fallback_chain: [echo]
+when_to_use:
+  query_languages: [en]
+  query_types: [technical]
+  avoid_for: []
+quality_hint:
+  typical_yield: low
+  chinese_native: false
+---

--- a/tests/fixtures/skills/channels/stub_ok/methods/echo.py
+++ b/tests/fixtures/skills/channels/stub_ok/methods/echo.py
@@ -1,0 +1,16 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from datetime import UTC, datetime
+
+from autosearch.core.models import Evidence, SubQuery
+
+
+async def search(query: SubQuery) -> list[Evidence]:
+    return [
+        Evidence(
+            url=f"https://example.com/stub-ok/{query.text.replace(' ', '-')}",
+            title=f"stub_ok result for {query.text}",
+            snippet=query.rationale,
+            source_channel="stub_ok:echo",
+            fetched_at=datetime.now(UTC),
+        )
+    ]

--- a/tests/unit/test_channel_health.py
+++ b/tests/unit/test_channel_health.py
@@ -1,0 +1,112 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from __future__ import annotations
+
+import pytest
+
+from autosearch.observability.channel_health import ChannelHealth
+
+
+class FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.value = start
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def test_record_success_resets_streak() -> None:
+    clock = FakeClock()
+    health = ChannelHealth(now=clock)
+
+    health.record("stub", "echo", success=False, latency_ms=2.0, error="timeout")
+    clock.advance(10)
+    health.record("stub", "echo", success=False, latency_ms=2.0, error="timeout")
+    clock.advance(10)
+    health.record("stub", "echo", success=True, latency_ms=1.0)
+    clock.advance(10)
+    health.record("stub", "echo", success=False, latency_ms=2.0, error="timeout")
+
+    snapshot = health.snapshot()
+
+    assert health.is_in_cooldown("stub", "echo") is False
+    assert snapshot["stub"]["echo"]["success_count"] == 1
+    assert snapshot["stub"]["echo"]["fail_count"] == 3
+
+
+def test_three_fails_enters_cooldown() -> None:
+    clock = FakeClock()
+    health = ChannelHealth(now=clock)
+
+    for _ in range(3):
+        health.record("stub", "echo", success=False, latency_ms=3.0, error="rate_limit")
+        clock.advance(1)
+
+    snapshot = health.snapshot()
+
+    assert health.is_in_cooldown("stub", "echo") is True
+    assert snapshot["stub"]["echo"]["in_cooldown"] is True
+
+
+def test_cooldown_expires_after_configured_seconds() -> None:
+    clock = FakeClock()
+    health = ChannelHealth(now=clock, cooldown_seconds=30)
+
+    for _ in range(3):
+        health.record("stub", "echo", success=False, latency_ms=4.0, error="transient")
+
+    assert health.is_in_cooldown("stub", "echo") is True
+
+    clock.advance(31)
+
+    assert health.is_in_cooldown("stub", "echo") is False
+
+
+def test_is_in_cooldown_method_specific_vs_any() -> None:
+    clock = FakeClock()
+    health = ChannelHealth(now=clock)
+
+    for _ in range(3):
+        health.record("stub", "first", success=False, latency_ms=5.0, error="timeout")
+    health.record("stub", "second", success=True, latency_ms=1.0)
+
+    assert health.is_in_cooldown("stub", "first") is True
+    assert health.is_in_cooldown("stub", "second") is False
+    assert health.is_in_cooldown("stub") is True
+
+
+def test_success_rate_within_window() -> None:
+    clock = FakeClock()
+    health = ChannelHealth(now=clock)
+
+    health.record("stub", "echo", success=True, latency_ms=1.0)
+    clock.advance(10)
+    health.record("stub", "echo", success=False, latency_ms=1.0, error="timeout")
+    clock.advance(10)
+    health.record("stub", "echo", success=True, latency_ms=1.0)
+
+    assert health.success_rate("stub", "echo", window_seconds=60) == pytest.approx(2 / 3)
+
+    clock.advance(100)
+
+    assert health.success_rate("stub", "echo", window_seconds=30) == 0.0
+
+
+def test_snapshot_shape() -> None:
+    health = ChannelHealth()
+
+    health.record("stub", "echo", success=True, latency_ms=1.0)
+    snapshot = health.snapshot()
+
+    assert set(snapshot) == {"stub"}
+    assert set(snapshot["stub"]) == {"echo"}
+    assert set(snapshot["stub"]["echo"]) == {
+        "success_count",
+        "fail_count",
+        "in_cooldown",
+        "cooldown_until",
+    }
+    assert snapshot["stub"]["echo"]["success_count"] == 1
+    assert snapshot["stub"]["echo"]["fail_count"] == 0

--- a/tests/unit/test_channel_registry.py
+++ b/tests/unit/test_channel_registry.py
@@ -1,0 +1,210 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F001
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from autosearch.channels.base import ChannelRegistry, Environment, MethodUnavailable
+from autosearch.channels.demo import DemoChannel
+from autosearch.core.models import Evidence, SubQuery
+from autosearch.observability.channel_health import ChannelHealth
+
+
+def _fixture_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "fixtures" / "skills" / "channels"
+
+
+def _write_channel_skill(
+    root: Path,
+    *,
+    name: str,
+    skill_text: str,
+    methods: dict[str, str] | None = None,
+) -> Path:
+    skill_dir = root / name
+    (skill_dir / "methods").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(dedent(skill_text).strip() + "\n", encoding="utf-8")
+    for relative_path, content in (methods or {}).items():
+        path = skill_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(dedent(content).lstrip(), encoding="utf-8")
+    return skill_dir
+
+
+@pytest.mark.asyncio
+async def test_compile_from_skills_loads_stub() -> None:
+    registry = ChannelRegistry.compile_from_skills(_fixture_root(), Environment())
+
+    results = await registry.get("stub_ok").search(
+        SubQuery(text="ranking signals", rationale="Need one compiled stub result")
+    )
+
+    assert len(results) >= 1
+    assert all(isinstance(item, Evidence) for item in results)
+    assert results[0].source_channel == "stub_ok:echo"
+
+
+def test_compile_from_skills_method_unavailable_with_unmet_requires() -> None:
+    registry = ChannelRegistry.compile_from_skills(_fixture_root(), Environment())
+
+    metadata = registry.metadata("stub_cookie")
+
+    assert len(metadata.methods) == 1
+    assert metadata.methods[0].available is False
+    assert "cookie:stub_cookie" in metadata.methods[0].unmet_requires
+
+
+def test_compile_from_skills_impl_missing_marks_unavailable(tmp_path: Path) -> None:
+    root = tmp_path / "channels"
+    _write_channel_skill(
+        root,
+        name="missing_impl",
+        skill_text="""
+        ---
+        name: missing_impl
+        description: "Fixture channel with a missing implementation file."
+        version: 1
+        languages: [en]
+        methods:
+          - id: pending
+            impl: methods/pending.py
+            requires: []
+        fallback_chain: [pending]
+        ---
+        """,
+    )
+
+    registry = ChannelRegistry.compile_from_skills(root, Environment())
+    method = registry.metadata("missing_impl").methods[0]
+
+    assert method.available is False
+    assert method.unmet_requires == ["impl_missing"]
+    assert registry.available() == []
+
+
+def test_available_filters_out_channels_with_no_available_methods() -> None:
+    registry = ChannelRegistry.compile_from_skills(_fixture_root(), Environment())
+
+    available_names = {channel.name for channel in registry.available()}
+
+    assert "stub_ok" in available_names
+    assert "stub_cookie" not in available_names
+
+
+@pytest.mark.asyncio
+async def test_fallback_chain_tries_methods_in_order(tmp_path: Path) -> None:
+    root = tmp_path / "channels"
+    _write_channel_skill(
+        root,
+        name="fallback_stub",
+        skill_text="""
+        ---
+        name: fallback_stub
+        description: "Fixture channel with retryable fallback ordering."
+        version: 1
+        languages: [en]
+        methods:
+          - id: first
+            impl: methods/first.py
+            requires: []
+          - id: second
+            impl: methods/second.py
+            requires: []
+        fallback_chain: [first, second]
+        ---
+        """,
+        methods={
+            "methods/first.py": """
+                # Self-written, plan autosearch-0418-channels-and-skills.md § F001
+                from autosearch.channels.base import MethodUnavailable
+                from autosearch.core.models import Evidence, SubQuery
+
+
+                async def search(query: SubQuery) -> list[Evidence]:
+                    raise MethodUnavailable(f"first method unavailable for {query.text}")
+            """,
+            "methods/second.py": """
+                # Self-written, plan autosearch-0418-channels-and-skills.md § F001
+                from datetime import UTC, datetime
+
+                from autosearch.core.models import Evidence, SubQuery
+
+
+                async def search(query: SubQuery) -> list[Evidence]:
+                    return [
+                        Evidence(
+                            url="https://example.com/fallback/second",
+                            title=f"fallback result for {query.text}",
+                            snippet=query.rationale,
+                            source_channel="fallback_stub:second",
+                            fetched_at=datetime.now(UTC),
+                        )
+                    ]
+            """,
+        },
+    )
+
+    registry = ChannelRegistry.compile_from_skills(root, Environment())
+
+    results = await registry.get("fallback_stub").search(
+        SubQuery(text="fallback query", rationale="Exercise method ordering")
+    )
+
+    assert len(results) == 1
+    assert results[0].source_channel == "fallback_stub:second"
+    assert results[0].title == "fallback result for fallback query"
+
+
+def test_existing_register_and_get_still_work() -> None:
+    registry = ChannelRegistry()
+    channel = DemoChannel(name="legacy-demo")
+
+    registry.register(channel)
+
+    assert registry.get("legacy-demo") is channel
+    assert registry.all_channels() == [channel]
+
+
+def test_attach_health_filters_cooldown() -> None:
+    registry = ChannelRegistry.compile_from_skills(_fixture_root(), Environment())
+    health = ChannelHealth()
+    registry.attach_health(health)
+
+    for _ in range(3):
+        health.record("stub_ok", "echo", success=False, latency_ms=5.0, error="timeout")
+
+    available_names = {channel.name for channel in registry.available()}
+
+    assert health.is_in_cooldown("stub_ok", "echo") is True
+    assert "stub_ok" not in available_names
+
+
+@pytest.mark.asyncio
+async def test_missing_impl_channel_raises_method_unavailable(tmp_path: Path) -> None:
+    root = tmp_path / "channels"
+    _write_channel_skill(
+        root,
+        name="missing_impl_call",
+        skill_text="""
+        ---
+        name: missing_impl_call
+        description: "Fixture channel with no callable methods."
+        version: 1
+        languages: [en]
+        methods:
+          - id: pending
+            impl: methods/pending.py
+            requires: []
+        fallback_chain: [pending]
+        ---
+        """,
+    )
+
+    registry = ChannelRegistry.compile_from_skills(root, Environment())
+
+    with pytest.raises(MethodUnavailable, match="no available search methods"):
+        await registry.get("missing_impl_call").search(
+            SubQuery(text="pending query", rationale="Exercise missing impl stub")
+        )


### PR DESCRIPTION
## Summary

F001-B of plan `autosearch-0418-channels-and-skills.md` — second half of Channel Skill foundation. Replaces #117 (auto-closed when base branch `feature/f001a-skill-loader` was deleted after #116 merged). Content identical to #117, only rebased onto current main.

- `autosearch/channels/base.py` (+339 LOC) — extend existing `Channel` Protocol + `ChannelRegistry` (API preserved) with `ChannelMetadata`, `CompiledMethod`, `Environment`, `compile_from_skills()`, `available()`, `metadata()`, `attach_health()`. 5 new exception classes.
- `autosearch/observability/channel_health.py` (117 LOC) — per-(channel, method) success rate + cooldown tracker with injectable clock.
- `tests/fixtures/skills/channels/{stub_ok,stub_cookie}/` — channel fixtures with real `methods/*.py`
- `tests/unit/test_channel_registry.py` + `tests/unit/test_channel_health.py` — 14 cases

## Validation

- **14/14 new tests pass**; 136 full suite green (pre-push)
- ruff check + format clean
- Existing `Channel` Protocol signature unchanged (pipeline.py:482 untouched)
- Legacy `register/get/all_channels` API preserved (F004 DDGS code-registered path compatible)

## Scaffold-safe guarantee

SKILL.md pointing to `methods/*.py` that doesn't exist yet is loadable — `available=False` + `unmet_requires=["impl_missing"]` + no-op stub callable. Unblocks F002c (10 channel skeletons) before any real impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)