### PR TITLE
feat(skills): cookie-manager + rate-limiter tool skills (F002a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ tests/integration/sessions/
 
 # E2B per-run artifacts (transient per-task stdout/stderr logs); master reports live in docs/validation/
 reports/
+
+# Autosearch runtime state (cookies, caches) — never versioned
+.autosearch/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -30,6 +30,11 @@ keywords = [".ts.net", ".local"]
   paths = ['''tests/e2b/matrix\.yaml$''']
   regexes = ['''\$HOME/\.local/bin/uv''']
 
+  [[rules.allowlists]]
+  description = "SKILL.md prose references .local paths (Linux XDG, not a Tailscale domain)"
+  paths = ['''skills/.*/SKILL\.md$''']
+  regexes = ['''\.local/']
+
 # ── Public-repo-only rules ───────────────────────────────────────────────────
 
 [[rules]]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,7 +33,7 @@ keywords = [".ts.net", ".local"]
   [[rules.allowlists]]
   description = "SKILL.md prose references .local paths (Linux XDG, not a Tailscale domain)"
   paths = ['''skills/.*/SKILL\.md$''']
-  regexes = ['''\.local/']
+  regexes = ['''\.local/''']
 
 # ── Public-repo-only rules ───────────────────────────────────────────────────
 

--- a/skills/tools/cookie-manager/SKILL.md
+++ b/skills/tools/cookie-manager/SKILL.md
@@ -1,0 +1,47 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F002a -->
+---
+name: cookie-manager
+description: Retrieve per-channel cookies from multiple sources for authenticated search methods.
+version: 1
+methods:
+  - id: get_cookie
+    impl: impl.py
+    requires: []
+---
+
+This tool skill resolves a cookie bundle for one channel at a time.
+It exists so authenticated channel methods do not each reinvent cookie lookup.
+The return value is a plain name to value mapping ready for an HTTP client.
+Channels should treat the mapping as ephemeral runtime state.
+The manager does not persist new cookies back to disk.
+The first source is the manual JSON file under `~/.autosearch/cookies/{channel}.json`.
+That file is the preferred operator-controlled source.
+It keeps setup explicit and avoids surprising browser access.
+The JSON file must contain a single object with cookie names as keys.
+If the file is empty or malformed, the lookup warns and continues.
+The second source is the macOS keychain path.
+That path is only attempted on Darwin when keychain lookup is enabled.
+Non-macOS environments skip keychain without noise.
+Keychain support is intended for local developer machines.
+It is optional and should not be required for CI.
+The third source is `rookiepy`, which is disabled by default.
+`rookiepy` is imported lazily so the dependency stays optional.
+If the import fails, the manager warns and moves on.
+If browser extraction is enabled, it remains a best-effort fallback.
+Manual JSON still wins over every other source.
+This precedence keeps channel behavior deterministic.
+It also makes debugging auth issues simpler.
+Security matters more than convenience in this tool.
+Cookie values are never logged.
+Success logs include only the channel name and the source label.
+Failure logs include only the channel name and a reason code.
+No cookie content should appear in warnings, info events, or exceptions.
+Channel methods should call the tool near request construction time.
+A typical flow is: resolve cookie, decide whether auth-only method is available, then attach cookies to the request client.
+Methods that can degrade gracefully may switch to an unauthenticated path when `None` is returned.
+Methods that require auth should surface a clear unavailable error instead.
+This tool is intentionally narrow.
+It does not validate channel-specific session freshness.
+It does not know whether a cookie unlocks a given endpoint.
+It only resolves the best available cookie mapping for the requested channel.
+Use it as a shared primitive inside channel implementations, not as a routed search method.

--- a/skills/tools/cookie-manager/impl.py
+++ b/skills/tools/cookie-manager/impl.py
@@ -1,0 +1,243 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F002a
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+LOGGER = structlog.get_logger(__name__).bind(component="cookie_manager")
+
+
+class CookieManager:
+    """Resolve per-channel cookie from: ~/.autosearch/cookies/{channel}.json → keychain → rookiepy.
+
+    Security: never log cookie values. Log channel name + source only.
+    """
+
+    def __init__(
+        self,
+        cookies_dir: Path | None = None,
+        enable_keychain: bool = True,
+        enable_rookiepy: bool = False,
+    ) -> None:
+        self.cookies_dir = (
+            cookies_dir if cookies_dir is not None else Path("~/.autosearch/cookies").expanduser()
+        )
+        self.enable_keychain = enable_keychain
+        self.enable_rookiepy = enable_rookiepy
+
+    def get_cookie(self, channel: str) -> dict[str, str] | None:
+        """Return a cookie dict (name→value) or None if unavailable.
+
+        Sources tried in order: cookies_dir (file-based json) → keychain (macOS only,
+        stub for non-darwin) → rookiepy (if enabled, lazy-imported).
+        """
+
+        cookie = self._load_from_file(channel)
+        if cookie is not None:
+            LOGGER.info("cookie_resolved", channel=channel, source="file")
+            return cookie
+
+        if self.enable_keychain and sys.platform == "darwin":
+            cookie = self._load_from_keychain(channel)
+            if cookie is not None:
+                LOGGER.info("cookie_resolved", channel=channel, source="keychain")
+                return cookie
+
+        if self.enable_rookiepy:
+            cookie = self._load_from_rookiepy(channel)
+            if cookie is not None:
+                LOGGER.info("cookie_resolved", channel=channel, source="rookiepy")
+                return cookie
+
+        LOGGER.info("cookie_unavailable", channel=channel, reason="not_found")
+        return None
+
+    def has_cookie(self, channel: str) -> bool:
+        return self.get_cookie(channel) is not None
+
+    def _load_from_file(self, channel: str) -> dict[str, str] | None:
+        cookie_path = self.cookies_dir / f"{channel}.json"
+        if not cookie_path.is_file():
+            return None
+
+        try:
+            raw_text = cookie_path.read_text(encoding="utf-8")
+        except OSError:
+            LOGGER.warning("cookie_source_failed", channel=channel, reason="file_read_error")
+            return None
+
+        return self._parse_cookie_payload(
+            raw_text,
+            channel=channel,
+            malformed_reason="malformed_json",
+            empty_reason="empty_json",
+            invalid_reason="invalid_cookie_mapping",
+        )
+
+    def _load_from_keychain(self, channel: str) -> dict[str, str] | None:
+        for service_name in (
+            f"autosearch.cookie.{channel}",
+            f"autosearch.{channel}",
+            channel,
+        ):
+            try:
+                result = subprocess.run(
+                    [
+                        "security",
+                        "find-generic-password",
+                        "-s",
+                        service_name,
+                        "-a",
+                        channel,
+                        "-w",
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+            except OSError:
+                LOGGER.warning(
+                    "cookie_source_failed", channel=channel, reason="keychain_unavailable"
+                )
+                return None
+
+            if result.returncode != 0:
+                continue
+
+            return self._parse_cookie_payload(
+                result.stdout,
+                channel=channel,
+                malformed_reason="keychain_malformed_json",
+                empty_reason="keychain_empty_json",
+                invalid_reason="keychain_invalid_cookie_mapping",
+            )
+
+        return None
+
+    def _load_from_rookiepy(self, channel: str) -> dict[str, str] | None:
+        try:
+            rookiepy = importlib.import_module("rookiepy")
+        except ImportError:
+            LOGGER.warning("cookie_source_failed", channel=channel, reason="rookiepy_import_error")
+            return None
+
+        for loader_name in (
+            "chrome",
+            "chromium",
+            "brave",
+            "edge",
+            "firefox",
+            "opera",
+            "safari",
+        ):
+            loader = getattr(rookiepy, loader_name, None)
+            if not callable(loader):
+                continue
+
+            cookies = self._call_rookiepy_loader(loader, channel)
+            normalized = self._normalize_rookiepy_cookies(cookies, channel)
+            if normalized:
+                return normalized
+
+        LOGGER.warning("cookie_source_failed", channel=channel, reason="rookiepy_no_cookie")
+        return None
+
+    def _call_rookiepy_loader(self, loader: Any, channel: str) -> object | None:
+        call_specs = (
+            {"domains": [channel]},
+            {"domain_name": channel},
+            {},
+        )
+        for kwargs in call_specs:
+            try:
+                return loader(**kwargs)
+            except TypeError:
+                continue
+            except Exception:
+                return None
+
+        try:
+            return loader(channel)
+        except TypeError:
+            return None
+        except Exception:
+            return None
+
+    def _normalize_rookiepy_cookies(
+        self,
+        cookies: object | None,
+        channel: str,
+    ) -> dict[str, str] | None:
+        if cookies is None:
+            return None
+
+        if isinstance(cookies, Mapping):
+            normalized = self._coerce_cookie_mapping(cookies)
+            return normalized if normalized else None
+
+        if not isinstance(cookies, Iterable) or isinstance(cookies, str | bytes):
+            return None
+
+        normalized: dict[str, str] = {}
+        for entry in cookies:
+            name: object | None = None
+            value: object | None = None
+            domain: object | None = None
+
+            if isinstance(entry, Mapping):
+                name = entry.get("name")
+                value = entry.get("value")
+                domain = entry.get("domain")
+            else:
+                name = getattr(entry, "name", None)
+                value = getattr(entry, "value", None)
+                domain = getattr(entry, "domain", None)
+
+            if not isinstance(name, str) or not isinstance(value, str):
+                continue
+            if isinstance(domain, str) and channel not in domain:
+                continue
+            normalized[name] = value
+
+        return normalized or None
+
+    def _parse_cookie_payload(
+        self,
+        raw_text: str,
+        *,
+        channel: str,
+        malformed_reason: str,
+        empty_reason: str,
+        invalid_reason: str,
+    ) -> dict[str, str] | None:
+        try:
+            payload = json.loads(raw_text)
+        except json.JSONDecodeError:
+            LOGGER.warning("cookie_source_failed", channel=channel, reason=malformed_reason)
+            return None
+
+        normalized = self._coerce_cookie_mapping(payload)
+        if normalized is None:
+            reason = empty_reason if payload == {} else invalid_reason
+            LOGGER.warning("cookie_source_failed", channel=channel, reason=reason)
+            return None
+
+        return normalized
+
+    def _coerce_cookie_mapping(self, payload: object) -> dict[str, str] | None:
+        if not isinstance(payload, Mapping) or not payload:
+            return None
+
+        normalized: dict[str, str] = {}
+        for name, value in payload.items():
+            if not isinstance(name, str) or not isinstance(value, str):
+                return None
+            normalized[name] = value
+        return normalized

--- a/skills/tools/rate-limiter/SKILL.md
+++ b/skills/tools/rate-limiter/SKILL.md
@@ -1,0 +1,43 @@
+<!-- Self-written, plan autosearch-0418-channels-and-skills.md § F002a -->
+---
+name: rate-limiter
+description: Enforce per-channel request budgets across methods with async token buckets.
+version: 1
+methods:
+  - id: acquire
+    impl: impl.py
+    requires: []
+---
+
+This tool skill coordinates request pacing for channel methods.
+It provides a per-channel and per-method token bucket guard.
+Each method can declare short and long budget limits.
+The most common inputs are `per_min` and `per_hour`.
+Minute limits protect against sharp bursts.
+Hour limits protect against sustained scraping patterns.
+When both are present, both buckets must have capacity.
+The tighter bucket determines the wait time.
+Usage is intentionally lightweight for channel implementations.
+Call it with `async with limiter.acquire(channel, method, ...)`.
+Enter the context immediately before the outbound request.
+Exit happens automatically after the request block completes.
+The context manager does not wrap retries or circuit breaking.
+Those concerns stay with the calling channel code.
+Buckets are independent per `(channel, method)` pair.
+Different methods on the same channel do not share burst state.
+Different channels also do not interfere with each other.
+The bucket capacity matches the configured limit.
+That means a method can consume a full short burst immediately.
+Tokens then refill gradually over time.
+The refill clock is monotonic and injectable for tests.
+Sleep is also injectable so tests can verify blocking without waiting in real time.
+If the required wait would exceed the configured ceiling, the tool raises `RateLimited`.
+This makes backpressure explicit instead of silently stalling forever.
+Callers can catch that exception and fall back to another method or channel.
+The limiter itself does not decide fallback policy.
+It only enforces the declared pacing contract.
+Use this tool anywhere a channel method has known API quotas or anti-abuse thresholds.
+Keep the limit values with the method metadata or method implementation.
+Do not hardcode channel-wide sleeps in unrelated code.
+Centralizing pacing here keeps behavior testable and consistent.
+This tool is designed as a shared primitive, not a routed search skill.

--- a/skills/tools/rate-limiter/impl.py
+++ b/skills/tools/rate-limiter/impl.py
@@ -1,0 +1,150 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F002a
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+try:
+    from autosearch.channels.base import RateLimited
+except ImportError:
+
+    class RateLimited(Exception):
+        """Raised when a requested rate-limited acquire would wait too long."""
+
+
+@dataclass
+class _Bucket:
+    capacity: int
+    refill_rate: float
+    tokens: float
+    updated_at: float
+
+
+class RateLimiter:
+    """Per-(channel, method) token bucket.
+
+    Usage:
+        limiter = RateLimiter()
+        async with limiter.acquire("zhihu", "api_search", per_min=30):
+            ...
+
+    Raises RateLimited when bucket exhausted and wait would exceed `max_wait_seconds`.
+    """
+
+    def __init__(
+        self,
+        max_wait_seconds: float = 30.0,
+        now: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self.max_wait_seconds = max_wait_seconds
+        self._now = now
+        self._sleep = sleep
+        self._buckets: dict[tuple[str, str, str], _Bucket] = {}
+        self._locks: dict[tuple[str, str], asyncio.Lock] = {}
+
+    @asynccontextmanager
+    async def acquire(
+        self,
+        channel: str,
+        method: str,
+        per_min: int | None = None,
+        per_hour: int | None = None,
+    ) -> AsyncIterator[None]:
+        limits = self._build_limits(per_min=per_min, per_hour=per_hour)
+        if not limits:
+            yield
+            return
+
+        lock = self._locks.setdefault((channel, method), asyncio.Lock())
+
+        while True:
+            async with lock:
+                current = self._now()
+                buckets = [
+                    self._get_bucket(
+                        channel=channel,
+                        method=method,
+                        scope=scope,
+                        capacity=capacity,
+                        refill_rate=refill_rate,
+                        current=current,
+                    )
+                    for scope, capacity, refill_rate in limits
+                ]
+                wait_seconds = max(self._wait_for_token(bucket) for bucket in buckets)
+                if wait_seconds == 0:
+                    for bucket in buckets:
+                        bucket.tokens -= 1
+                    break
+
+            if wait_seconds > self.max_wait_seconds:
+                raise RateLimited(
+                    f"Rate limit exhausted for {channel}.{method}; wait={wait_seconds:.3f}s"
+                )
+            await self._sleep(wait_seconds)
+
+        try:
+            yield
+        finally:
+            return
+
+    def _build_limits(
+        self,
+        *,
+        per_min: int | None,
+        per_hour: int | None,
+    ) -> list[tuple[str, int, float]]:
+        limits: list[tuple[str, int, float]] = []
+        if per_min is not None:
+            if per_min <= 0:
+                raise ValueError("per_min must be positive")
+            limits.append(("minute", per_min, per_min / 60.0))
+        if per_hour is not None:
+            if per_hour <= 0:
+                raise ValueError("per_hour must be positive")
+            limits.append(("hour", per_hour, per_hour / 3600.0))
+        return limits
+
+    def _get_bucket(
+        self,
+        *,
+        channel: str,
+        method: str,
+        scope: str,
+        capacity: int,
+        refill_rate: float,
+        current: float,
+    ) -> _Bucket:
+        key = (channel, method, scope)
+        bucket = self._buckets.get(key)
+        if bucket is None:
+            bucket = _Bucket(
+                capacity=capacity,
+                refill_rate=refill_rate,
+                tokens=float(capacity),
+                updated_at=current,
+            )
+            self._buckets[key] = bucket
+            return bucket
+
+        self._refill(bucket, current)
+        bucket.capacity = capacity
+        bucket.refill_rate = refill_rate
+        bucket.tokens = min(bucket.tokens, float(capacity))
+        return bucket
+
+    def _refill(self, bucket: _Bucket, current: float) -> None:
+        elapsed = max(0.0, current - bucket.updated_at)
+        if elapsed == 0:
+            return
+        bucket.tokens = min(bucket.capacity, bucket.tokens + elapsed * bucket.refill_rate)
+        bucket.updated_at = current
+
+    def _wait_for_token(self, bucket: _Bucket) -> float:
+        if bucket.tokens >= 1:
+            return 0.0
+        return (1 - bucket.tokens) / bucket.refill_rate

--- a/tests/unit/test_cookie_manager.py
+++ b/tests/unit/test_cookie_manager.py
@@ -1,0 +1,177 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F002a
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module(module_name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _cookie_manager_module() -> ModuleType:
+    root = Path(__file__).resolve().parents[2]
+    return _load_module(
+        "test_cookie_manager_impl",
+        root / "skills" / "tools" / "cookie-manager" / "impl.py",
+    )
+
+
+class _CapturingLogger:
+    def __init__(self) -> None:
+        self.infos: list[tuple[str, dict[str, object]]] = []
+        self.warnings: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.infos.append((event, kwargs))
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warnings.append((event, kwargs))
+
+
+def test_get_cookie_from_json_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _cookie_manager_module()
+    logger = _CapturingLogger()
+    monkeypatch.setattr(module, "LOGGER", logger)
+
+    cookies_dir = tmp_path / "cookies"
+    cookies_dir.mkdir()
+    expected = {"z_c0": "token-123", "sessionid": "value-456"}
+    (cookies_dir / "zhihu.json").write_text(json.dumps(expected), encoding="utf-8")
+
+    manager = module.CookieManager(cookies_dir=cookies_dir)
+
+    assert manager.get_cookie("zhihu") == expected
+    assert logger.infos == [("cookie_resolved", {"channel": "zhihu", "source": "file"})]
+    assert logger.warnings == []
+
+
+def test_get_cookie_returns_none_when_file_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _cookie_manager_module()
+    logger = _CapturingLogger()
+    monkeypatch.setattr(module, "LOGGER", logger)
+
+    manager = module.CookieManager(cookies_dir=tmp_path / "cookies")
+
+    assert manager.get_cookie("zhihu") is None
+    assert logger.infos == [("cookie_unavailable", {"channel": "zhihu", "reason": "not_found"})]
+    assert logger.warnings == []
+
+
+def test_get_cookie_returns_none_and_warns_on_malformed_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _cookie_manager_module()
+    logger = _CapturingLogger()
+    monkeypatch.setattr(module, "LOGGER", logger)
+
+    cookies_dir = tmp_path / "cookies"
+    cookies_dir.mkdir()
+    (cookies_dir / "zhihu.json").write_text("{not-json", encoding="utf-8")
+
+    manager = module.CookieManager(cookies_dir=cookies_dir, enable_keychain=False)
+
+    assert manager.get_cookie("zhihu") is None
+    assert logger.warnings == [
+        ("cookie_source_failed", {"channel": "zhihu", "reason": "malformed_json"})
+    ]
+    assert logger.infos == [("cookie_unavailable", {"channel": "zhihu", "reason": "not_found"})]
+
+
+def test_get_cookie_does_not_log_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _cookie_manager_module()
+    logger = _CapturingLogger()
+    monkeypatch.setattr(module, "LOGGER", logger)
+
+    secret_value = "supersecret-cookie-value"
+    cookies_dir = tmp_path / "cookies"
+    cookies_dir.mkdir()
+    (cookies_dir / "zhihu.json").write_text(
+        json.dumps({"sessionid": secret_value}),
+        encoding="utf-8",
+    )
+
+    manager = module.CookieManager(cookies_dir=cookies_dir)
+
+    assert manager.get_cookie("zhihu") == {"sessionid": secret_value}
+    serialized_logs = " ".join(
+        [event + repr(kwargs) for event, kwargs in logger.infos + logger.warnings]
+    )
+    assert secret_value not in serialized_logs
+
+
+def test_has_cookie_matches_get_cookie(tmp_path: Path) -> None:
+    module = _cookie_manager_module()
+
+    cookies_dir = tmp_path / "cookies"
+    cookies_dir.mkdir()
+    (cookies_dir / "zhihu.json").write_text(json.dumps({"sessionid": "abc"}), encoding="utf-8")
+
+    manager = module.CookieManager(cookies_dir=cookies_dir, enable_keychain=False)
+
+    assert manager.has_cookie("zhihu") is True
+    assert manager.has_cookie("weibo") is False
+
+
+def test_keychain_disabled_on_non_darwin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _cookie_manager_module()
+    manager = module.CookieManager(cookies_dir=tmp_path / "cookies")
+    called = False
+
+    def _unexpected(_: str) -> dict[str, str] | None:
+        nonlocal called
+        called = True
+        return {"sessionid": "should-not-happen"}
+
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    monkeypatch.setattr(manager, "_load_from_keychain", _unexpected)
+
+    assert manager.get_cookie("zhihu") is None
+    assert called is False
+
+
+def test_rookiepy_lazy_import_failure_is_handled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _cookie_manager_module()
+    logger = _CapturingLogger()
+    monkeypatch.setattr(module, "LOGGER", logger)
+
+    def _import_module(name: str) -> ModuleType:
+        if name == "rookiepy":
+            raise ImportError("boom")
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(module.importlib, "import_module", _import_module)
+    manager = module.CookieManager(
+        cookies_dir=tmp_path / "cookies",
+        enable_keychain=False,
+        enable_rookiepy=True,
+    )
+
+    assert manager.get_cookie("zhihu") is None
+    assert ("cookie_source_failed", {"channel": "zhihu", "reason": "rookiepy_import_error"}) in (
+        logger.warnings
+    )

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -1,0 +1,154 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F002a
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module(module_name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _rate_limiter_module() -> ModuleType:
+    root = Path(__file__).resolve().parents[2]
+    return _load_module(
+        "test_rate_limiter_impl",
+        root / "skills" / "tools" / "rate-limiter" / "impl.py",
+    )
+
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.value = start
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.value
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.value += seconds
+
+
+@pytest.mark.asyncio
+async def test_acquire_within_budget_does_not_block() -> None:
+    module = _rate_limiter_module()
+    clock = _FakeClock()
+    limiter = module.RateLimiter(now=clock.now, sleep=clock.sleep)
+
+    for _ in range(5):
+        async with limiter.acquire("zhihu", "api_search", per_min=60):
+            pass
+
+    assert clock.sleeps == []
+    assert clock.value == 0.0
+
+
+@pytest.mark.asyncio
+async def test_acquire_blocks_when_exhausted() -> None:
+    module = _rate_limiter_module()
+    clock = _FakeClock()
+    limiter = module.RateLimiter(now=clock.now, sleep=clock.sleep)
+
+    async with limiter.acquire("zhihu", "api_search", per_min=2):
+        pass
+    async with limiter.acquire("zhihu", "api_search", per_min=2):
+        pass
+    async with limiter.acquire("zhihu", "api_search", per_min=2):
+        pass
+
+    assert len(clock.sleeps) == 1
+    assert clock.sleeps[0] == pytest.approx(30.0)
+    assert clock.value == pytest.approx(30.0)
+
+
+@pytest.mark.asyncio
+async def test_acquire_raises_rate_limited_when_max_wait_exceeded() -> None:
+    module = _rate_limiter_module()
+    clock = _FakeClock()
+    limiter = module.RateLimiter(max_wait_seconds=0.001, now=clock.now, sleep=clock.sleep)
+
+    async with limiter.acquire("zhihu", "api_search", per_min=1):
+        pass
+
+    with pytest.raises(module.RateLimited):
+        async with limiter.acquire("zhihu", "api_search", per_min=1):
+            pass
+
+    assert clock.sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_per_hour_limit_tighter_than_per_min() -> None:
+    module = _rate_limiter_module()
+    clock = _FakeClock()
+    limiter = module.RateLimiter(max_wait_seconds=2000.0, now=clock.now, sleep=clock.sleep)
+
+    async with limiter.acquire("zhihu", "api_search", per_min=60, per_hour=2):
+        pass
+    async with limiter.acquire("zhihu", "api_search", per_min=60, per_hour=2):
+        pass
+    async with limiter.acquire("zhihu", "api_search", per_min=60, per_hour=2):
+        pass
+
+    assert len(clock.sleeps) == 1
+    assert clock.sleeps[0] == pytest.approx(1800.0)
+
+
+@pytest.mark.asyncio
+async def test_independent_buckets_per_channel_method() -> None:
+    module = _rate_limiter_module()
+    clock = _FakeClock()
+    limiter = module.RateLimiter(now=clock.now, sleep=clock.sleep)
+
+    async with limiter.acquire("a", "m1", per_min=1):
+        pass
+    async with limiter.acquire("b", "m1", per_min=1):
+        pass
+    async with limiter.acquire("a", "m2", per_min=1):
+        pass
+
+    assert clock.sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_refill_over_time_allows_new_acquire() -> None:
+    module = _rate_limiter_module()
+    clock = _FakeClock()
+    limiter = module.RateLimiter(now=clock.now, sleep=clock.sleep)
+
+    async with limiter.acquire("zhihu", "api_search", per_min=2):
+        pass
+    async with limiter.acquire("zhihu", "api_search", per_min=2):
+        pass
+
+    clock.value += 30.0
+
+    async with limiter.acquire("zhihu", "api_search", per_min=2):
+        pass
+
+    assert clock.sleeps == []
+    assert clock.value == pytest.approx(30.0)
+
+
+@pytest.mark.asyncio
+async def test_acquire_without_limits_is_noop() -> None:
+    module = _rate_limiter_module()
+    clock = _FakeClock()
+    limiter = module.RateLimiter(now=clock.now, sleep=clock.sleep)
+
+    async with limiter.acquire("zhihu", "api_search"):
+        pass
+
+    assert clock.sleeps == []
+    assert clock.value == 0.0


### PR DESCRIPTION
## Summary

F002a of plan `autosearch-0418-channels-and-skills.md` — first tool-skill PR.

- `skills/tools/cookie-manager/{SKILL.md,impl.py}` — `CookieManager` with 3-source precedence (`~/.autosearch/cookies/{ch}.json` → keychain → rookiepy lazy-imported). **Never logs cookie values** — only channel + source/reason.
- `skills/tools/rate-limiter/{SKILL.md,impl.py}` — `RateLimiter` with per-(channel, method) token buckets, injectable `now`/`sleep` for tests. Raises `RateLimited` when wait exceeds `max_wait_seconds`.
- `.gitignore` adds `.autosearch/` (runtime cookie dir)
- `.gitleaks.toml` adds allowlist entry for SKILL.md prose referencing `.local/` (Linux XDG, not Tailscale)

## Validation

- **14/14 new tests pass** (7 cookie + 7 rate-limiter)
- **150 passed, 17 deselected** full suite (pre-push, was 136)
- ruff check + format clean
- Cookie-value logging explicitly tested: structlog output asserts no cookie value substring

## Security notes

- Keychain backend silently skipped on non-darwin (stubbed for Linux CI)
- `rookiepy` lazy-imported with `enable_rookiepy=False` default; no new runtime dep
- Cookie file format: flat JSON `{"name": "value"}`; malformed files → warn + return None (no crash)

## Depends on

F001-A (skill loader) + F001-B (channel registry) — both merged. Can land independently of F002b (discover-environment, blocked on Open Q #5) and F002c (10 channel skeletons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)