### PR TITLE
fix(docs): mintlify MDX build — replace HTML comment in skill-format.md

### DIFF
--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -1,5 +1,10 @@
-<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F001 -->
+---
+title: "Skill Format Reference"
+---
+
 # Skill Format
+
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F001.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Mintlify deployment failed on main commit `1751c48` (docs PR #116) with:
```
Failed to parse page content at path skill-format.md: Unexpected character \`!\` (U+0021) before name...
```

Root cause: `docs/skill-format.md` started with an HTML-style comment `<!-- Self-written, plan ... -->` for source attribution. Mintlify parses `.md` files as MDX, which doesn't accept HTML comments.

## Fix

Replace HTML comment with:
1. YAML frontmatter `title:` (Mintlify-standard)
2. Blockquote after H1 with the source attribution (`> Source: self-written, plan ...`)

Both render correctly as MDX and preserve the source attribution required by project convention.

## Follow-up note

Any future `docs/*.md` file added to the Mintlify-watched tree must use this pattern (frontmatter + prose) rather than HTML comments. Worth adding to project CLAUDE.md after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)