### PR TITLE
feat(channels): add package_search channel pypi+npm aggregator (F201 Wave C final)

### DIFF
--- a/skills/channels/package_search/SKILL.md
+++ b/skills/channels/package_search/SKILL.md
@@ -1,0 +1,29 @@
+# Self-written for task F201
+
+---
+name: package_search
+description: Discover packages across PyPI (exact-name lookup) and npm (full-text search) registries.
+version: 1
+languages: [en, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 20, per_hour: 300}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [library, package, sdk, dependency, installation]
+  domain_hints: [software, programming]
+quality_hint:
+  typical_yield: medium
+  chinese_native: false
+---
+
+`package_search` helps discover software packages across two public registries: PyPI for Python packages and npm for JavaScript and Node.js packages. It combines exact-name PyPI lookups with npm full-text search so package-related queries can still return useful evidence even when one registry has limited recall.
+
+## Known Quirks
+
+- PyPI has no official JSON search API, so this channel only does exact-name lookups against `/pypi/<name>/json`; multi-word queries are split into tokens and only the first 5 tokens are tried.
+- npm supports real full-text search through the public registry search endpoint and is the broader-recall half of this channel.
+- Descriptions are truncated to 300 characters for snippets, and PyPI README-sized `description` content is intentionally excluded in favor of the shorter `summary`.

--- a/skills/channels/package_search/methods/api_search.py
+++ b/skills/channels/package_search/methods/api_search.py
@@ -1,0 +1,261 @@
+# Self-written for task F201
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="package_search")
+
+NPM_SEARCH_URL = "https://registry.npmjs.org/-/v1/search"
+PYPI_JSON_URL = "https://pypi.org/pypi/{token}/json"
+USER_AGENT = "autosearch/1.0 (+https://github.com/0xmariowu/autosearch)"
+REQUEST_HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": USER_AGENT,
+}
+MAX_NPM_RESULTS = 10
+MAX_SNIPPET_LENGTH = 300
+PER_SOURCE_TIMEOUT_SECONDS = 5.0
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _tokenize_pypi_query(text: str, *, max_pypi_tokens: int) -> list[str]:
+    return text.split()[:max_pypi_tokens]
+
+
+def _to_pypi_evidence(payload: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    info = payload.get("info")
+    if not isinstance(info, Mapping):
+        raise ValueError("invalid PyPI info payload")
+
+    package_url = str(info.get("package_url") or "").strip()
+    home_page = str(info.get("home_page") or "").strip()
+    url = package_url or home_page
+    if not url:
+        return None
+
+    name = str(info.get("name") or "").strip()
+    version = str(info.get("version") or "").strip()
+    title = " ".join(part for part in (name, version) if part) or name or url
+    summary = str(info.get("summary") or "").strip()
+    snippet = _truncate_on_word_boundary(summary, max_length=MAX_SNIPPET_LENGTH) or None
+    content = summary or None
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=content,
+        source_channel="package_search:pypi",
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+def _to_npm_evidence(package: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    links = package.get("links")
+    link_map = links if isinstance(links, Mapping) else {}
+    npm_url = str(link_map.get("npm") or "").strip()
+    homepage = str(link_map.get("homepage") or "").strip()
+    url = npm_url or homepage
+    if not url:
+        return None
+
+    name = str(package.get("name") or "").strip()
+    version = str(package.get("version") or "").strip()
+    title = " ".join(part for part in (name, version) if part) or name or url
+    description = str(package.get("description") or "").strip()
+    snippet = _truncate_on_word_boundary(description, max_length=MAX_SNIPPET_LENGTH) or None
+    content = description or None
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=content,
+        source_channel="package_search:npm",
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+def _dedupe_by_url(evidences: list[Evidence]) -> list[Evidence]:
+    seen_urls: set[str] = set()
+    deduped: list[Evidence] = []
+
+    for evidence in evidences:
+        if evidence.url in seen_urls:
+            continue
+        seen_urls.add(evidence.url)
+        deduped.append(evidence)
+
+    return deduped
+
+
+async def _fetch_pypi_token(
+    client: httpx.AsyncClient,
+    token: str,
+    *,
+    fetched_at: datetime,
+) -> list[Evidence]:
+    response = await client.get(PYPI_JSON_URL.format(token=token), headers=REQUEST_HEADERS)
+    if response.status_code == 404:
+        return []
+
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid PyPI payload")
+
+    evidence = _to_pypi_evidence(payload, fetched_at=fetched_at)
+    return [evidence] if evidence is not None else []
+
+
+async def _fetch_npm_results(
+    client: httpx.AsyncClient,
+    query_text: str,
+    *,
+    fetched_at: datetime,
+) -> list[Evidence]:
+    response = await client.get(
+        NPM_SEARCH_URL,
+        params={"text": query_text, "size": MAX_NPM_RESULTS},
+        headers=REQUEST_HEADERS,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid npm payload")
+
+    objects = payload.get("objects")
+    if not isinstance(objects, list):
+        raise ValueError("invalid npm objects payload")
+
+    evidences: list[Evidence] = []
+    for item in objects:
+        if not isinstance(item, Mapping):
+            continue
+
+        package = item.get("package")
+        if not isinstance(package, Mapping):
+            continue
+
+        evidence = _to_npm_evidence(package, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences
+
+
+async def _run_pypi_source(
+    client: httpx.AsyncClient,
+    token: str,
+    *,
+    fetched_at: datetime,
+) -> list[Evidence]:
+    source = f"pypi:{token}"
+    try:
+        return await asyncio.wait_for(
+            _fetch_pypi_token(client, token, fetched_at=fetched_at),
+            timeout=PER_SOURCE_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        LOGGER.warning("package_search_source_failed", source=source, reason="timeout")
+        return []
+    except httpx.HTTPError as exc:
+        LOGGER.warning("package_search_source_failed", source=source, reason=str(exc))
+        return []
+    except Exception as exc:
+        LOGGER.warning("package_search_source_failed", source=source, reason=str(exc))
+        return []
+
+
+async def _run_npm_source(
+    client: httpx.AsyncClient,
+    query_text: str,
+    *,
+    fetched_at: datetime,
+) -> list[Evidence]:
+    try:
+        return await asyncio.wait_for(
+            _fetch_npm_results(client, query_text, fetched_at=fetched_at),
+            timeout=PER_SOURCE_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        LOGGER.warning("package_search_source_failed", source="npm", reason="timeout")
+        return []
+    except httpx.HTTPError as exc:
+        LOGGER.warning("package_search_source_failed", source="npm", reason=str(exc))
+        return []
+    except Exception as exc:
+        LOGGER.warning("package_search_source_failed", source="npm", reason=str(exc))
+        return []
+
+
+async def _search_with_client(
+    query: SubQuery,
+    *,
+    client: httpx.AsyncClient,
+    max_pypi_tokens: int,
+) -> list[Evidence]:
+    fetched_at = datetime.now(UTC)
+    pypi_tokens = _tokenize_pypi_query(query.text, max_pypi_tokens=max_pypi_tokens)
+    source_names = ["npm", *[f"pypi:{token}" for token in pypi_tokens]]
+    tasks = [
+        _run_npm_source(client, query.text, fetched_at=fetched_at),
+        *[_run_pypi_source(client, token, fetched_at=fetched_at) for token in pypi_tokens],
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    npm_results: list[Evidence] = []
+    pypi_results: list[Evidence] = []
+    for source, result in zip(source_names, results, strict=True):
+        if isinstance(result, Exception):
+            LOGGER.warning("package_search_source_failed", source=source, reason=str(result))
+            continue
+        if source == "npm":
+            npm_results.extend(result)
+            continue
+        pypi_results.extend(result)
+
+    return _dedupe_by_url([*npm_results, *pypi_results])
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    max_pypi_tokens: int = 5,
+) -> list[Evidence]:
+    if http_client is not None:
+        return await _search_with_client(
+            query,
+            client=http_client,
+            max_pypi_tokens=max_pypi_tokens,
+        )
+
+    async with httpx.AsyncClient(timeout=PER_SOURCE_TIMEOUT_SECONDS) as client:
+        return await _search_with_client(
+            query,
+            client=client,
+            max_pypi_tokens=max_pypi_tokens,
+        )

--- a/tests/channels/package_search/__init__.py
+++ b/tests/channels/package_search/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F201

--- a/tests/channels/package_search/test_api_search.py
+++ b/tests/channels/package_search/test_api_search.py
@@ -1,0 +1,274 @@
+# Self-written for task F201
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "package_search"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_package_search_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query(text: str) -> SubQuery:
+    return SubQuery(text=text, rationale="Need package registry coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_combines_npm_and_pypi_results() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["accept"] == "application/json"
+        assert request.headers["user-agent"] == MODULE.USER_AGENT
+
+        if request.url.host == "registry.npmjs.org":
+            assert request.url.params["text"] == "fastapi"
+            assert request.url.params["size"] == "10"
+            return httpx.Response(
+                200,
+                json={
+                    "total": 1,
+                    "objects": [
+                        {
+                            "package": {
+                                "name": "fastify",
+                                "description": "Fast and low overhead web framework, for Node.js",
+                                "version": "5.1.0",
+                                "links": {
+                                    "npm": "https://www.npmjs.com/package/fastify",
+                                },
+                            }
+                        }
+                    ],
+                },
+                request=request,
+            )
+
+        assert request.url.host == "pypi.org"
+        assert request.url.path == "/pypi/fastapi/json"
+        return httpx.Response(
+            200,
+            json={
+                "info": {
+                    "name": "fastapi",
+                    "summary": "FastAPI framework, high performance, easy to learn.",
+                    "package_url": "https://pypi.org/project/fastapi/",
+                    "version": "0.115.0",
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query("fastapi"), http_client=http_client)
+
+    assert [item.source_channel for item in results] == [
+        "package_search:npm",
+        "package_search:pypi",
+    ]
+    assert [item.title for item in results] == [
+        "fastify 5.1.0",
+        "fastapi 0.115.0",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pypi_single_token_exact_lookup_maps_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "registry.npmjs.org":
+            return httpx.Response(200, json={"total": 0, "objects": []}, request=request)
+
+        assert request.url.path == "/pypi/fastapi/json"
+        return httpx.Response(
+            200,
+            json={
+                "info": {
+                    "name": "fastapi",
+                    "summary": "FastAPI framework, high performance, easy to learn.",
+                    "home_page": "https://github.com/fastapi/fastapi",
+                    "package_url": "https://pypi.org/project/fastapi/",
+                    "version": "0.115.0",
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query("fastapi"), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://pypi.org/project/fastapi/"
+    assert results[0].title == "fastapi 0.115.0"
+    assert results[0].snippet == "FastAPI framework, high performance, easy to learn."
+    assert results[0].content == "FastAPI framework, high performance, easy to learn."
+    assert results[0].source_channel == "package_search:pypi"
+
+
+@pytest.mark.asyncio
+async def test_pypi_404_is_silent_no_warning_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "registry.npmjs.org":
+            return httpx.Response(200, json={"total": 0, "objects": []}, request=request)
+
+        return httpx.Response(404, json={"message": "Not Found"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query("missingpkg"), http_client=http_client)
+
+    assert results == []
+    assert logger.events == []
+
+
+@pytest.mark.asyncio
+async def test_pypi_splits_multi_word_query_into_tokens() -> None:
+    requested_tokens: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "registry.npmjs.org":
+            return httpx.Response(200, json={"total": 0, "objects": []}, request=request)
+
+        requested_tokens.append(request.url.path.split("/")[2])
+        return httpx.Response(404, json={"message": "Not Found"}, request=request)
+
+    async with _client(handler) as http_client:
+        await search(_query("llm agent framework"), http_client=http_client)
+
+    assert sorted(requested_tokens) == ["agent", "framework", "llm"]
+
+
+@pytest.mark.asyncio
+async def test_pypi_caps_at_max_pypi_tokens() -> None:
+    requested_tokens: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "registry.npmjs.org":
+            return httpx.Response(200, json={"total": 0, "objects": []}, request=request)
+
+        requested_tokens.append(request.url.path.split("/")[2])
+        return httpx.Response(404, json={"message": "Not Found"}, request=request)
+
+    async with _client(handler) as http_client:
+        await search(
+            _query("one two three four five six seven eight nine ten"),
+            http_client=http_client,
+            max_pypi_tokens=5,
+        )
+
+    assert sorted(requested_tokens) == ["five", "four", "one", "three", "two"]
+
+
+@pytest.mark.asyncio
+async def test_npm_maps_objects_list_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "registry.npmjs.org":
+            return httpx.Response(
+                200,
+                json={
+                    "total": 2,
+                    "objects": [
+                        {
+                            "package": {
+                                "name": "express",
+                                "description": "Fast, unopinionated, minimalist web framework",
+                                "version": "4.21.2",
+                                "links": {
+                                    "npm": "https://www.npmjs.com/package/express",
+                                },
+                            }
+                        },
+                        {
+                            "package": {
+                                "name": "vite",
+                                "description": "Next generation frontend tooling",
+                                "version": "5.4.0",
+                                "links": {
+                                    "npm": "https://www.npmjs.com/package/vite",
+                                },
+                            }
+                        },
+                    ],
+                },
+                request=request,
+            )
+
+        return httpx.Response(404, json={"message": "Not Found"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query("frontend tooling"), http_client=http_client)
+
+    assert len(results) == 2
+    assert [item.url for item in results] == [
+        "https://www.npmjs.com/package/express",
+        "https://www.npmjs.com/package/vite",
+    ]
+    assert [item.title for item in results] == [
+        "express 4.21.2",
+        "vite 5.4.0",
+    ]
+    assert [item.source_channel for item in results] == [
+        "package_search:npm",
+        "package_search:npm",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_both_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"message": "server error"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query("fastapi"), http_client=http_client)
+
+    assert results == []
+    assert len(logger.events) == 2
+    assert {event for event, _ in logger.events} == {"package_search_source_failed"}
+
+    reasons_by_source = {
+        str(kwargs["source"]): str(kwargs["reason"]) for _, kwargs in logger.events
+    }
+    assert set(reasons_by_source) == {"npm", "pypi:fastapi"}
+    assert "500" in reasons_by_source["npm"]
+    assert "500" in reasons_by_source["pypi:fastapi"]

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -13,10 +13,10 @@ def _load_specs():
     return load_all(_channels_root())
 
 
-def test_all_15_channels_loadable() -> None:
+def test_all_16_channels_loadable() -> None:
     specs = _load_specs()
 
-    assert len(specs) == 15
+    assert len(specs) == 16
     assert [spec.name for spec in specs] == [
         "arxiv",
         "bilibili",
@@ -25,6 +25,7 @@ def test_all_15_channels_loadable() -> None:
         "douyin",
         "github",
         "hackernews",
+        "package_search",
         "papers",
         "reddit",
         "stackoverflow",
@@ -80,6 +81,7 @@ def test_shipped_method_impls_exist_for_registry_channels() -> None:
         "devto": ["methods/api_search.py"],
         "github": ["methods/search_public_repos.py"],
         "hackernews": ["methods/algolia.py"],
+        "package_search": ["methods/api_search.py"],
         "papers": ["methods/via_paper_search.py"],
         "reddit": ["methods/api_search.py"],
         "stackoverflow": ["methods/api_search.py"],
@@ -103,6 +105,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         "devto",
         "github",
         "hackernews",
+        "package_search",
         "papers",
         "reddit",
         "stackoverflow",
@@ -114,6 +117,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             "ddgs": "methods/api.py",
             "devto": "methods/api_search.py",
             "hackernews": "methods/algolia.py",
+            "package_search": "methods/api_search.py",
             "papers": "methods/via_paper_search.py",
             "reddit": "methods/api_search.py",
             "stackoverflow": "methods/api_search.py",


### PR DESCRIPTION
## Summary

Last piece of Wave C — one channel aggregates two package registries.

| Registry | Mode | Why |
|---|---|---|
| npm | Full-text search via `registry.npmjs.org/-/v1/search?text=<q>&size=10` | Official search API, clean JSON |
| PyPI | **Exact-name lookup** via `pypi.org/pypi/<pkg>/json` | PyPI has no true search API — verified live (`/search/?q=` returns HTML, `/simple/` has no query filter) |

For multi-word queries, PyPI side splits by space and tries each token as an exact package name (capped at 5 tokens). Yes this is limited — documented as the known quirk in SKILL.md.

## Commits (3)

1. `feat(channels)` — SKILL.md + `methods/api_search.py`. Concurrent fan-out via `asyncio.gather(return_exceptions=True)`. Per-source 5s timeout. npm first (interleave), then pypi. Dedupe by URL.
2. `test(channels)` — 7 cases: combined maps, pypi single/multi-token, 404-silent semantics, cap on `max_pypi_tokens`, npm mapping, both-failed warning logging.
3. `test(unit)` — scaffold registry + alphabetical available list.

## Design decision: 404-silent

PyPI 404 on unknown package is *normal* (most query tokens aren't valid package names). Logging warn would spam logs. So 404 is handled silently (empty result, no logger event). Other errors (500s, timeouts, network) still warn via `package_search_source_failed`.

## Test plan

- [x] 223 tests pass (216 prior + 7 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] Descriptions truncated to 300 chars (pypi's long README explicitly excluded via `info.summary` over `info.description`)

## After merge

Wave C **done** — 10 shipped channels + demo. Wave D coming next: wikipedia, wikidata, google_trends, google_news.