### PR TITLE
feat(channels): add wikipedia + wikidata channels (F202 Wave D part 1)

### DIFF
--- a/skills/channels/wikidata/SKILL.md
+++ b/skills/channels/wikidata/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: wikidata
+description: Structured entity data (people, places, concepts) from Wikidata knowledge graph.
+version: 1
+languages: [en, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 60, per_hour: 2000}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [entity-definition, disambiguation, structured-facts]
+  domain_hints: [science, history, culture, people, places]
+quality_hint:
+  typical_yield: medium
+  chinese_native: false
+---
+
+## Overview
+
+Wikidata provides authoritative structured entity descriptions for people, places, organizations, scientific concepts, and other knowledge-graph items through the public Wikidata Action API. It is useful when the query needs compact entity definitions, disambiguation, or canonical identifiers rather than long-form narrative content.
+
+## Known Quirks
+
+- Results expose short entity descriptions, not long-form article content.
+- `language=en` is hardcoded in v1.
+- `type=item` intentionally filters out lexemes and properties.

--- a/skills/channels/wikidata/methods/api_search.py
+++ b/skills/channels/wikidata/methods/api_search.py
@@ -1,0 +1,84 @@
+# Self-written for task F202
+import html
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="wikidata")
+
+MAX_RESULTS = 10
+HTTP_TIMEOUT = 15.0
+BASE_URL = "https://www.wikidata.org/w/api.php"
+USER_AGENT = "autosearch/1.0 (+https://github.com/0xmariowu/autosearch; mario@miao.company)"
+
+
+def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    entity_id = str(item.get("id") or "").strip()
+    concepturi = str(item.get("concepturi") or "").strip()
+    url = concepturi or (f"https://www.wikidata.org/wiki/{entity_id}" if entity_id else "")
+    if not url:
+        return None
+
+    title = html.unescape(str(item.get("label") or entity_id or concepturi).strip())
+    description = html.unescape(str(item.get("description") or "").strip()) or None
+    source_channel = f"wikidata:{entity_id}" if entity_id else "wikidata"
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=description,
+        content=description,
+        source_channel=source_channel,
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    params = {
+        "action": "wbsearchentities",
+        "search": query.text,
+        "language": "en",
+        "format": "json",
+        "limit": MAX_RESULTS,
+        "type": "item",
+    }
+    try:
+        if http_client is not None:
+            response = await http_client.get(BASE_URL, params=params, headers=headers)
+        else:
+            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+                response = await client.get(BASE_URL, params=params, headers=headers)
+
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("search")
+        if not isinstance(items, list):
+            raise ValueError("invalid search payload")
+    except Exception as exc:
+        LOGGER.warning("wikidata_search_failed", reason=str(exc))
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+
+        evidence = _to_evidence(item, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/skills/channels/wikipedia/SKILL.md
+++ b/skills/channels/wikipedia/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: wikipedia
+description: Authoritative encyclopedia articles via the Wikipedia Action API (English edition).
+version: 1
+languages: [en, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 60, per_hour: 2000}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [definition, background, factual-overview, historical]
+  domain_hints: [science, history, culture, general-knowledge]
+quality_hint:
+  typical_yield: high
+  chinese_native: false
+---
+
+## Overview
+
+Wikipedia provides authoritative encyclopedia-style background, definitions, factual overviews, and historical context through the English Wikipedia Action API. It is useful when the query needs broad, neutral summary coverage across science, history, culture, and general-knowledge topics before drilling into more specialized sources.
+
+## Known Quirks
+
+- English Wikipedia only in v1; Chinese Wikipedia support is a future follow-up.
+- Search results only expose list-API snippets, not full article bodies.
+- Requests must include a policy-compliant User-Agent with contact information per Wikimedia requirements.

--- a/skills/channels/wikipedia/methods/api_search.py
+++ b/skills/channels/wikipedia/methods/api_search.py
@@ -1,0 +1,109 @@
+# Self-written for task F202
+import html
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="wikipedia")
+
+MAX_RESULTS = 10
+HTTP_TIMEOUT = 15.0
+MAX_SNIPPET_LENGTH = 300
+BASE_URL = "https://en.wikipedia.org/w/api.php"
+USER_AGENT = "autosearch/1.0 (+https://github.com/0xmariowu/autosearch; mario@miao.company)"
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _truncate_on_word_boundary(text: str, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _clean_snippet(snippet: object) -> str | None:
+    cleaned = TAG_RE.sub("", str(snippet or "")).strip()
+    cleaned = html.unescape(cleaned)
+    if not cleaned:
+        return None
+    return _truncate_on_word_boundary(cleaned, MAX_SNIPPET_LENGTH) or None
+
+
+def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    pageid = item.get("pageid")
+    if pageid in (None, ""):
+        return None
+
+    snippet = _clean_snippet(item.get("snippet"))
+
+    return Evidence(
+        url=f"https://en.wikipedia.org/?curid={pageid}",
+        title=html.unescape(str(item.get("title") or "").strip()),
+        snippet=snippet,
+        content=snippet,
+        source_channel="wikipedia:en",
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    params = {
+        "action": "query",
+        "list": "search",
+        "srsearch": query.text,
+        "format": "json",
+        "srlimit": MAX_RESULTS,
+        "srprop": "snippet",
+    }
+    try:
+        if http_client is not None:
+            response = await http_client.get(BASE_URL, params=params, headers=headers)
+        else:
+            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+                response = await client.get(BASE_URL, params=params, headers=headers)
+
+        response.raise_for_status()
+        payload = response.json()
+        query_payload = payload.get("query")
+        if not isinstance(query_payload, Mapping):
+            raise ValueError("invalid query payload")
+
+        items = query_payload.get("search")
+        if not isinstance(items, list):
+            raise ValueError("invalid search payload")
+    except Exception as exc:
+        LOGGER.warning("wikipedia_search_failed", reason=str(exc))
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+
+        evidence = _to_evidence(item, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/tests/channels/wikidata/__init__.py
+++ b/tests/channels/wikidata/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F202

--- a/tests/channels/wikidata/test_api_search.py
+++ b/tests/channels/wikidata/test_api_search.py
@@ -1,0 +1,222 @@
+# Self-written for task F202
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "wikidata"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_wikidata_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="python", rationale="Need entity definitions")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_maps_wikidata_response_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["action"] == "wbsearchentities"
+        assert request.url.params["search"] == "python"
+        assert request.url.params["language"] == "en"
+        assert request.url.params["limit"] == "10"
+        assert request.url.params["type"] == "item"
+        return httpx.Response(
+            200,
+            json={
+                "search": [
+                    {
+                        "id": "Q2283",
+                        "label": "Python",
+                        "description": "general-purpose programming language",
+                        "concepturi": "http://www.wikidata.org/entity/Q2283",
+                    },
+                    {
+                        "id": "Q7477",
+                        "label": "Monty Python",
+                        "description": "British surreal comedy group",
+                        "concepturi": "http://www.wikidata.org/entity/Q7477",
+                    },
+                ],
+                "success": 1,
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "http://www.wikidata.org/entity/Q2283"
+    assert first.title == "Python"
+    assert first.snippet == "general-purpose programming language"
+    assert first.content == "general-purpose programming language"
+    assert first.source_channel == "wikidata:Q2283"
+
+    second = results[1]
+    assert second.url == "http://www.wikidata.org/entity/Q7477"
+    assert second.title == "Monty Python"
+    assert second.snippet == "British surreal comedy group"
+    assert second.source_channel == "wikidata:Q7477"
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_q_id_url_when_concepturi_missing() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "search": [
+                    {
+                        "id": "Q2283",
+                        "label": "Python",
+                        "description": "general-purpose programming language",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://www.wikidata.org/wiki/Q2283"
+
+
+@pytest.mark.asyncio
+async def test_search_uses_label_as_title_fallback_to_id() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "search": [
+                    {
+                        "id": "Q2283",
+                        "description": "general-purpose programming language",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].title == "Q2283"
+
+
+@pytest.mark.asyncio
+async def test_search_handles_entity_without_description() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "search": [
+                    {
+                        "id": "Q2283",
+                        "label": "Python",
+                        "concepturi": "http://www.wikidata.org/entity/Q2283",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].snippet is None
+    assert results[0].content is None
+
+
+@pytest.mark.asyncio
+async def test_search_sends_user_agent_with_contact_info() -> None:
+    captured: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["user_agent"] = request.headers.get("user-agent", "")
+        captured["accept"] = request.headers.get("accept", "")
+        return httpx.Response(200, json={"search": []}, request=request)
+
+    async with _client(handler) as http_client:
+        await search(_query(), http_client=http_client)
+
+    assert "autosearch/" in captured["user_agent"]
+    assert "@" in captured["user_agent"] or "http" in captured["user_agent"]
+    assert captured["accept"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "wikidata_search_failed"
+    assert "500" in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"success": 1}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events == [("wikidata_search_failed", {"reason": "invalid search payload"})]

--- a/tests/channels/wikipedia/__init__.py
+++ b/tests/channels/wikipedia/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F202

--- a/tests/channels/wikipedia/test_api_search.py
+++ b/tests/channels/wikipedia/test_api_search.py
@@ -1,0 +1,229 @@
+# Self-written for task F202
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "wikipedia"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_wikipedia_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="large language model", rationale="Need encyclopedia coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_maps_wikipedia_response_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["action"] == "query"
+        assert request.url.params["list"] == "search"
+        assert request.url.params["srsearch"] == "large language model"
+        assert request.url.params["srlimit"] == "10"
+        assert request.url.params["srprop"] == "snippet"
+        return httpx.Response(
+            200,
+            json={
+                "query": {
+                    "search": [
+                        {
+                            "title": "Large language model &amp; AI",
+                            "snippet": (
+                                'A <span class="searchmatch">large language</span> model'
+                                " &amp; system."
+                            ),
+                            "pageid": 12345,
+                        },
+                        {
+                            "title": "Python &quot;language&quot;",
+                            "snippet": "Programming language article.",
+                            "pageid": 67890,
+                        },
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://en.wikipedia.org/?curid=12345"
+    assert first.title == "Large language model & AI"
+    assert first.snippet == "A large language model & system."
+    assert first.content == "A large language model & system."
+    assert first.source_channel == "wikipedia:en"
+
+    second = results[1]
+    assert second.url == "https://en.wikipedia.org/?curid=67890"
+    assert second.title == 'Python "language"'
+    assert second.snippet == "Programming language article."
+    assert second.source_channel == "wikipedia:en"
+
+
+@pytest.mark.asyncio
+async def test_search_strips_span_markers_from_snippet() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "query": {
+                    "search": [
+                        {
+                            "title": "Example",
+                            "snippet": '<span class="searchmatch">foo</span> bar',
+                            "pageid": 123,
+                        }
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].snippet == "foo bar"
+
+
+@pytest.mark.asyncio
+async def test_search_decodes_html_entities() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "query": {
+                    "search": [
+                        {
+                            "title": "Python (programming language)",
+                            "snippet": "&quot;Python&quot; is a programming language.",
+                            "pageid": 23862,
+                        }
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].title == "Python (programming language)"
+    assert results[0].snippet == '"Python" is a programming language.'
+
+
+@pytest.mark.asyncio
+async def test_search_skips_item_without_pageid() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "query": {
+                    "search": [
+                        {
+                            "title": "Missing pageid",
+                            "snippet": "Should be skipped.",
+                        }
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_sends_user_agent_with_contact_info() -> None:
+    captured: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["user_agent"] = request.headers.get("user-agent", "")
+        captured["accept"] = request.headers.get("accept", "")
+        return httpx.Response(200, json={"query": {"search": []}}, request=request)
+
+    async with _client(handler) as http_client:
+        await search(_query(), http_client=http_client)
+
+    assert "autosearch/" in captured["user_agent"]
+    assert "@" in captured["user_agent"] or "http" in captured["user_agent"]
+    assert captured["accept"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"query": {}}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events == [("wikipedia_search_failed", {"reason": "invalid search payload"})]
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "wikipedia_search_failed"
+    assert "500" in str(logger.events[0][1]["reason"])

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -13,10 +13,10 @@ def _load_specs():
     return load_all(_channels_root())
 
 
-def test_all_16_channels_loadable() -> None:
+def test_all_18_channels_loadable() -> None:
     specs = _load_specs()
 
-    assert len(specs) == 16
+    assert len(specs) == 18
     assert [spec.name for spec in specs] == [
         "arxiv",
         "bilibili",
@@ -31,6 +31,8 @@ def test_all_16_channels_loadable() -> None:
         "stackoverflow",
         "twitter",
         "weibo",
+        "wikidata",
+        "wikipedia",
         "xiaohongshu",
         "youtube",
         "zhihu",
@@ -85,6 +87,8 @@ def test_shipped_method_impls_exist_for_registry_channels() -> None:
         "papers": ["methods/via_paper_search.py"],
         "reddit": ["methods/api_search.py"],
         "stackoverflow": ["methods/api_search.py"],
+        "wikidata": ["methods/api_search.py"],
+        "wikipedia": ["methods/api_search.py"],
         "zhihu": ["methods/via_tikhub.py"],
         "youtube": ["methods/data_api_v3.py"],
     }
@@ -109,6 +113,8 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         "papers",
         "reddit",
         "stackoverflow",
+        "wikidata",
+        "wikipedia",
     ]
     for spec in _load_specs():
         metadata = registry.metadata(spec.name)
@@ -121,6 +127,8 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             "papers": "methods/via_paper_search.py",
             "reddit": "methods/api_search.py",
             "stackoverflow": "methods/api_search.py",
+            "wikidata": "methods/api_search.py",
+            "wikipedia": "methods/api_search.py",
         }
         if spec.name == "github":
             methods = {method.id: method for method in metadata.methods}


### PR DESCRIPTION
## Summary

Wave D first batch — two Wikimedia channels. Authoritative reference + structured entity data.

| Channel | Endpoint | Returns |
|---|---|---|
| wikipedia | `en.wikipedia.org/w/api.php?action=query&list=search` | English encyclopedia articles (list-API, snippet only) |
| wikidata | `wikidata.org/w/api.php?action=wbsearchentities` | Structured entity records (Q-ids + labels + descriptions) |

Both comply with Wikimedia User-Agent policy — UA includes contact info (`autosearch/1.0 (+https://github.com/0xmariowu/autosearch; mario@miao.company)`).

## Commits (5)

1. `feat` wikipedia — SKILL + method (109 LOC). URLs use `?curid={pageid}` (stable under title renames). Snippet HTML-stripped (removes `<span class="searchmatch">` markers) and entity-decoded.
2. `test` wikipedia — 6+ cases including span-stripping assertion and UA policy check.
3. `feat` wikidata — SKILL + method (84 LOC). `source_channel` tagged with Q-id (e.g. `wikidata:Q2283`).
4. `test` wikidata — 6+ cases including concepturi fallback, label→id title fallback.
5. `test(unit)` scaffold — both registered in available list + scaffold expected-impls.

## Design decisions

- **English only for v1**: Chinese Wikipedia / zh Wikidata are future follow-ups. Don't pretend to handle multi-language when only `en` is wired.
- **Curid URLs for Wikipedia**: stable under article renames, unlike `/wiki/<title>`.
- **Wikidata snippet = description**: API doesn't return long content; description is the authoritative short summary.
- **`type=item` on Wikidata**: filters out lexemes/properties/mediainfo, returns only conceptual items.

## Test plan

- [x] 237 tests pass (223 prior + 14 new: 7 wikipedia + 7 wikidata)
- [x] `ruff check` + `ruff format --check` clean
- [x] No new runtime deps
- [x] User-Agent includes contact info (Wikimedia policy)

## Wave D remaining

- `google_trends` (via `pytrends` lib — needs new dep)
- `google_news` (RSS `news.google.com/rss/search?q=`)

Next PR.