### PR TITLE
feat(skills): 10 channel SKILL.md skeletons for F005+ wave (F002c)

### DIFF
--- a/skills/channels/arxiv/SKILL.md
+++ b/skills/channels/arxiv/SKILL.md
@@ -1,0 +1,48 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: arxiv
+description: Use for academic preprint searches in CS/ML/physics when query is English or mixed and expects peer-reviewed or preprint papers.
+version: 1
+languages: [en]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [academic, research-paper, literature-review, survey]
+  avoid_for: [news, product-review, real-time]
+quality_hint:
+  typical_yield: medium-high
+  chinese_native: false
+---
+
+## Overview
+
+arXiv is the core discovery surface for open academic preprints in computer science, machine learning, mathematics, and physics. It is useful when the user wants papers, author names, abstracts, and recent literature rather than social discussion or product sentiment.
+
+For autosearch coverage, this channel gives the planner a clean paper-oriented source with predictable metadata and low noise. It complements web search by making research intent explicit and by supporting literature-review style queries that should not route to news or community channels.
+
+## When to Choose It
+
+- Choose it for English or mixed-language paper lookup on topics like model architectures, benchmarks, safety methods, or optimization techniques.
+- Choose it when the user asks for research papers, surveys, or literature review material rather than blog posts.
+- Choose it when titles, authors, abstracts, and paper identifiers are more important than commentary.
+- Avoid it for breaking news, shopping advice, or fast-moving public opinion.
+
+## How To Search (Planned)
+
+- `api_search` - Query the arXiv API search endpoint with keyword and category filters, then parse Atom feed results into normalized paper evidence.
+- `api_search` - Expected fields include title, authors, summary, published date, primary category, and canonical arXiv URL.
+- `api_search` - Initial ranking should favor exact topic matches and recent relevant submissions for literature-review workflows.
+
+## Known Quirks
+
+- The API is stable but not high throughput; keep requests conservative even though no auth is required.
+- arXiv indexes preprints, not peer-review status, so downstream ranking should not imply formal publication.
+- Query syntax can be sensitive to exact author names and category terms.
+- Some papers are highly relevant but have terse abstracts, so recall can be uneven on broad queries.

--- a/skills/channels/bilibili/SKILL.md
+++ b/skills/channels/bilibili/SKILL.md
@@ -1,0 +1,53 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: bilibili
+description: Chinese video platform for tech tutorials, comparison videos, gaming/ACG, and expert breakdowns — use for visual content in Chinese.
+version: 1
+languages: [zh, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+  - id: api_video_detail
+    impl: methods/api_video_detail.py
+    requires: [cookie:bilibili]
+    rate_limit: {per_min: 20, per_hour: 300}
+fallback_chain: [api_search, api_video_detail]
+when_to_use:
+  query_languages: [zh, mixed]
+  query_types: [tutorial-video, comparison, breakdown, tech-opinion]
+  avoid_for: [text-only-query, academic-papers]
+quality_hint:
+  typical_yield: medium
+  chinese_native: true
+---
+
+## Overview
+
+Bilibili is a Chinese video platform with strong coverage in tutorials, hardware comparisons, software explainers, gaming, and creator-led technical commentary. It is useful when the user wants Chinese-language visual content rather than text-first references.
+
+For autosearch coverage, this channel fills a gap between global video search and Chinese-native creator ecosystems. It matters because many Chinese tutorials, teardown videos, and side-by-side product breakdowns are published on Bilibili long before they appear elsewhere.
+
+## When to Choose It
+
+- Choose it for Chinese tutorial-video and breakdown queries.
+- Choose it for device comparisons, creator explainers, and tech-opinion in video form.
+- Choose it when visual demonstration matters more than short text description.
+- Prefer it over YouTube when the target audience, terminology, or creator ecosystem is Chinese-native.
+- Avoid it for pure text lookup or formal academic paper search.
+
+## How To Search (Planned)
+
+- `api_search` - Call Bilibili search endpoints for videos and creators using Chinese or mixed query text, then rank by topical relevance and engagement.
+- `api_video_detail` - Fetch richer metadata for shortlisted videos with authenticated detail access when `cookie:bilibili` is available.
+- `api_video_detail` - Normalize title, uploader, publish time, duration, play stats, and canonical video URL.
+
+## Known Quirks
+
+- Basic search works without auth, but video detail and richer metadata are more stable with a valid cookie.
+- Many results are entertainment-adjacent, so ranking must distinguish tech and tutorial intent carefully.
+- Some high-signal tutorials use slang or fandom terminology that generic keyword matching may miss.
+- Video popularity can dominate search ordering even when a smaller creator has the better explanation.

--- a/skills/channels/douyin/SKILL.md
+++ b/skills/channels/douyin/SKILL.md
@@ -1,0 +1,49 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: douyin
+description: Chinese short-form video platform for trending content, product launches, consumer commentary, and lifestyle segments in Chinese.
+version: 1
+languages: [zh]
+methods:
+  - id: via_douyin_mcp
+    impl: methods/via_douyin_mcp.py
+    requires: [mcp:douyin-mcp-server, cookie:douyin]
+    rate_limit: {per_min: 10, per_hour: 120}
+fallback_chain: [via_douyin_mcp]
+when_to_use:
+  query_languages: [zh]
+  query_types: [trending, short-form, product-launch, consumer-commentary, lifestyle]
+  avoid_for: [technical-deep-dive, academic]
+quality_hint:
+  typical_yield: medium
+  chinese_native: true
+---
+
+## Overview
+
+Douyin is a Chinese short-form video platform geared toward trends, launches, fast product reactions, and lifestyle content. It is useful when the query needs highly current Chinese consumer commentary or creator-driven short-form coverage.
+
+For autosearch coverage, this channel adds a format and audience segment that neither Weibo nor Xiaohongshu fully captures. It matters because some product launches and viral consumer narratives spread first through short-form video rather than text posts.
+
+## When to Choose It
+
+- Choose it for Chinese trending or short-form video queries.
+- Choose it for product launch buzz, consumer commentary, and fast lifestyle coverage.
+- Choose it when creator clips and short demonstrations are more relevant than long-form explanation.
+- Prefer it over deeper video channels when immediacy and viral spread matter most.
+- Avoid it for technical deep dives or academic-style research questions.
+
+## How To Search (Planned)
+
+- `via_douyin_mcp` - Use the `douyin-mcp-server` route with authenticated session access to search clips, creators, and topical results.
+- `via_douyin_mcp` - Normalize clip title or caption, creator identity, publish time, engagement counts, and canonical share URL.
+- `via_douyin_mcp` - Keep extraction lightweight and ranking recency-aware because the platform is heavily short-form and trend-driven.
+
+## Known Quirks
+
+- The planned route depends on both `mcp:douyin-mcp-server` and `cookie:douyin`.
+- Short-form content is high-noise and can be weak on factual detail without corroboration.
+- Trend vocabulary changes quickly, so rigid keyword matching will miss some relevant clips.
+- Platform defenses and session expiry can make access more brittle than standard web APIs.

--- a/skills/channels/github/SKILL.md
+++ b/skills/channels/github/SKILL.md
@@ -1,0 +1,58 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: github
+description: Use for code-level, issue-level, and repository discovery when query involves a library, framework, or implementation detail.
+version: 1
+languages: [en]
+methods:
+  - id: search_repositories
+    impl: methods/search_repos.py
+    requires: [env:GITHUB_TOKEN]
+    rate_limit: {per_min: 30, per_hour: 5000}
+  - id: search_issues
+    impl: methods/search_issues.py
+    requires: [env:GITHUB_TOKEN]
+    rate_limit: {per_min: 30, per_hour: 5000}
+  - id: search_code
+    impl: methods/search_code.py
+    requires: [env:GITHUB_TOKEN]
+    rate_limit: {per_min: 10, per_hour: 5000}
+fallback_chain: [search_repositories, search_issues, search_code]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [code, library, implementation, debugging, tooling]
+  avoid_for: [news, product-review, people]
+quality_hint:
+  typical_yield: high
+  chinese_native: false
+---
+
+## Overview
+
+GitHub is the primary channel for repository discovery, issue triage, and code search across open source software. It is the right surface when the user is asking how something is implemented, which repo is authoritative, or whether a bug already exists upstream.
+
+For autosearch, this channel anchors developer intent to concrete artifacts instead of commentary. It matters because many technical queries are better answered by repositories, issue threads, and source snippets than by generic web summaries.
+
+## When to Choose It
+
+- Choose it when the query names a package, framework, SDK, CLI, or implementation pattern.
+- Choose it for debugging signals such as open issues, regressions, workarounds, or maintainer discussion.
+- Choose it when repository health, stars, forks, recent activity, and code examples are relevant.
+- Prefer it over forum channels when the user wants source-of-truth implementation detail.
+- Avoid it for general news, consumer reviews, or person-focused lookups.
+
+## How To Search (Planned)
+
+- `search_repositories` - Call the GitHub Search Repositories API with keyword and language qualifiers, then rank likely primary repos by relevance and activity.
+- `search_issues` - Call the GitHub Search Issues API to find bug reports, feature requests, and maintainer responses tied to the query.
+- `search_code` - Call the GitHub Search Code API for symbol names, config fragments, or error strings when implementation detail matters more than repo discovery.
+- `search_code` - Normalize output around repository, path, snippet context, and canonical GitHub URLs for downstream evidence ranking.
+
+## Known Quirks
+
+- All planned methods require `GITHUB_TOKEN`; unauthenticated search is too constrained for reliable routing.
+- Code search is usually the tightest rate-limited method, so it belongs later in the fallback chain.
+- Repository popularity can overwhelm niche but relevant results if ranking is not intent-aware.
+- Issue search returns mixed issue and PR style records, so later impls should normalize thread type carefully.

--- a/skills/channels/hackernews/SKILL.md
+++ b/skills/channels/hackernews/SKILL.md
@@ -1,0 +1,49 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: hackernews
+description: Use for real-time developer discussion, tooling opinions, and early-stage product signals from the HN community.
+version: 1
+languages: [en]
+methods:
+  - id: algolia_search
+    impl: methods/algolia.py
+    requires: []
+    rate_limit: {per_min: 60, per_hour: 1000}
+fallback_chain: [algolia_search]
+when_to_use:
+  query_languages: [en]
+  query_types: [tech-opinion, tooling, startup, product-launch, hacker-culture]
+  avoid_for: [academic, chinese-query]
+quality_hint:
+  typical_yield: medium-high
+  chinese_native: false
+---
+
+## Overview
+
+Hacker News is a strong source for English-language developer reactions to tools, startups, launches, and technical blog posts. It is especially useful when the user wants candid operator sentiment, early adoption signals, or discussion around a new product in the developer ecosystem.
+
+For autosearch coverage, this channel adds community judgment that is often missing from official docs or vendor pages. It matters because HN can surface quality critiques, deployment pain points, and adoption signals earlier than more polished media sources.
+
+## When to Choose It
+
+- Choose it for English queries about developer opinion on a tool, launch, or startup.
+- Choose it when comment quality and community debate matter more than formal documentation.
+- Choose it for "what do engineers think of this" style prompts.
+- Prefer it for early-stage product signals before broader media coverage stabilizes.
+- Avoid it for academic paper retrieval or Chinese-language discourse.
+
+## How To Search (Planned)
+
+- `algolia_search` - Query the Algolia-backed HN search API for stories and comments matching the query, then rank by recency and discussion value.
+- `algolia_search` - Capture story title, points, comment count, author, created time, and the HN thread URL.
+- `algolia_search` - Support both top-level launch discovery and comment-level opinion lookup for tooling and startup queries.
+
+## Known Quirks
+
+- The Algolia index is convenient and fast, but ranking can drift toward viral threads instead of the most technically useful ones.
+- HN is English-first and culturally specific, so it should not be treated as representative public sentiment.
+- Comment quality varies sharply by thread age and topic.
+- Some external links disappear or change after posting, leaving the HN thread as the durable evidence source.

--- a/skills/channels/twitter/SKILL.md
+++ b/skills/channels/twitter/SKILL.md
@@ -1,0 +1,49 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: twitter
+description: Use for real-time public commentary, AI researcher threads, and announcements when query targets current events or expert takes.
+version: 1
+languages: [en, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: [env:TWITTER_BEARER_TOKEN]
+    rate_limit: {per_min: 10, per_hour: 100}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [real-time, expert-take, announcement, researcher-thread]
+  avoid_for: [academic-papers, deep-technical-tutorial]
+quality_hint:
+  typical_yield: medium
+  chinese_native: false
+---
+
+## Overview
+
+Twitter is a real-time public commentary channel for announcements, expert reactions, and short-form discussion threads. It is useful when the query targets current events, AI researcher commentary, launch announcements, or ongoing public conversation that has not yet settled into longer-form coverage.
+
+For autosearch, this channel expands timely coverage beyond static web pages and official press posts. It matters because expert accounts and organizational announcement threads often appear first here, even when a later route will be needed for higher-confidence confirmation.
+
+## When to Choose It
+
+- Choose it for current-event and announcement queries where timing matters.
+- Choose it for AI researcher threads, conference reactions, or short expert takes.
+- Choose it when the user wants public commentary around a model release, paper release, or product launch.
+- Use it for mixed-language queries only when the likely evidence source is still English-dominant public discussion.
+- Avoid it for academic paper retrieval or deep tutorial-style instruction.
+
+## How To Search (Planned)
+
+- `api_search` - Use the official recent search API with keyword, account, hashtag, and recency filters under the assumed Basic tier route.
+- `api_search` - Normalize posts around author handle, created time, engagement counts, thread linkage, and canonical status URL.
+- `api_search` - Prefer high-signal accounts such as researchers, labs, maintainers, and official product teams when ranking evidence.
+
+## Known Quirks
+
+- This route is intentionally provisional; plan F006 may replace or reshape the implementation strategy.
+- Official API quotas are relatively tight, so broad exploratory queries need careful budgeting.
+- Search results can be noisy around viral topics and ambiguous entity names.
+- Important evidence may live inside threads or quote posts rather than standalone posts.

--- a/skills/channels/weibo/SKILL.md
+++ b/skills/channels/weibo/SKILL.md
@@ -1,0 +1,53 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: weibo
+description: Chinese microblog platform for real-time opinion, trending topics, and event-level commentary in Chinese discourse.
+version: 1
+languages: [zh, mixed]
+methods:
+  - id: mobile_api_search
+    impl: methods/mobile_api.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+  - id: api_detail
+    impl: methods/api_detail.py
+    requires: [cookie:weibo]
+    rate_limit: {per_min: 20, per_hour: 300}
+fallback_chain: [mobile_api_search, api_detail]
+when_to_use:
+  query_languages: [zh, mixed]
+  query_types: [real-time, trending, public-opinion, event]
+  avoid_for: [academic, tutorial, deep-technical]
+quality_hint:
+  typical_yield: medium
+  chinese_native: true
+---
+
+## Overview
+
+Weibo is a Chinese real-time social platform oriented around trends, public reaction, and event-level commentary. It is useful when the query needs live Chinese discourse, viral narratives, or fast-moving reaction around a person, brand, release, or public event.
+
+For autosearch coverage, this channel gives strong Chinese social recency that blog and Q&A sources cannot provide. It matters because many Chinese public-opinion signals appear on Weibo first, especially around launches, controversies, and trending hashtags.
+
+## When to Choose It
+
+- Choose it for Chinese real-time or trending-topic queries.
+- Choose it when event-level commentary and public reaction matter more than depth.
+- Choose it for launch buzz, controversy tracking, or fast sentiment checks in Chinese discourse.
+- Prefer it over slower Q&A channels when recency is the main routing signal.
+- Avoid it for academic lookup, tutorials, or deep technical explanation.
+
+## How To Search (Planned)
+
+- `mobile_api_search` - Query mobile-oriented search endpoints for posts, keywords, and trending topic matches without assuming authenticated detail access.
+- `api_detail` - Fetch richer post metadata and engagement details when a valid `cookie:weibo` is present.
+- `api_detail` - Normalize post author, created time, reposts, comments, likes, and canonical mobile or web URLs.
+
+## Known Quirks
+
+- Search endpoints can be unstable and rate-limited during major events.
+- Detail access is more reliable with a valid `cookie:weibo`, especially for older or restricted posts.
+- Trending content is noisy and can include spam, repost farms, or thin commentary.
+- Entity ambiguity is common because nicknames, hashtags, and shorthand terms dominate conversation.

--- a/skills/channels/xiaohongshu/SKILL.md
+++ b/skills/channels/xiaohongshu/SKILL.md
@@ -1,0 +1,53 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: xiaohongshu
+description: Chinese lifestyle and consumer product platform — use when query is Chinese and targets product recommendations, lifestyle experiences, or consumer reviews.
+version: 1
+languages: [zh]
+methods:
+  - id: via_mcporter
+    impl: methods/via_mcporter.py
+    requires: [mcp:mcporter, cookie:xiaohongshu]
+    rate_limit: {per_min: 5, per_hour: 60}
+  - id: via_xhs_cli
+    impl: methods/via_xhs_cli.py
+    requires: [binary:xhs-cli, cookie:xiaohongshu]
+    rate_limit: {per_min: 5, per_hour: 60}
+fallback_chain: [via_mcporter, via_xhs_cli]
+when_to_use:
+  query_languages: [zh]
+  query_types: [product-recommendation, lifestyle, consumer-review, food, travel]
+  avoid_for: [technical, academic, code]
+quality_hint:
+  typical_yield: medium
+  chinese_native: true
+---
+
+## Overview
+
+Xiaohongshu is a Chinese lifestyle and consumer discovery platform centered on short posts, shopping notes, travel tips, and product impressions. It is useful when the user wants Chinese-language recommendation content, daily-life experience reports, or creator-style product reviews.
+
+For autosearch coverage, this channel adds consumer and lifestyle evidence that is poorly covered by developer-oriented sources. It matters because many Chinese purchase decisions, travel planning queries, and beauty or gadget recommendation workflows depend on Xiaohongshu-native content.
+
+## When to Choose It
+
+- Choose it for Chinese product recommendation and consumer review queries.
+- Choose it for food, travel, beauty, lifestyle, and everyday experience lookup.
+- Choose it when creator-style usage notes matter more than formal specifications.
+- Prefer it for Chinese consumer intent rather than technical or code-heavy questions.
+- Avoid it for academic, engineering deep-dive, or implementation detail queries.
+
+## How To Search (Planned)
+
+- `via_mcporter` - Route search through the `mcporter` MCP bridge with authenticated Xiaohongshu session access for note discovery and metadata extraction.
+- `via_xhs_cli` - Use a local `xhs-cli` executable plus authenticated cookies as a fallback when MCP access is unavailable.
+- `via_xhs_cli` - Normalize note title, author, engagement counts, tags, and canonical note URL for downstream evidence ranking.
+
+## Known Quirks
+
+- Both planned methods require an authenticated Xiaohongshu cookie; anonymous access is unreliable.
+- Rate budgets are intentionally conservative because anti-automation defenses are common.
+- Content is recommendation-heavy and can skew toward influencer aesthetics instead of balanced comparison.
+- Search quality is best for native Chinese product and lifestyle terminology, not English technical jargon.

--- a/skills/channels/youtube/SKILL.md
+++ b/skills/channels/youtube/SKILL.md
@@ -1,0 +1,49 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: youtube
+description: Use for video tutorial discovery, conference talks, technical walkthroughs, and product demos.
+version: 1
+languages: [en, zh, mixed]
+methods:
+  - id: data_api_search
+    impl: methods/data_api_v3.py
+    requires: [env:YOUTUBE_API_KEY]
+    rate_limit: {per_min: 100, per_hour: 10000}
+fallback_chain: [data_api_search]
+when_to_use:
+  query_languages: [en, zh, mixed]
+  query_types: [tutorial, conference-talk, walkthrough, demo]
+  avoid_for: [latest-text-news]
+quality_hint:
+  typical_yield: medium
+  chinese_native: false
+---
+
+## Overview
+
+YouTube is the broadest video discovery channel in the stack for tutorials, talks, walkthroughs, and product demos. It is useful when the user wants audiovisual explanation, presenter context, or conference footage rather than text-first sources.
+
+For autosearch coverage, this channel adds strong visual learning and long-form talk retrieval across both English and Chinese queries. It matters because many technical explanations are easier to validate from recorded demos and conference sessions than from short text summaries.
+
+## When to Choose It
+
+- Choose it for tutorial and walkthrough queries where visual explanation is part of the answer.
+- Choose it for conference talks, keynote sessions, and recorded technical presentations.
+- Choose it for product demo discovery across English, Chinese, or mixed-language queries.
+- Prefer it when channel reputation and video format matter more than text recency.
+- Avoid it for latest text-only news where a news or social channel is a better primary source.
+
+## How To Search (Planned)
+
+- `data_api_search` - Call the YouTube Data API v3 search endpoint with query text, language hints, and video result filters.
+- `data_api_search` - Follow up with video metadata fields such as title, channel, duration, publish time, description, and watch URL for normalization.
+- `data_api_search` - Rank toward tutorials, talks, and demos instead of general entertainment matches by combining keyword and channel-level cues.
+
+## Known Quirks
+
+- The Data API requires `YOUTUBE_API_KEY`, and quota cost can rise quickly if detail lookups are added later.
+- Search quality varies by language and by how creators title multilingual content.
+- Video metadata is useful, but true instructional quality still depends on transcript and channel context.
+- Recency alone can be misleading because older talks may remain the authoritative explanation.

--- a/skills/channels/zhihu/SKILL.md
+++ b/skills/channels/zhihu/SKILL.md
@@ -1,0 +1,53 @@
+# Skill Attribution
+> Source: self-written, plan `autosearch-0418-channels-and-skills.md` § F002c.
+
+---
+name: zhihu
+description: Chinese Q&A platform with deep technical discussions and user experience reports — use when query is Chinese or mixed and targets developer opinions, comparisons, or tutorials.
+version: 1
+languages: [zh, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+  - id: api_answer_detail
+    impl: methods/api_answer.py
+    requires: [cookie:zhihu]
+    rate_limit: {per_min: 20, per_hour: 300}
+fallback_chain: [api_search, api_answer_detail]
+when_to_use:
+  query_languages: [zh, mixed]
+  query_types: [technical, experience-report, product-review, tutorial, comparison]
+  avoid_for: [real-time-news, academic-papers]
+quality_hint:
+  typical_yield: medium-high
+  chinese_native: true
+---
+
+## Overview
+
+Zhihu is a major Chinese question-and-answer platform with long-form posts, answer threads, and high-signal technical comparisons. It is useful when the user wants Chinese-language reasoning, practical experience reports, or side-by-side discussion of tools and products.
+
+For autosearch coverage, this channel brings native Chinese discourse that is not well represented on English platforms. It matters because many Chinese developer and user communities publish nuanced tutorials, migration notes, and comparative buying advice directly on Zhihu.
+
+## When to Choose It
+
+- Choose it for Chinese or mixed-language queries about technical tradeoffs, tutorials, or product comparisons.
+- Choose it when user experience reports and long-form answers are more useful than short posts.
+- Choose it for developer opinion in Chinese around frameworks, devices, services, or workflow tools.
+- Prefer it over general social feeds when depth and explanation matter.
+- Avoid it for breaking news or formal paper lookup.
+
+## How To Search (Planned)
+
+- `api_search` - Use Zhihu search endpoints to discover questions, answers, and articles matching the query, then extract canonical URLs and brief snippets.
+- `api_answer_detail` - Fetch fuller answer detail for shortlisted posts using authenticated endpoints when a cookie is available.
+- `api_answer_detail` - Normalize answer author, vote count, created time, question title, and answer body excerpt for downstream ranking.
+
+## Known Quirks
+
+- Unauthenticated search can work, but deeper answer detail is more reliable with a valid `cookie:zhihu`.
+- Zhihu content quality varies from expert long-form posts to shallow SEO-style reposts.
+- Answer pages can change structure, so detail extraction is more brittle than simple search discovery.
+- Technical queries in Chinese often benefit from strong entity normalization because product names mix English and Chinese tokens.

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -1,0 +1,87 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F002c
+from pathlib import Path
+
+from autosearch.channels.base import ChannelRegistry, Environment
+from autosearch.skills.loader import load_all
+
+
+def _channels_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "skills" / "channels"
+
+
+def _load_specs():
+    return load_all(_channels_root())
+
+
+def test_all_10_channels_loadable() -> None:
+    specs = _load_specs()
+
+    assert len(specs) == 10
+    assert [spec.name for spec in specs] == [
+        "arxiv",
+        "bilibili",
+        "douyin",
+        "github",
+        "hackernews",
+        "twitter",
+        "weibo",
+        "xiaohongshu",
+        "youtube",
+        "zhihu",
+    ]
+
+
+def test_channels_have_required_frontmatter_fields() -> None:
+    for spec in _load_specs():
+        assert spec.name
+        assert spec.description
+        assert spec.languages
+        assert spec.methods
+        assert spec.when_to_use is not None
+        assert spec.when_to_use.query_languages
+        assert spec.when_to_use.query_types
+        assert spec.quality_hint is not None
+
+
+def test_fallback_chain_matches_methods() -> None:
+    for spec in _load_specs():
+        method_ids = {method.id for method in spec.methods}
+
+        assert spec.fallback_chain
+        assert set(spec.fallback_chain).issubset(method_ids)
+
+
+def test_chinese_native_channels_cover_5() -> None:
+    chinese_native = {
+        spec.name
+        for spec in _load_specs()
+        if spec.quality_hint is not None and spec.quality_hint.chinese_native
+    }
+
+    assert chinese_native == {
+        "bilibili",
+        "douyin",
+        "weibo",
+        "xiaohongshu",
+        "zhihu",
+    }
+    assert len(chinese_native) == 5
+
+
+def test_no_method_impl_exists_yet() -> None:
+    for spec in _load_specs():
+        for method in spec.methods:
+            assert not (spec.skill_dir / method.impl).exists()
+
+
+def test_compile_from_skills_marks_all_unavailable() -> None:
+    registry = ChannelRegistry.compile_from_skills(_channels_root(), Environment())
+
+    assert [channel.name for channel in registry.available()] == []
+    for spec in _load_specs():
+        metadata = registry.metadata(spec.name)
+
+        assert metadata.available_methods() == []
+        assert len(metadata.methods) == len(spec.methods)
+        assert all(method.available is False for method in metadata.methods)
+        assert all(method.unmet_requires == ["impl_missing"] for method in metadata.methods)


### PR DESCRIPTION
## Summary

F002c of plan `autosearch-0418-channels-and-skills.md` — 10 channel SKILL.md skeletons, metadata only, **no method impl yet**. This unblocks F005 (海外 API-only wave: arxiv/github/hn/youtube) and F007/F008 (中文 waves) where each channel PR only adds `methods/*.py` implementation on top of existing metadata.

Relies on F001-B's scaffold-safe guarantee: `ChannelRegistry.compile_from_skills` handles missing `methods/*.py` by marking `available=False, unmet_requires=["impl_missing"]` — so these skeletons load cleanly without crashing the pipeline.

## Channels included

| # | Channel | Languages | Methods planned | Chinese native |
|---|---------|-----------|-----------------|----------------|
| 1 | arxiv | en | api_search | no |
| 2 | github | en | search_repos / search_issues / search_code | no |
| 3 | hackernews | en | algolia_search | no |
| 4 | twitter | en, mixed | api_search (route TBD per F006) | no |
| 5 | youtube | en, zh, mixed | data_api_search | no |
| 6 | zhihu | zh, mixed | api_search / api_answer_detail | yes |
| 7 | weibo | zh, mixed | mobile_api_search / api_detail | yes |
| 8 | xiaohongshu | zh | via_mcporter / via_xhs_cli | yes |
| 9 | bilibili | zh, mixed | api_search / api_video_detail | yes |
| 10 | douyin | zh | via_douyin_mcp | yes |

5 native Chinese channels = satisfies `feedback_autosearch-chinese-channels` hard rule (≥ 2 available chinese channels) once any 2 impls ship.

## Per-skill content

Each `SKILL.md`:
- Attribution blockquote (MDX-safe, not HTML comment)
- Frontmatter: `name, description, version, languages, methods, fallback_chain, when_to_use, quality_hint`
- Prose: `## Overview`, `## When to Choose It`, `## How To Search (Planned)`, `## Known Quirks`

## Validation

- **6 new tests pass** in `tests/unit/test_channel_skill_scaffolds.py`:
  - `test_all_10_channels_loadable`
  - `test_channels_have_required_frontmatter_fields`
  - `test_fallback_chain_matches_methods`
  - `test_chinese_native_channels_cover_5` (zhihu/weibo/xhs/bilibili/douyin)
  - `test_no_method_impl_exists_yet` (F002c guarantee)
  - `test_compile_from_skills_marks_all_unavailable` (all methods unmet without cookies/mcp/env/impl)
- **142 passed, 17 deselected** full suite
- ruff clean
- Loader sanity: `load_all(Path('skills/channels'))` returns all 10 sorted

## Dependencies

- ✅ F001-A (skill loader) — merged
- ✅ F001-B (channel registry) — merged
- Independent of: F002a #120 (tools), F002b (blocked Q#5), F004 #121 (DDGS)

## Next actions post-merge

- F005 Wave 1 arxiv implementation = one PR that adds `skills/channels/arxiv/methods/api_search.py` + unit test + E2B matrix task. No metadata changes needed.
- Same pattern for github / hackernews / youtube.

🤖 Generated with [Claude Code](https://claude.com/claude-code)