### PR TITLE
feat(channels): add HackerNewsChannel via Algolia API (F005 Wave 1.2)

### DIFF
--- a/autosearch/channels/hackernews.py
+++ b/autosearch/channels/hackernews.py
@@ -1,0 +1,102 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F005
+import html
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel")
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _clean_text(value: object) -> str:
+    text = html.unescape(str(value or ""))
+    text = _HTML_TAG_RE.sub("", text)
+    return _normalize_whitespace(text)
+
+
+def _truncate_with_ellipsis(text: str, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+    return f"{text[:max_length]}..."
+
+
+class HackerNewsChannel:
+    """HN Algolia search — free, no auth. Real-time dev discussion coverage.
+
+    Uses https://hn.algolia.com/api/v1/search endpoint.
+    """
+
+    name = "hackernews"
+
+    def __init__(
+        self,
+        max_results: int = 10,
+        http_timeout: float = 15.0,
+        base_url: str = "https://hn.algolia.com/api/v1/search",
+    ) -> None:
+        self.max_results = max_results
+        self.http_timeout = http_timeout
+        self.base_url = base_url
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        """Run Hacker News Algolia search, convert hits to Evidence."""
+
+        try:
+            async with httpx.AsyncClient(timeout=self.http_timeout) as client:
+                response = await client.get(
+                    self.base_url,
+                    params={
+                        "query": query.text,
+                        "hitsPerPage": self.max_results,
+                        "tags": "(story,comment)",
+                    },
+                )
+                response.raise_for_status()
+
+            payload = response.json()
+            hits = payload.get("hits", [])
+            if not isinstance(hits, list):
+                raise ValueError("invalid hits payload")
+        except Exception as exc:
+            LOGGER.warning("hackernews_search_failed", channel=self.name, reason=str(exc))
+            return []
+
+        fetched_at = datetime.now(UTC)
+        return [
+            self._to_evidence(hit, fetched_at=fetched_at)
+            for hit in hits
+            if isinstance(hit, Mapping)
+        ]
+
+    def _to_evidence(self, hit: Mapping[str, object], *, fetched_at: datetime) -> Evidence:
+        object_id = str(hit.get("objectID") or "").strip()
+        internal_url = self._item_url(object_id)
+        external_url = str(hit.get("url") or "").strip()
+        title = _clean_text(hit.get("title"))
+        story_text = _clean_text(hit.get("story_text"))
+        comment_text = _clean_text(hit.get("comment_text"))
+        snippet = (story_text or comment_text)[:500] or None
+        fallback_title = comment_text or story_text or f"Hacker News item {object_id}".strip()
+
+        return Evidence(
+            url=external_url or internal_url,
+            title=title or _truncate_with_ellipsis(fallback_title, 80),
+            snippet=snippet,
+            source_channel=self.name,
+            fetched_at=fetched_at,
+            score=0.0,
+        )
+
+    def _item_url(self, object_id: str) -> str:
+        if object_id:
+            return f"https://news.ycombinator.com/item?id={object_id}"
+        return "https://news.ycombinator.com/"

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -12,6 +12,7 @@ from autosearch import __version__
 from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
+from autosearch.channels.hackernews import HackerNewsChannel
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline, PipelineResult
 from autosearch.init_runner import InitError, InitRunner
@@ -84,7 +85,7 @@ def query(
         result = asyncio.run(
             Pipeline(
                 llm=LLMClient(),
-                channels=[DemoChannel(), DDGSChannel(), ArxivChannel()],
+                channels=[DemoChannel(), DDGSChannel(), ArxivChannel(), HackerNewsChannel()],
                 top_k_evidence=top_k,
                 on_event=stream_callback,
             ).run(query, mode_hint=mode)

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -7,13 +7,17 @@ from mcp.server.fastmcp import FastMCP
 from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
+from autosearch.channels.hackernews import HackerNewsChannel
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline
 from autosearch.llm.client import LLMClient
 
 
 def _default_pipeline_factory() -> Pipeline:
-    return Pipeline(llm=LLMClient(), channels=[DemoChannel(), DDGSChannel(), ArxivChannel()])
+    return Pipeline(
+        llm=LLMClient(),
+        channels=[DemoChannel(), DDGSChannel(), ArxivChannel(), HackerNewsChannel()],
+    )
 
 
 def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> FastMCP:

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -15,6 +15,7 @@ from autosearch import __version__
 from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
+from autosearch.channels.hackernews import HackerNewsChannel
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline, PipelineResult
 from autosearch.llm.client import LLMClient
@@ -67,7 +68,7 @@ app.add_middleware(
 def _default_pipeline_factory(on_event: EventCallback | None = None) -> Pipeline:
     return Pipeline(
         llm=LLMClient(),
-        channels=[DemoChannel(), DDGSChannel(), ArxivChannel()],
+        channels=[DemoChannel(), DDGSChannel(), ArxivChannel(), HackerNewsChannel()],
         on_event=on_event,
     )
 

--- a/tests/e2b/matrix.yaml
+++ b/tests/e2b/matrix.yaml
@@ -607,6 +607,44 @@ phases:
           exit: 0
           stdout_contains: "arxiv_in_report_ok"
 
+  # F013 S2 — hackernews channel smoke (Algolia API, no auth)
+  F013_channel_hackernews_smoke:
+    parallel: 1
+    timeout: 600
+    upload:
+      - src: /tmp/autosearch-src.tar.gz
+        dst: /tmp/autosearch-src.tar.gz
+    setup: |
+      set -e
+      mkdir -p $HOME/work/autosearch
+      tar -xzf /tmp/autosearch-src.tar.gz -C $HOME/work/autosearch
+      curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1
+      cd $HOME/work/autosearch
+      $HOME/.local/bin/uv venv --python 3.12 .venv
+      $HOME/.local/bin/uv pip install --python .venv/bin/python -e . > /tmp/install.log 2>&1
+    tasks:
+      - id: hackernews_in_sources
+        timeout: 480
+        env_keys: [ANTHROPIC_API_KEY]
+        cmd: |
+          set -o pipefail
+          cd $HOME/work/autosearch
+          AUTOSEARCH_PROVIDER_CHAIN=anthropic \
+          .venv/bin/autosearch query "What are developers saying about Rust vs Go for systems programming" --mode fast --json 2>&1 | tail -80 | python3 -c "
+          import sys, json
+          out = sys.stdin.read()
+          start = out.index('{')
+          data = json.loads(out[start:])
+          sources = data.get('sources') or {}
+          channels = set(sources.keys()) if isinstance(sources, dict) else set()
+          print('channels=', sorted(channels))
+          assert 'hackernews' in channels, f'hackernews missing from sources: {channels}'
+          print('hackernews_in_sources_ok')
+          "
+        expect:
+          exit: 0
+          stdout_contains: "hackernews_in_sources_ok"
+
   # F002 S3 — Failure paths
   F002_S3_failure_paths:
     parallel: 1

--- a/tests/fixtures/hackernews_response.json
+++ b/tests/fixtures/hackernews_response.json
@@ -1,0 +1,37 @@
+{
+  "hits": [
+    {
+      "objectID": "1001",
+      "title": "Rust vs Go in 2026",
+      "url": "https://example.com/rust-vs-go",
+      "story_text": "A comparison of Rust and Go for systems programming decisions.",
+      "author": "alice",
+      "points": 120,
+      "num_comments": 45,
+      "created_at": "2026-04-18T00:00:00Z",
+      "_tags": ["story", "author_alice"]
+    },
+    {
+      "objectID": "1002",
+      "title": "Ask HN: Show me your build cache tricks",
+      "url": null,
+      "story_text": "Self-post body with details about build cache strategies inside large monorepos.",
+      "author": "bob",
+      "points": 54,
+      "num_comments": 30,
+      "created_at": "2026-04-18T01:00:00Z",
+      "_tags": ["story", "ask_hn", "author_bob"]
+    },
+    {
+      "objectID": "1003",
+      "title": null,
+      "url": null,
+      "comment_text": "I have shipped both. Rust gives stronger safety guarantees, but Go is still easier to onboard for most teams.",
+      "author": "carol",
+      "points": null,
+      "num_comments": null,
+      "created_at": "2026-04-18T02:00:00Z",
+      "_tags": ["comment", "author_carol", "story_1001"]
+    }
+  ]
+}

--- a/tests/unit/test_hackernews_channel.py
+++ b/tests/unit/test_hackernews_channel.py
@@ -1,0 +1,196 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F005
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+import autosearch.channels.hackernews as hackernews_module
+from autosearch.channels.hackernews import HackerNewsChannel
+from autosearch.core.models import Evidence, SubQuery
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _fixture_json(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def _patch_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: httpx.MockTransport,
+) -> None:
+    original_async_client = httpx.AsyncClient
+
+    def factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        return original_async_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(hackernews_module.httpx, "AsyncClient", factory)
+
+
+def _transport(
+    payload: object,
+    *,
+    captured: dict[str, object] | None = None,
+) -> httpx.MockTransport:
+    def respond(request: httpx.Request) -> httpx.Response:
+        if captured is not None:
+            captured["url"] = str(request.url)
+            captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json=payload, request=request)
+
+    return httpx.MockTransport(respond)
+
+
+@pytest.mark.asyncio
+async def test_search_maps_story_hit_to_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    payload = _fixture_json("hackernews_response.json")
+    _patch_async_client(monkeypatch, _transport(payload, captured=captured))
+
+    results = await HackerNewsChannel().search(
+        SubQuery(text="Rust vs Go", rationale="Need HN discussion")
+    )
+
+    assert len(results) == 3
+    assert all(isinstance(item, Evidence) for item in results)
+    assert (
+        captured["url"]
+        == "https://hn.algolia.com/api/v1/search?query=Rust+vs+Go&hitsPerPage=10&tags=%28story%2Ccomment%29"
+    )
+    assert captured["params"] == {
+        "query": "Rust vs Go",
+        "hitsPerPage": "10",
+        "tags": "(story,comment)",
+    }
+    assert results[0].url == "https://example.com/rust-vs-go"
+    assert results[0].title == "Rust vs Go in 2026"
+    assert results[0].source_channel == "hackernews"
+    assert results[0].score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_search_maps_comment_hit_uses_internal_item_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _fixture_json("hackernews_response.json")
+    _patch_async_client(monkeypatch, _transport(payload))
+
+    results = await HackerNewsChannel().search(
+        SubQuery(text="Rust vs Go", rationale="Need HN discussion")
+    )
+
+    comment_text = str((payload["hits"])[2]["comment_text"])
+    assert results[2].url == "https://news.ycombinator.com/item?id=1003"
+    assert results[2].title == f"{comment_text[:80]}..."
+
+
+@pytest.mark.asyncio
+async def test_search_story_with_null_external_url_falls_back_to_hn_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _fixture_json("hackernews_response.json")
+    _patch_async_client(monkeypatch, _transport(payload))
+
+    results = await HackerNewsChannel().search(
+        SubQuery(text="build cache", rationale="Need Ask HN coverage")
+    )
+
+    assert results[1].url == "https://news.ycombinator.com/item?id=1002"
+    assert results[1].title == "Ask HN: Show me your build cache tricks"
+
+
+@pytest.mark.asyncio
+async def test_search_strips_html_from_snippet(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "hits": [
+            {
+                "objectID": "9999",
+                "title": None,
+                "url": None,
+                "comment_text": '<p>Use the <a href="https://example.com">link</a> text.</p>',
+            }
+        ]
+    }
+    _patch_async_client(monkeypatch, _transport(payload))
+
+    results = await HackerNewsChannel().search(
+        SubQuery(text="html snippet", rationale="Need sanitization coverage")
+    )
+
+    assert results[0].snippet == "Use the link text."
+    assert "<" not in results[0].snippet
+    assert ">" not in results[0].snippet
+
+
+@pytest.mark.asyncio
+async def test_search_empty_hits_returns_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Logger()
+    _patch_async_client(monkeypatch, _transport({"hits": []}))
+    monkeypatch.setattr(hackernews_module, "LOGGER", logger)
+
+    results = await HackerNewsChannel().search(
+        SubQuery(text="no hits", rationale="Need empty search coverage")
+    )
+
+    assert results == []
+    assert logger.events == []
+
+
+@pytest.mark.asyncio
+async def test_search_network_error_returns_empty_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(respond))
+    monkeypatch.setattr(hackernews_module, "LOGGER", logger)
+
+    results = await HackerNewsChannel().search(
+        SubQuery(text="Rust vs Go", rationale="Need HN discussion")
+    )
+
+    assert results == []
+    assert logger.events == [
+        (
+            "hackernews_search_failed",
+            {"channel": "hackernews", "reason": "boom"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_snippet_truncated_to_500_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    story_text = "a" * 750
+    payload = {
+        "hits": [
+            {
+                "objectID": "5000",
+                "title": "Long story",
+                "url": "https://example.com/long-story",
+                "story_text": story_text,
+            }
+        ]
+    }
+    _patch_async_client(monkeypatch, _transport(payload))
+
+    results = await HackerNewsChannel().search(
+        SubQuery(text="Long story", rationale="Need truncation coverage")
+    )
+
+    assert results[0].snippet is not None
+    assert len(results[0].snippet) == 500
+    assert results[0].snippet == story_text[:500]


### PR DESCRIPTION
## Summary

F005 Wave 1.2 — HN discussion/opinion source. Free API, no auth.

- `autosearch/channels/hackernews.py` — `HackerNewsChannel` using `httpx.AsyncClient` against `https://hn.algolia.com/api/v1/search`. Handles both stories (has external url + title) and comments (no title, internal item URL fallback). HTML tags stripped from snippets. 500-char truncation. Graceful error handling (warn + `[]`).
- Registered in `cli/main.py`, `mcp/server.py`, `server/main.py` — now `channels=[DemoChannel(), DDGSChannel(), ArxivChannel(), HackerNewsChannel()]`
- `tests/unit/test_hackernews_channel.py` — 7 cases (story mapping / comment fallback / null URL fallback / HTML strip / empty hits / network error / snippet trunc)
- `tests/fixtures/hackernews_response.json` — 3-hit fixture (story with url, self-post without, comment)
- `tests/e2b/matrix.yaml` — `F013_channel_hackernews_smoke` asserting `hackernews` in sources

## Validation

- **7/7 tests pass**
- **173 passed, 17 deselected** full suite (was 166, +7)
- ruff check + format clean

## Design notes

- URL precedence: `hit.url` (external) → `https://news.ycombinator.com/item?id={objectID}` (fallback)
- Title precedence: `hit.title` (stories) → comment_text[:80] + "..." (comments)
- HTML strip: simple `re.sub(r'<[^>]+>', '', text)` — HN comments commonly have `<a>`, `<p>`, `<i>` wrappers
- No rate limiter wrap yet (deferred — same as arxiv)

## Dependencies

- ✅ F002c (hackernews SKILL.md metadata) — merged
- ✅ F005 arxiv (pattern reference) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)