### PR TITLE
feat(channels): add reddit + stackoverflow channels (F201 Wave C part 1)

### DIFF
--- a/skills/channels/reddit/SKILL.md
+++ b/skills/channels/reddit/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: reddit
+description: Reddit community discussions, user experience reports, and topic debates via the public search.json endpoint.
+version: 1
+languages: [en, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 300}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [community-opinion, experience-report, troubleshooting, debate]
+  domain_hints: [software, tech, product, consumer]
+quality_hint:
+  typical_yield: medium
+  chinese_native: false
+---
+
+## Overview
+
+Reddit adds public community discussion, user experience reports, troubleshooting threads, and debate-oriented evidence through the unauthenticated `search.json` endpoint. It is useful when the query needs candid practitioner commentary or consumer sentiment that is less polished than docs, vendor content, or editorial articles.
+
+## Known Quirks
+
+- Reddit blocks default client signatures, so requests must set a non-empty custom User-Agent.
+- The public endpoint is relatively open, but this channel keeps a conservative rate limit to stay polite.
+- The unauthenticated search API supports broad search well enough for this use case, but it does not provide reliable time-range filtering.

--- a/skills/channels/reddit/methods/api_search.py
+++ b/skills/channels/reddit/methods/api_search.py
@@ -1,0 +1,120 @@
+# Self-written for task F201
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="reddit")
+
+MAX_RESULTS = 10
+HTTP_TIMEOUT = 15.0
+MAX_SNIPPET_LENGTH = 300
+BASE_URL = "https://www.reddit.com/search.json"
+USER_AGENT = "autosearch/1.0 (+https://github.com/0xmariowu/autosearch)"
+
+
+def _truncate_on_word_boundary(text: str, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _resolve_url(post: Mapping[str, object]) -> str | None:
+    if bool(post.get("is_self")):
+        permalink = str(post.get("permalink") or "").strip()
+        if not permalink:
+            return None
+        return f"https://www.reddit.com{permalink}"
+
+    url = str(post.get("url") or "").strip()
+    return url or None
+
+
+def _to_evidence(post: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    url = _resolve_url(post)
+    if not url:
+        return None
+
+    selftext = str(post.get("selftext") or "").strip()
+    subreddit = str(post.get("subreddit") or "").strip()
+    snippet = _truncate_on_word_boundary(selftext, MAX_SNIPPET_LENGTH) or None
+    source_channel = f"reddit:r/{subreddit}" if subreddit else "reddit"
+
+    return Evidence(
+        url=url,
+        title=str(post.get("title") or "").strip(),
+        snippet=snippet,
+        content=selftext or snippet,
+        source_channel=source_channel,
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    try:
+        if http_client is not None:
+            response = await http_client.get(
+                BASE_URL,
+                params={
+                    "q": query.text,
+                    "limit": MAX_RESULTS,
+                    "raw_json": 1,
+                },
+                headers={"User-Agent": USER_AGENT},
+            )
+        else:
+            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+                response = await client.get(
+                    BASE_URL,
+                    params={
+                        "q": query.text,
+                        "limit": MAX_RESULTS,
+                        "raw_json": 1,
+                    },
+                    headers={"User-Agent": USER_AGENT},
+                )
+
+        response.raise_for_status()
+        payload = response.json()
+        data = payload.get("data")
+        if not isinstance(data, Mapping):
+            raise ValueError("invalid data payload")
+
+        children = data.get("children")
+        if not isinstance(children, list):
+            raise ValueError("invalid children payload")
+    except Exception as exc:
+        LOGGER.warning("reddit_search_failed", reason=str(exc))
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for child in children:
+        if not isinstance(child, Mapping):
+            continue
+
+        post = child.get("data")
+        if not isinstance(post, Mapping):
+            continue
+
+        evidence = _to_evidence(post, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/skills/channels/stackoverflow/SKILL.md
+++ b/skills/channels/stackoverflow/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: stackoverflow
+description: Programming Q&A with community-voted answers across 200+ technical tags via api.stackexchange.com.
+version: 1
+languages: [en, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 10, per_hour: 300}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [programming-error, how-to, api-usage, technical-reference]
+  domain_hints: [software, programming, devops]
+quality_hint:
+  typical_yield: high
+  chinese_native: false
+---
+
+## Overview
+
+Stack Overflow provides high-signal programming Q&A, code-level troubleshooting, API usage guidance, and technical reference material via the public Stack Exchange API. It is especially valuable when the query is about concrete errors, implementation details, or how practitioners resolved a specific development problem in production code.
+
+## Known Quirks
+
+- Unauthenticated requests are limited to roughly 300 requests per day per IP, so this channel uses a conservative rate limit.
+- The request must include `filter=withbody` or the API omits `body_markdown`, which makes evidence snippets much less useful.
+- Because unauthenticated quota is IP-scoped, parallel E2B or shared-runner executions can collide even when one local run is well behaved.

--- a/skills/channels/stackoverflow/methods/api_search.py
+++ b/skills/channels/stackoverflow/methods/api_search.py
@@ -1,0 +1,114 @@
+# Self-written for task F201
+import html
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="stackoverflow")
+
+MAX_RESULTS = 10
+HTTP_TIMEOUT = 15.0
+MAX_SNIPPET_LENGTH = 300
+BASE_URL = "https://api.stackexchange.com/2.3/search/advanced"
+
+
+def _truncate_on_word_boundary(text: str, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _source_channel(tags: object) -> str:
+    if not isinstance(tags, list):
+        return "stackoverflow"
+
+    normalized_tags = [str(tag).strip() for tag in tags if str(tag).strip()]
+    if not normalized_tags:
+        return "stackoverflow"
+
+    return f"stackoverflow:{','.join(normalized_tags[:3])}"
+
+
+def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    url = str(item.get("link") or "").strip()
+    if not url:
+        return None
+
+    body_markdown = str(item.get("body_markdown") or "").strip()
+    snippet = _truncate_on_word_boundary(body_markdown, MAX_SNIPPET_LENGTH) or None
+
+    return Evidence(
+        url=url,
+        title=html.unescape(str(item.get("title") or "").strip()),
+        snippet=snippet,
+        content=body_markdown or snippet,
+        source_channel=_source_channel(item.get("tags")),
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    try:
+        if http_client is not None:
+            response = await http_client.get(
+                BASE_URL,
+                params={
+                    "q": query.text,
+                    "site": "stackoverflow",
+                    "pagesize": MAX_RESULTS,
+                    "order": "desc",
+                    "sort": "relevance",
+                    "filter": "withbody",
+                },
+            )
+        else:
+            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+                response = await client.get(
+                    BASE_URL,
+                    params={
+                        "q": query.text,
+                        "site": "stackoverflow",
+                        "pagesize": MAX_RESULTS,
+                        "order": "desc",
+                        "sort": "relevance",
+                        "filter": "withbody",
+                    },
+                )
+
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("items")
+        if not isinstance(items, list):
+            raise ValueError("invalid items payload")
+    except Exception as exc:
+        LOGGER.warning("stackoverflow_search_failed", reason=str(exc))
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+
+        evidence = _to_evidence(item, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/tests/channels/__init__.py
+++ b/tests/channels/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F201

--- a/tests/channels/reddit/__init__.py
+++ b/tests/channels/reddit/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F201

--- a/tests/channels/reddit/test_api_search.py
+++ b/tests/channels/reddit/test_api_search.py
@@ -1,0 +1,230 @@
+# Self-written for task F201
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "reddit"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_reddit_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="httpx retries", rationale="Need Reddit discussion coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_maps_reddit_response_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["q"] == "httpx retries"
+        assert request.url.params["limit"] == "10"
+        assert request.url.params["raw_json"] == "1"
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "children": [
+                        {
+                            "kind": "t3",
+                            "data": {
+                                "title": "Self post title",
+                                "selftext": "This is a text post with details.",
+                                "url": "https://example.com/ignored",
+                                "permalink": "/r/python/comments/abc123/self_post_title/",
+                                "subreddit": "python",
+                                "is_self": True,
+                            },
+                        },
+                        {
+                            "kind": "t3",
+                            "data": {
+                                "title": "Link post title",
+                                "selftext": "",
+                                "url": "https://example.com/post",
+                                "permalink": "/r/programming/comments/def456/link_post_title/",
+                                "subreddit": "programming",
+                                "is_self": False,
+                            },
+                        },
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://www.reddit.com/r/python/comments/abc123/self_post_title/"
+    assert first.title == "Self post title"
+    assert first.snippet == "This is a text post with details."
+    assert first.content == "This is a text post with details."
+    assert first.source_channel == "reddit:r/python"
+
+    second = results[1]
+    assert second.url == "https://example.com/post"
+    assert second.title == "Link post title"
+    assert second.snippet is None
+    assert second.content is None
+    assert second.source_channel == "reddit:r/programming"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_entries_without_resolvable_url() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "children": [
+                        {
+                            "kind": "t3",
+                            "data": {
+                                "title": "Broken self post",
+                                "selftext": "No permalink here.",
+                                "url": "",
+                                "permalink": "",
+                                "subreddit": "python",
+                                "is_self": True,
+                            },
+                        }
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_sets_user_agent_header() -> None:
+    captured: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["user_agent"] = request.headers.get("user-agent", "")
+        return httpx.Response(200, json={"data": {"children": []}}, request=request)
+
+    async with _client(handler) as http_client:
+        await search(_query(), http_client=http_client)
+
+    assert "autosearch/" in captured["user_agent"]
+    assert captured["user_agent"] != ""
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, json={"message": "slow down"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "reddit_search_failed"
+    assert "429" in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {}}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events == [
+        (
+            "reddit_search_failed",
+            {"reason": "invalid children payload"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_truncates_snippet_on_word_boundary() -> None:
+    long_selftext = ("word " * 59) + "splitpoint continues after the limit"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "children": [
+                        {
+                            "kind": "t3",
+                            "data": {
+                                "title": "Long post",
+                                "selftext": long_selftext,
+                                "url": "https://example.com/ignored",
+                                "permalink": "/r/python/comments/ghi789/long_post/",
+                                "subreddit": "python",
+                                "is_self": True,
+                            },
+                        }
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].snippet == f"{('word ' * 59).strip()}…"
+    assert results[0].snippet is not None
+    assert results[0].snippet.endswith("…")

--- a/tests/channels/stackoverflow/__init__.py
+++ b/tests/channels/stackoverflow/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F201

--- a/tests/channels/stackoverflow/test_api_search.py
+++ b/tests/channels/stackoverflow/test_api_search.py
@@ -1,0 +1,199 @@
+# Self-written for task F201
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "stackoverflow"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_stackoverflow_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="httpx retry middleware", rationale="Need Stack Overflow coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_maps_stackoverflow_response_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "title": "How to retry with httpx?",
+                        "link": "https://stackoverflow.com/questions/123/example",
+                        "tags": ["python", "async", "httpx", "retry"],
+                        "body_markdown": "Use a transport wrapper around the client.",
+                    },
+                    {
+                        "title": "Another question",
+                        "link": "https://stackoverflow.com/questions/456/example",
+                        "tags": ["pytest"],
+                        "body_markdown": "Patch the client or inject a fake transport.",
+                    },
+                ],
+                "quota_remaining": 299,
+                "quota_max": 300,
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://stackoverflow.com/questions/123/example"
+    assert first.title == "How to retry with httpx?"
+    assert first.snippet == "Use a transport wrapper around the client."
+    assert first.content == "Use a transport wrapper around the client."
+    assert first.source_channel == "stackoverflow:python,async,httpx"
+
+    second = results[1]
+    assert second.url == "https://stackoverflow.com/questions/456/example"
+    assert second.title == "Another question"
+    assert second.snippet == "Patch the client or inject a fake transport."
+    assert second.content == "Patch the client or inject a fake transport."
+    assert second.source_channel == "stackoverflow:pytest"
+
+
+@pytest.mark.asyncio
+async def test_search_request_includes_filter_withbody() -> None:
+    captured: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["filter"] = request.url.params.get("filter", "")
+        return httpx.Response(200, json={"items": []}, request=request)
+
+    async with _client(handler) as http_client:
+        await search(_query(), http_client=http_client)
+
+    assert captured["filter"] == "withbody"
+
+
+@pytest.mark.asyncio
+async def test_search_handles_item_without_tags() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "title": "No tags here",
+                        "link": "https://stackoverflow.com/questions/789/example",
+                        "tags": [],
+                        "body_markdown": "Still a valid question body.",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].source_channel == "stackoverflow"
+
+
+@pytest.mark.asyncio
+async def test_search_decodes_html_entities_in_title() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "title": "How to use &quot;httpx&quot; retries?",
+                        "link": "https://stackoverflow.com/questions/321/example",
+                        "tags": ["python"],
+                        "body_markdown": "Wrap the request execution in retry logic.",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].title == 'How to use "httpx" retries?'
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, json={"error": "bad gateway"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "stackoverflow_search_failed"
+    assert "502" in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events == [
+        (
+            "stackoverflow_search_failed",
+            {"reason": "invalid items payload"},
+        )
+    ]

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -13,10 +13,10 @@ def _load_specs():
     return load_all(_channels_root())
 
 
-def test_all_12_channels_loadable() -> None:
+def test_all_14_channels_loadable() -> None:
     specs = _load_specs()
 
-    assert len(specs) == 12
+    assert len(specs) == 14
     assert [spec.name for spec in specs] == [
         "arxiv",
         "bilibili",
@@ -25,6 +25,8 @@ def test_all_12_channels_loadable() -> None:
         "github",
         "hackernews",
         "papers",
+        "reddit",
+        "stackoverflow",
         "twitter",
         "weibo",
         "xiaohongshu",
@@ -76,6 +78,8 @@ def test_shipped_method_impls_exist_for_registry_channels() -> None:
         "ddgs": ["methods/api.py"],
         "hackernews": ["methods/algolia.py"],
         "papers": ["methods/via_paper_search.py"],
+        "reddit": ["methods/api_search.py"],
+        "stackoverflow": ["methods/api_search.py"],
         "zhihu": ["methods/via_tikhub.py"],
         "youtube": ["methods/data_api_v3.py"],
     }
@@ -95,6 +99,8 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         "ddgs",
         "hackernews",
         "papers",
+        "reddit",
+        "stackoverflow",
     ]
     for spec in _load_specs():
         metadata = registry.metadata(spec.name)
@@ -103,6 +109,8 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             "ddgs": "methods/api.py",
             "hackernews": "methods/algolia.py",
             "papers": "methods/via_paper_search.py",
+            "reddit": "methods/api_search.py",
+            "stackoverflow": "methods/api_search.py",
         }
         if spec.name in expected_impls:
             assert len(metadata.methods) == 1


### PR DESCRIPTION
## Summary

Plan F201 Wave C (first batch). Two free English channels — no API keys needed.

| Channel | Endpoint | Cost | Quality signal |
|---|---|---|---|
| reddit | `reddit.com/search.json?q=...&raw_json=1` | free, polite 30/min | community opinions, experience reports |
| stackoverflow | `api.stackexchange.com/2.3/search/advanced?filter=withbody&...` | free, 300/day per IP | programming Q&A with community-voted answers |

## Commits

1. `feat(channels)` reddit — SKILL.md + methods/api_search.py (120 LOC). Sets required `User-Agent: autosearch/1.0 ...` to avoid Reddit's default-UA 429. URL resolution: self posts → `www.reddit.com{permalink}`; link posts → external `url`. source_channel tagged `reddit:r/{subreddit}`.
2. `test(channels)` reddit — 6 mock-based cases covering URL resolution, UA header assertion, 429 graceful fallback, malformed payload, snippet word-boundary truncation.
3. `feat(channels)` stackoverflow — SKILL.md + methods/api_search.py (114 LOC). Uses `filter=withbody` for answer body; `html.unescape` for title entities. source_channel tagged `stackoverflow:python,async` (top 3 tags).
4. `test(channels+unit)` stackoverflow + scaffold — 6 mock cases + registry scaffold assertions for both new channels.

## Package markers

Added `tests/channels/__init__.py` + `tests/channels/{reddit,stackoverflow}/__init__.py` to prevent pytest collection collision between two `test_api_search.py` files in sibling channel dirs.

## Test plan

- [x] 205 tests pass (193 + 12 new — 6 reddit + 6 stackoverflow)
- [x] `ruff check` + `ruff format --check` clean
- [x] No new runtime deps
- [x] Pre-push hook pass (~2s regression)
- [ ] Live smoke (deferred to post-merge)

## Wave C remaining

- `github-untoken` (`api.github.com/search/repositories`, 10/min no token)
- `package_search` (pypi + npm combined)
- `dev.to` (`dev.to/api/articles`)

Next PR after this merges.