### PR TITLE
feat(channels): add YouTubeChannel via Data API v3 (F005 Wave 1.3)

### DIFF
--- a/autosearch/channels/youtube.py
+++ b/autosearch/channels/youtube.py
@@ -1,0 +1,103 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F005
+import html
+import os
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel")
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _clean_text(value: object) -> str:
+    return _normalize_whitespace(html.unescape(str(value or "")))
+
+
+class YouTubeChannel:
+    """YouTube Data API v3 search channel.
+
+    SECURITY: API key sent via `x-goog-api-key` header, never as URL query param
+    (prevents key leaking into logs / error traces — same lesson as gemini provider).
+    """
+
+    name = "youtube"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        max_results: int = 10,
+        http_timeout: float = 15.0,
+        base_url: str = "https://www.googleapis.com/youtube/v3/search",
+    ) -> None:
+        self.api_key = api_key or os.getenv("YOUTUBE_API_KEY")
+        self.max_results = max_results
+        self.http_timeout = http_timeout
+        self.base_url = base_url
+        self._warned_no_api_key = False
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        """Return YouTube video matches or [] when unavailable/failing."""
+
+        if not self.api_key:
+            if not self._warned_no_api_key:
+                LOGGER.warning("youtube_search_skipped", channel=self.name, reason="no_api_key")
+                self._warned_no_api_key = True
+            return []
+
+        try:
+            async with httpx.AsyncClient(timeout=self.http_timeout) as client:
+                response = await client.get(
+                    self.base_url,
+                    params={
+                        "part": "snippet",
+                        "q": query.text,
+                        "type": "video",
+                        "maxResults": self.max_results,
+                    },
+                    headers={"x-goog-api-key": self.api_key},
+                )
+                response.raise_for_status()
+
+            payload = response.json()
+            items = payload.get("items", [])
+            if not isinstance(items, list):
+                raise ValueError("invalid items payload")
+            fetched_at = datetime.now(UTC)
+            return [
+                self._to_evidence(item, fetched_at=fetched_at)
+                for item in items
+                if isinstance(item, Mapping)
+            ]
+        except httpx.HTTPStatusError as exc:
+            reason = "auth_failed" if exc.response.status_code in {401, 403} else str(exc)
+            LOGGER.warning("youtube_search_failed", channel=self.name, reason=reason)
+            return []
+        except Exception as exc:
+            LOGGER.warning("youtube_search_failed", channel=self.name, reason=str(exc))
+            return []
+
+    def _to_evidence(self, item: Mapping[str, object], *, fetched_at: datetime) -> Evidence:
+        item_id = item["id"]
+        snippet = item["snippet"]
+        if not isinstance(item_id, Mapping) or not isinstance(snippet, Mapping):
+            raise ValueError("invalid youtube item")
+
+        video_id = str(item_id["videoId"]).strip()
+        title = _clean_text(snippet["title"])
+        description = _clean_text(snippet.get("description"))
+
+        return Evidence(
+            url=f"https://www.youtube.com/watch?v={video_id}",
+            title=title,
+            snippet=description[:500] or None,
+            source_channel=self.name,
+            fetched_at=fetched_at,
+            score=0.0,
+        )

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -12,6 +12,7 @@ from autosearch import __version__
 from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
+from autosearch.channels.youtube import YouTubeChannel
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline, PipelineResult
 from autosearch.init_runner import InitError, InitRunner
@@ -84,7 +85,12 @@ def query(
         result = asyncio.run(
             Pipeline(
                 llm=LLMClient(),
-                channels=[DemoChannel(), DDGSChannel(), ArxivChannel()],
+                channels=[
+                    DemoChannel(),
+                    DDGSChannel(),
+                    ArxivChannel(),
+                    YouTubeChannel(),
+                ],
                 top_k_evidence=top_k,
                 on_event=stream_callback,
             ).run(query, mode_hint=mode)

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -7,13 +7,22 @@ from mcp.server.fastmcp import FastMCP
 from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
+from autosearch.channels.youtube import YouTubeChannel
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline
 from autosearch.llm.client import LLMClient
 
 
 def _default_pipeline_factory() -> Pipeline:
-    return Pipeline(llm=LLMClient(), channels=[DemoChannel(), DDGSChannel(), ArxivChannel()])
+    return Pipeline(
+        llm=LLMClient(),
+        channels=[
+            DemoChannel(),
+            DDGSChannel(),
+            ArxivChannel(),
+            YouTubeChannel(),
+        ],
+    )
 
 
 def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> FastMCP:

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -15,6 +15,7 @@ from autosearch import __version__
 from autosearch.channels.arxiv import ArxivChannel
 from autosearch.channels.ddgs import DDGSChannel
 from autosearch.channels.demo import DemoChannel
+from autosearch.channels.youtube import YouTubeChannel
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline, PipelineResult
 from autosearch.llm.client import LLMClient
@@ -67,7 +68,12 @@ app.add_middleware(
 def _default_pipeline_factory(on_event: EventCallback | None = None) -> Pipeline:
     return Pipeline(
         llm=LLMClient(),
-        channels=[DemoChannel(), DDGSChannel(), ArxivChannel()],
+        channels=[
+            DemoChannel(),
+            DDGSChannel(),
+            ArxivChannel(),
+            YouTubeChannel(),
+        ],
         on_event=on_event,
     )
 

--- a/tests/e2b/matrix.yaml
+++ b/tests/e2b/matrix.yaml
@@ -607,6 +607,53 @@ phases:
           exit: 0
           stdout_contains: "arxiv_in_report_ok"
 
+  # F013 S3 — youtube channel smoke (Data API v3, needs YOUTUBE_API_KEY)
+  F013_channel_youtube_smoke:
+    parallel: 1
+    timeout: 600
+    upload:
+      - src: /tmp/autosearch-src.tar.gz
+        dst: /tmp/autosearch-src.tar.gz
+    setup: |
+      set -e
+      mkdir -p $HOME/work/autosearch
+      tar -xzf /tmp/autosearch-src.tar.gz -C $HOME/work/autosearch
+      curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1
+      cd $HOME/work/autosearch
+      $HOME/.local/bin/uv venv --python 3.12 .venv
+      $HOME/.local/bin/uv pip install --python .venv/bin/python -e . > /tmp/install.log 2>&1
+    tasks:
+      - id: youtube_in_sources
+        timeout: 480
+        env_keys: [ANTHROPIC_API_KEY, YOUTUBE_API_KEY]
+        cmd: |
+          set -o pipefail
+          cd $HOME/work/autosearch
+          AUTOSEARCH_PROVIDER_CHAIN=anthropic \
+          .venv/bin/autosearch query "Best introductory video tutorials for BM25 ranking function" --mode fast --json 2>&1 | tail -80 | python3 -c "
+          import sys, json
+          out = sys.stdin.read()
+          start = out.index('{')
+          data = json.loads(out[start:])
+          sources = data.get('sources') or {}
+          channels = set()
+          if isinstance(sources, dict):
+              channels.update(sources.keys())
+          elif isinstance(sources, list):
+              for source in sources:
+                  if isinstance(source, dict) and 'channel' in source:
+                      channels.add(source['channel'])
+          print('channels=', sorted(channels))
+          assert 'youtube' in channels, f'youtube missing from sources: {channels}'
+          md = data.get('markdown') or ''
+          has_yt_url = 'youtube.com/watch' in md or 'youtu.be/' in md
+          assert has_yt_url, 'no youtube URL in markdown'
+          print('youtube_in_report_ok')
+          "
+        expect:
+          exit: 0
+          stdout_contains: "youtube_in_report_ok"
+
   # F002 S3 — Failure paths
   F002_S3_failure_paths:
     parallel: 1

--- a/tests/fixtures/youtube_response.json
+++ b/tests/fixtures/youtube_response.json
@@ -1,0 +1,66 @@
+{
+  "kind": "youtube#searchListResponse",
+  "etag": "fixture-etag",
+  "items": [
+    {
+      "kind": "youtube#searchResult",
+      "etag": "etag-1",
+      "id": {
+        "kind": "youtube#video",
+        "videoId": "video-001"
+      },
+      "snippet": {
+        "publishedAt": "2026-04-10T12:00:00Z",
+        "channelId": "channel-001",
+        "title": "BM25 Tutorial for Search Engineers",
+        "description": "A practical introduction to BM25 ranking for search applications.",
+        "thumbnails": {
+          "default": {
+            "url": "https://i.ytimg.com/vi/video-001/default.jpg"
+          }
+        },
+        "channelTitle": "Search Lab"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "etag-2",
+      "id": {
+        "kind": "youtube#video",
+        "videoId": "video-002"
+      },
+      "snippet": {
+        "publishedAt": "2026-03-28T08:30:00Z",
+        "channelId": "channel-002",
+        "title": "Understanding BM25 Step by Step",
+        "description": "Walkthrough of term frequency, inverse document frequency, and document length normalization.",
+        "thumbnails": {
+          "default": {
+            "url": "https://i.ytimg.com/vi/video-002/default.jpg"
+          }
+        },
+        "channelTitle": "IR Explained"
+      }
+    },
+    {
+      "kind": "youtube#searchResult",
+      "etag": "etag-3",
+      "id": {
+        "kind": "youtube#video",
+        "videoId": "video-003"
+      },
+      "snippet": {
+        "publishedAt": "2026-02-14T17:45:00Z",
+        "channelId": "channel-003",
+        "title": "Ranking Functions in Practice",
+        "description": "Comparing BM25 with learned retrieval methods for introductory use cases.",
+        "thumbnails": {
+          "default": {
+            "url": "https://i.ytimg.com/vi/video-003/default.jpg"
+          }
+        },
+        "channelTitle": "Signals and Search"
+      }
+    }
+  ]
+}

--- a/tests/unit/test_youtube_channel.py
+++ b/tests/unit/test_youtube_channel.py
@@ -1,0 +1,219 @@
+# Self-written, plan autosearch-0418-channels-and-skills.md § F005
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+import autosearch.channels.youtube as youtube_module
+from autosearch.channels.youtube import YouTubeChannel
+from autosearch.core.models import Evidence, SubQuery
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _fixture_json(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def _patch_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: httpx.MockTransport,
+) -> None:
+    original_async_client = httpx.AsyncClient
+
+    def factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        return original_async_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(youtube_module.httpx, "AsyncClient", factory)
+
+
+def _transport(
+    payload: object | None = None,
+    *,
+    status_code: int = 200,
+    captured: dict[str, object] | None = None,
+) -> httpx.MockTransport:
+    def respond(request: httpx.Request) -> httpx.Response:
+        if captured is not None:
+            captured["url"] = str(request.url)
+            captured["params"] = dict(request.url.params)
+            captured["headers"] = dict(request.headers)
+        return httpx.Response(status_code, json=payload, request=request)
+
+    return httpx.MockTransport(respond)
+
+
+@pytest.mark.asyncio
+async def test_search_maps_items_to_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _fixture_json("youtube_response.json")
+    _patch_async_client(monkeypatch, _transport(payload))
+
+    results = await YouTubeChannel(api_key="test-key").search(
+        SubQuery(text="bm25 tutorial", rationale="Need introductory videos")
+    )
+
+    assert len(results) == 3
+    assert all(isinstance(item, Evidence) for item in results)
+    assert results[0].url == "https://www.youtube.com/watch?v=video-001"
+    assert results[0].title == "BM25 Tutorial for Search Engineers"
+    assert results[0].snippet == "A practical introduction to BM25 ranking for search applications."
+    assert all(item.source_channel == "youtube" for item in results)
+    assert all(item.score == 0.0 for item in results)
+
+
+@pytest.mark.asyncio
+async def test_search_without_api_key_returns_empty_and_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+    monkeypatch.setattr(youtube_module, "LOGGER", logger)
+    channel = YouTubeChannel(api_key=None)
+
+    first = await channel.search(SubQuery(text="bm25 tutorial", rationale="Need videos"))
+    second = await channel.search(SubQuery(text="dense retrieval", rationale="Need videos"))
+
+    assert first == []
+    assert second == []
+    assert logger.events == [
+        (
+            "youtube_search_skipped",
+            {"channel": "youtube", "reason": "no_api_key"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_api_key_in_header_not_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    _patch_async_client(monkeypatch, _transport({"items": []}, captured=captured))
+
+    await YouTubeChannel(api_key="SECRET_SENTINEL").search(
+        SubQuery(text="bm25 tutorial", rationale="Need videos")
+    )
+
+    url = captured["url"]
+    headers = captured["headers"]
+    assert isinstance(url, str)
+    assert isinstance(headers, dict)
+    assert "SECRET_SENTINEL" not in url
+    assert "key=" not in url
+    assert headers.get("x-goog-api-key") == "SECRET_SENTINEL"
+
+
+@pytest.mark.asyncio
+async def test_api_key_value_not_in_logs_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(youtube_module, "LOGGER", logger)
+    _patch_async_client(monkeypatch, _transport({"error": "denied"}, status_code=401))
+
+    results = await YouTubeChannel(api_key="SECRET_SENTINEL").search(
+        SubQuery(text="bm25 tutorial", rationale="Need videos")
+    )
+
+    assert results == []
+    assert logger.events == [
+        (
+            "youtube_search_failed",
+            {"channel": "youtube", "reason": "auth_failed"},
+        )
+    ]
+    assert logger.events
+    assert "SECRET_SENTINEL" not in json.dumps(logger.events)
+
+
+@pytest.mark.asyncio
+async def test_html_entities_unescaped_in_title_and_snippet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "items": [
+            {
+                "id": {"videoId": "video-entities"},
+                "snippet": {
+                    "title": "Don&#39;t Panic &amp; Rank Better",
+                    "description": "Use BM25 &amp; TF-IDF, don&#39;t overfit.",
+                },
+            }
+        ]
+    }
+    _patch_async_client(monkeypatch, _transport(payload))
+
+    results = await YouTubeChannel(api_key="test-key").search(
+        SubQuery(text="bm25 entities", rationale="Need unescape coverage")
+    )
+
+    assert results[0].title == "Don't Panic & Rank Better"
+    assert results[0].snippet == "Use BM25 & TF-IDF, don't overfit."
+
+
+@pytest.mark.asyncio
+async def test_snippet_truncated_to_500_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "items": [
+            {
+                "id": {"videoId": "video-long"},
+                "snippet": {
+                    "title": "Long description video",
+                    "description": "a" * 750,
+                },
+            }
+        ]
+    }
+    _patch_async_client(monkeypatch, _transport(payload))
+
+    results = await YouTubeChannel(api_key="test-key").search(
+        SubQuery(text="long description", rationale="Need truncation coverage")
+    )
+
+    assert results[0].snippet is not None
+    assert len(results[0].snippet) == 500
+    assert results[0].snippet == "a" * 500
+
+
+@pytest.mark.asyncio
+async def test_network_error_returns_empty_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(respond))
+    monkeypatch.setattr(youtube_module, "LOGGER", logger)
+
+    results = await YouTubeChannel(api_key="test-key").search(
+        SubQuery(text="bm25 tutorial", rationale="Need videos")
+    )
+
+    assert results == []
+    assert logger.events == [
+        (
+            "youtube_search_failed",
+            {"channel": "youtube", "reason": "boom"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_empty_items_returns_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Logger()
+    _patch_async_client(monkeypatch, _transport({"items": []}))
+    monkeypatch.setattr(youtube_module, "LOGGER", logger)
+
+    results = await YouTubeChannel(api_key="test-key").search(
+        SubQuery(text="no videos", rationale="Need empty search coverage")
+    )
+
+    assert results == []
+    assert logger.events == []


### PR DESCRIPTION
## Summary

F005 Wave 1.3 — video tutorial / conference talk / demo source. Uses YouTube Data API v3 with YOUTUBE_API_KEY.

- `autosearch/channels/youtube.py` — `YouTubeChannel` using `httpx.AsyncClient` against `https://www.googleapis.com/youtube/v3/search`. **API key sent via `x-goog-api-key` header, never as URL query param** (same security lesson as gemini provider — prevents key leak into logs).
- Missing-key graceful handling: returns `[]` + single structlog warn (no log spam on repeated calls)
- Registered in `cli/main.py`, `mcp/server.py`, `server/main.py`: `channels=[DemoChannel(), DDGSChannel(), ArxivChannel(), YouTubeChannel()]`
- `tests/unit/test_youtube_channel.py` — 8 cases including:
  - `test_api_key_in_header_not_url` — asserts request URL contains no `key=`, headers contain `x-goog-api-key`
  - `test_api_key_value_not_in_logs_on_error` — sentinel key not in any structlog output on error
  - `test_search_without_api_key_returns_empty_and_warns_once` — warn-once semantics
  - html entity unescape + snippet truncation + empty/network-error paths
- `tests/fixtures/youtube_response.json` — 3-item fixture
- `tests/e2b/matrix.yaml` — `F013_channel_youtube_smoke` asserting `youtube` in sources + `youtube.com/watch` URL in report

## Validation

- **8/8 YouTube tests pass**
- **174 passed, 17 deselected** full suite (+8 from main 166; delta reflects main-branch state, not the ghost hackernews sync that Codex accidentally pulled in and Claude cleaned out before commit)
- ruff check + format clean

## Security design (header-only auth)

API key used exclusively in `headers={"x-goog-api-key": self.api_key}`. URL built only with `params={"part":..., "q":..., "type":..., "maxResults":...}`. This matches the gemini provider hardening (PR #113).

## Post-merge sibling expectation

PR #125 (hackernews) is still open in parallel. The two don't conflict — both append to the same 3 `channels=[...]` lists but in separate positions. Whichever merges first, the second will rebase cleanly by re-applying the `channels.append(...)` equivalent edit. If GitHub flags a conflict, it's a trivial merge.

## Dependencies

- ✅ F002c (youtube SKILL.md metadata)
- ✅ F005 arxiv (pattern reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)