### PR TITLE
docs: correct validation report — no delivery-status drift (was my misdiagnosis)

### DIFF
--- a/docs/validation/2026-04-18-e2b.md
+++ b/docs/validation/2026-04-18-e2b.md
@@ -45,7 +45,7 @@ Wall time (run 1 only): 24:06. Total sandboxes consumed: 13. Runs 2+3 combined: 
 
 2. **Matrix lying-pass: `fast_stream_openai` with empty key.** `OPENAI_API_KEY` in `~/.config/ai-secrets.env` is present but empty. Task expected `exit 0` but got `exit 1` ("No LLM provider configured"). Removed from matrix rather than skip-guarded; will re-add when real OPENAI key lands in boss secrets.
 
-3. **Doc drift: 4 shipped module paths in `docs/delivery-status.md` don't exist.** F011 `shipped_modules_importable` surfaced that M0 Knowledge Recall lives in `core/knowledge.py` (not `core/recall.py`), M7 Synthesizer in `synthesis/report.py` (not `synthesis/synthesizer.py`), SessionStore in `persistence/session_store.py` (not `observability/session.py`), and the FastAPI SSE app in `server/main.py` (not `server/sse.py`). Matrix assertions corrected; `delivery-status.md` still carries old labels in the module table — low-severity follow-up.
+3. **Matrix import-path drift (self-authored, not a doc bug).** F011 `shipped_modules_importable` surfaced that the importable path list I hand-wrote into `matrix.yaml` was wrong: used `autosearch.core.recall`, `autosearch.synthesis.synthesizer`, `autosearch.observability.session`, `autosearch.server.sse` — none of those modules exist. Real paths: `core.knowledge`, `synthesis.report`, `persistence.session_store`, `server.main`. Matrix assertions corrected. **Originally mis-labeled as `delivery-status.md` drift** — verified that file never carried these paths; the drift was entirely in the matrix spec I authored during plan drafting.
 
 ## Known gaps (not tested)
 
@@ -70,8 +70,7 @@ Wall time (run 1 only): 24:06. Total sandboxes consumed: 13. Runs 2+3 combined: 
 
 ## Next session candidates
 
-1. **Fold paths**: fix `docs/delivery-status.md` module table to match real code paths (bug #3 above)
-2. **Build `autosearch-claude` E2B template** → unlocks F004 S5 + S6
-3. **F012 nightly workflow**: `.github/workflows/e2b-nightly.yml` + boss adds GH Actions secrets
-4. **F010 perf baseline** — first-run commit, then nightly regression diff
-5. **F006 quality** — needs ~$8 budget + human rubric review per plan § § "Phase 5 必经人审"
+1. **Build `autosearch-claude` E2B template** → unlocks F004 S5 + S6
+2. **F012 nightly workflow**: `.github/workflows/e2b-nightly.yml` + boss adds GH Actions secrets
+3. **F010 perf baseline** — first-run commit, then nightly regression diff
+4. **F006 quality** — needs ~$8 budget + human rubric review per plan § "Phase 5 必经人审"


### PR DESCRIPTION
## Summary

Small correction to `docs/validation/2026-04-18-e2b.md`. The "bug #3 doc drift" claim I wrote at the end of the previous session was incorrect — `docs/delivery-status.md` never carried those wrong paths.

## What actually happened

F011 `shipped_modules_importable` task revealed the matrix.yaml I authored during plan drafting listed non-existent import paths (`core.recall`, `synthesis.synthesizer`, `observability.session`, `server.sse`). I hand-typed them from the plan's § "被测系统全景" table without checking the real module structure.

Correct paths (already fixed in matrix via 2026-04-18 run3): `core.knowledge`, `synthesis.report`, `persistence.session_store`, `server.main`.

`docs/delivery-status.md` was never touched — I grep'd it and it never contained those labels. So there's no doc to patch.

## Change

- Bugs section item #3: rewrite as "matrix import-path drift (self-authored)" and explicitly note the mis-attribution to delivery-status
- Next session candidates: remove the phantom "fix delivery-status paths" item

Prevents a future session from chasing a ghost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)