### PR TITLE
feat(channels): add ArxivChannel for academic paper search (F005 Wave 1.1)

### DIFF
--- a/autosearch/channels/arxiv.py
+++ b/autosearch/channels/arxiv.py
@@ -1,0 +1,82 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F005
+import asyncio
+from datetime import UTC, datetime
+
+import feedparser
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel")
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+class ArxivChannel:
+    """arxiv.org search channel — free, no auth. Academic preprint coverage.
+
+    Follows skills/channels/arxiv/SKILL.md spec. Uses export.arxiv.org Atom API.
+    Code-registered for now (per F005 wave pattern); will migrate to registry.compile_from_skills
+    under F003 once the pipeline reads skill methods directly.
+    """
+
+    name = "arxiv"
+
+    def __init__(
+        self,
+        max_results: int = 10,
+        http_timeout: float = 30.0,
+        base_url: str = "http://export.arxiv.org/api/query",
+    ) -> None:
+        self.max_results = max_results
+        self.http_timeout = http_timeout
+        self.base_url = base_url
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        """Run arxiv Atom query, parse feed, return Evidence list."""
+
+        try:
+            async with httpx.AsyncClient(timeout=self.http_timeout) as client:
+                response = await client.get(
+                    self.base_url,
+                    params={
+                        "search_query": f"all:{query.text}",
+                        "start": 0,
+                        "max_results": self.max_results,
+                        "sortBy": "relevance",
+                        "sortOrder": "descending",
+                    },
+                )
+                response.raise_for_status()
+
+            feed = await asyncio.to_thread(feedparser.parse, response.text)
+            if getattr(feed, "bozo", 0):
+                bozo_exception = getattr(feed, "bozo_exception", None)
+                raise ValueError(str(bozo_exception or "failed to parse Atom feed"))
+
+            entries = list(getattr(feed, "entries", []))
+            if not entries:
+                raise ValueError("empty feed")
+        except Exception as exc:
+            LOGGER.warning("arxiv_search_failed", channel=self.name, reason=str(exc))
+            return []
+
+        fetched_at = datetime.now(UTC)
+        return [self._to_evidence(entry, fetched_at=fetched_at) for entry in entries]
+
+    def _to_evidence(self, entry: object, *, fetched_at: datetime) -> Evidence:
+        title = _normalize_whitespace(str(getattr(entry, "title", "") or ""))
+        summary = _normalize_whitespace(str(getattr(entry, "summary", "") or ""))
+        url = str(getattr(entry, "link", "") or getattr(entry, "id", "") or "").strip()
+
+        return Evidence(
+            url=url,
+            title=title,
+            snippet=summary[:500] or None,
+            source_channel=self.name,
+            fetched_at=fetched_at,
+            score=0.0,
+        )

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -9,6 +9,7 @@ import typer
 import uvicorn
 
 from autosearch import __version__
+from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
 from autosearch.core.models import SearchMode
@@ -83,7 +84,7 @@ def query(
         result = asyncio.run(
             Pipeline(
                 llm=LLMClient(),
-                channels=[DemoChannel(), DDGSChannel()],
+                channels=[DemoChannel(), DDGSChannel(), ArxivChannel()],
                 top_k_evidence=top_k,
                 on_event=stream_callback,
             ).run(query, mode_hint=mode)

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 
+from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
 from autosearch.core.models import SearchMode
@@ -12,7 +13,7 @@ from autosearch.llm.client import LLMClient
 
 
 def _default_pipeline_factory() -> Pipeline:
-    return Pipeline(llm=LLMClient(), channels=[DemoChannel(), DDGSChannel()])
+    return Pipeline(llm=LLMClient(), channels=[DemoChannel(), DDGSChannel(), ArxivChannel()])
 
 
 def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> FastMCP:

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
 from autosearch import __version__
+from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
 from autosearch.core.models import SearchMode
@@ -66,7 +67,7 @@ app.add_middleware(
 def _default_pipeline_factory(on_event: EventCallback | None = None) -> Pipeline:
     return Pipeline(
         llm=LLMClient(),
-        channels=[DemoChannel(), DDGSChannel()],
+        channels=[DemoChannel(), DDGSChannel(), ArxivChannel()],
         on_event=on_event,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "aiosqlite",
   "ddgs",
   "fastapi",
+  "feedparser",
   "httpx",
   "mcp",
   "pydantic",

--- a/tests/e2b/matrix.yaml
+++ b/tests/e2b/matrix.yaml
@@ -560,6 +560,53 @@ phases:
           exit: 0
           stdout_contains: "ddgs_in_sources_ok"
 
+  # F013 S1 — arxiv channel smoke (free API, no key required)
+  F013_channel_arxiv_smoke:
+    parallel: 1
+    timeout: 600
+    upload:
+      - src: /tmp/autosearch-src.tar.gz
+        dst: /tmp/autosearch-src.tar.gz
+    setup: |
+      set -e
+      mkdir -p $HOME/work/autosearch
+      tar -xzf /tmp/autosearch-src.tar.gz -C $HOME/work/autosearch
+      curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1
+      cd $HOME/work/autosearch
+      $HOME/.local/bin/uv venv --python 3.12 .venv
+      $HOME/.local/bin/uv pip install --python .venv/bin/python -e . > /tmp/install.log 2>&1
+    tasks:
+      - id: arxiv_in_sources
+        timeout: 480
+        env_keys: [ANTHROPIC_API_KEY]
+        cmd: |
+          set -o pipefail
+          cd $HOME/work/autosearch
+          AUTOSEARCH_PROVIDER_CHAIN=anthropic \
+          .venv/bin/autosearch query "Survey papers on retrieval augmented generation" --mode fast --json 2>&1 | tail -80 | python3 -c "
+          import sys, json
+          out = sys.stdin.read()
+          start = out.index('{')
+          data = json.loads(out[start:])
+          sources = data.get('sources') or {}
+          channels = set()
+          if isinstance(sources, dict):
+              channels.update(sources.keys())
+          elif isinstance(sources, list):
+              for source in sources:
+                  if isinstance(source, dict) and 'channel' in source:
+                      channels.add(source['channel'])
+          print('channels=', sorted(channels))
+          assert 'arxiv' in channels, f'arxiv missing from sources: {channels}'
+          refs = data.get('markdown') or ''
+          has_arxiv_url = 'arxiv.org/abs' in refs
+          assert has_arxiv_url, 'no arxiv.org/abs URL in markdown'
+          print('arxiv_in_report_ok')
+          "
+        expect:
+          exit: 0
+          stdout_contains: "arxiv_in_report_ok"
+
   # F002 S3 — Failure paths
   F002_S3_failure_paths:
     parallel: 1

--- a/tests/fixtures/arxiv_response.atom
+++ b/tests/fixtures/arxiv_response.atom
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://arxiv.org/api/query?search_query=all:retrieval+augmented+generation</id>
+  <title>ArXiv Query: all:retrieval augmented generation</title>
+  <updated>2026-04-18T00:00:00Z</updated>
+  <entry>
+    <id>http://arxiv.org/abs/2304.12345v1</id>
+    <title>Retrieval-Augmented Generation for Large Language Models: A Survey</title>
+    <summary>Large language models demonstrate remarkable capabilities across a broad range of reasoning and generation tasks, but they remain bounded by static training corpora and weak source attribution. Retrieval-augmented generation combines parametric models with external knowledge stores to improve factuality, freshness, and controllability for downstream applications.</summary>
+    <link href="http://arxiv.org/abs/2304.12345v1" rel="alternate" type="text/html" />
+    <published>2026-04-15T00:00:00Z</published>
+    <author><name>Ada Researcher</name></author>
+    <author><name>Lin Scholar</name></author>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2401.54321v2</id>
+    <title>Long Context Retrieval Pipelines for Enterprise Search</title>
+    <summary>Enterprise retrieval systems increasingly join lexical ranking, dense retrieval, re-ranking, grounding, evaluation, and tool usage inside one response loop. This paper studies how long-context models interact with retrieval pipelines, how citation quality degrades when chunking is naive, and how evaluation should separate answer accuracy from evidence precision. We report controlled experiments across documentation search, question answering, and support workflows, analyze index freshness and failure modes, and propose a staged architecture that preserves citation fidelity under load while keeping latency predictable for end users in production systems with heterogeneous corpora and dynamic access constraints.</summary>
+    <link href="http://arxiv.org/abs/2401.54321v2" rel="alternate" type="text/html" />
+    <published>2026-04-10T00:00:00Z</published>
+    <author><name>Sam Engineer</name></author>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2502.99999v1</id>
+    <title>
+      Chain-of-Thought   Prompting
+      for   Retrieval    Systems
+    </title>
+    <summary>We examine whether explicit reasoning traces improve retrieval planning, citation selection, and error recovery in open-domain systems that mix search with generation.</summary>
+    <link href="http://arxiv.org/abs/2502.99999v1" rel="alternate" type="text/html" />
+    <published>2026-04-01T00:00:00Z</published>
+    <author><name>Casey Analyst</name></author>
+  </entry>
+</feed>

--- a/tests/unit/test_arxiv_channel.py
+++ b/tests/unit/test_arxiv_channel.py
@@ -1,0 +1,187 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F005
+from pathlib import Path
+import re
+
+import httpx
+import pytest
+
+import autosearch.channels.arxiv as arxiv_module
+from autosearch.channels.arxiv import ArxivChannel
+from autosearch.core.models import Evidence, SubQuery
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _fixture_text(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
+
+
+def _response(
+    text: str,
+    *,
+    status_code: int = 200,
+    url: str = "http://export.arxiv.org/api/query",
+    params: dict[str, object] | None = None,
+) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        text=text,
+        request=httpx.Request("GET", url, params=params),
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_returns_evidence_from_atom_feed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        captured["url"] = url
+        captured["params"] = dict(params)
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(arxiv_module.httpx.AsyncClient, "get", fake_get)
+
+    results = await ArxivChannel().search(
+        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
+    )
+
+    assert len(results) == 3
+    assert all(isinstance(item, Evidence) for item in results)
+    assert re.compile(r"^https?://arxiv\.org/abs/").search(results[0].url)
+    assert all(re.compile(r"^https?://arxiv\.org/abs/").search(item.url) for item in results)
+    assert captured["url"] == "http://export.arxiv.org/api/query"
+    assert captured["params"] == {
+        "search_query": "all:retrieval augmented generation",
+        "start": 0,
+        "max_results": 10,
+        "sortBy": "relevance",
+        "sortOrder": "descending",
+    }
+    assert all(item.source_channel == "arxiv" for item in results)
+    assert all(item.score == 0.0 for item in results)
+
+
+@pytest.mark.asyncio
+async def test_search_empty_feed_returns_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Logger()
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        return _response(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <id>http://arxiv.org/api/query</id>
+              <title>Empty</title>
+              <updated>2026-04-18T00:00:00Z</updated>
+            </feed>
+            """,
+            url=url,
+            params=params,
+        )
+
+    monkeypatch.setattr(arxiv_module.httpx.AsyncClient, "get", fake_get)
+    monkeypatch.setattr(arxiv_module, "LOGGER", logger)
+
+    results = await ArxivChannel().search(
+        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
+    )
+
+    assert results == []
+    assert logger.events == [
+        (
+            "arxiv_search_failed",
+            {"channel": "arxiv", "reason": "empty feed"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_handles_network_error_gracefully(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        _ = params
+        raise httpx.ConnectError("boom", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(arxiv_module.httpx.AsyncClient, "get", fake_get)
+    monkeypatch.setattr(arxiv_module, "LOGGER", logger)
+
+    results = await ArxivChannel().search(SubQuery(text="rag", rationale="Need paper coverage"))
+
+    assert results == []
+    assert logger.events == [
+        (
+            "arxiv_search_failed",
+            {"channel": "arxiv", "reason": "boom"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_handles_parse_error_gracefully(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        return _response("<feed><entry>", url=url, params=params)
+
+    monkeypatch.setattr(arxiv_module.httpx.AsyncClient, "get", fake_get)
+    monkeypatch.setattr(arxiv_module, "LOGGER", logger)
+
+    results = await ArxivChannel().search(SubQuery(text="rag", rationale="Need paper coverage"))
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "arxiv_search_failed"
+    assert logger.events[0][1]["channel"] == "arxiv"
+
+
+@pytest.mark.asyncio
+async def test_snippet_truncated_to_500_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(arxiv_module.httpx.AsyncClient, "get", fake_get)
+
+    results = await ArxivChannel().search(
+        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
+    )
+
+    assert len(results) == 3
+    assert results[1].snippet is not None
+    assert len(results[1].snippet) == 500
+
+
+@pytest.mark.asyncio
+async def test_title_whitespace_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(arxiv_module.httpx.AsyncClient, "get", fake_get)
+
+    results = await ArxivChannel().search(
+        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
+    )
+
+    assert len(results) == 3
+    assert results[2].title == "Chain-of-Thought Prompting for Retrieval Systems"
+    assert "\n" not in results[2].title
+    assert "  " not in results[2].title


### PR DESCRIPTION
## Summary

F005 Wave 1.1 — first academic-source channel. Unblocks english technical/research queries that DDGS doesn't cover well.

- `autosearch/channels/arxiv.py` — `ArxivChannel` using `httpx.AsyncClient` for `export.arxiv.org/api/query` + `feedparser` (via `asyncio.to_thread`) to parse Atom feed. Graceful exception handling (structlog warn + return `[]`).
- `feedparser` added to `pyproject.toml` dependencies (v6.0.12)
- Registered in 3 entry points: `autosearch/cli/main.py`, `autosearch/mcp/server.py`, `autosearch/server/main.py` — pattern matches DDGS (`channels=[DemoChannel(), DDGSChannel(), ArxivChannel()]`). Will migrate to `registry.compile_from_skills` under F003.
- `tests/unit/test_arxiv_channel.py` — 6 cases (atom parse + empty feed + network error + XML parse error + snippet truncation + title whitespace normalization)
- `tests/fixtures/arxiv_response.atom` — representative 3-entry Atom fixture
- `tests/e2b/matrix.yaml` — new `F013_channel_arxiv_smoke` phase asserting `arxiv` appears in `sources` + `arxiv.org/abs` URL in report markdown

## Validation

- **6/6 arxiv tests pass**
- **166 passed, 17 deselected** full suite (was 160 — arxiv +6)
- ruff check + format clean
- `feedparser==6.0.12` confirmed importable

## Design notes

- API: `GET /api/query?search_query=all:{q}&start=0&max_results={N}&sortBy=relevance&sortOrder=descending`
- No auth required (arxiv is free)
- Rate limit respected per SKILL.md (per_min=30, per_hour=500) — not enforced in this channel yet; F002a rate-limiter integration is follow-up (next PR can wrap method calls with `async with limiter.acquire("arxiv", "api_search", per_min=30)`)
- Title normalization: arxiv titles are wrapped across multiple lines in Atom; `_normalize_ws` collapses to single spaces
- Snippet: summary truncated to 500 chars

## Scope not covered

- Rate limiter wrap (follow-up — trivial wrap once pattern established)
- Migration to `skills/channels/arxiv/methods/api_search.py` (F003 scope)
- PDF download / full-text parse (deferred — abstract sufficient for ranking)

## Dependencies

- ✅ F002c (arxiv SKILL.md metadata) — merged
- ✅ F004 (DDGS pattern) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)