### PR TITLE
feat(channels): add google_news rss channel (F202 Wave D part 2)

### DIFF
--- a/skills/channels/google_news/SKILL.md
+++ b/skills/channels/google_news/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: google_news
+description: Current news headlines aggregated across publishers via Google News RSS (English US feed).
+version: 1
+languages: [en, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en, mixed]
+  query_types: [current-events, news, recent-development, company-announcement]
+  domain_hints: [tech, politics, business, science, health]
+quality_hint:
+  typical_yield: high
+  chinese_native: false
+---
+
+## Overview
+
+Google News adds current editorial coverage aggregated across many publishers through the public RSS search feed. It is useful when the query is about recent events, announcements, or developing stories and the search should stay broad across mainstream news outlets without depending on a private API key.
+
+## Known Quirks
+
+- RSS only provides headlines and short summaries, not full article bodies.
+- The `link` field is a Google News redirect URL rather than the direct publisher URL, and v1 keeps it intentionally to avoid lossy or failure-prone decoding.
+- The feed is hardcoded to `hl=en-US&gl=US&ceid=US:en` for v1; non-English and non-US market variants are a follow-up.

--- a/skills/channels/google_news/methods/api_search.py
+++ b/skills/channels/google_news/methods/api_search.py
@@ -1,0 +1,151 @@
+# Self-written for task F202
+from __future__ import annotations
+
+import asyncio
+import html
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import feedparser
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="google_news")
+
+BASE_URL = "https://news.google.com/rss/search"
+HTTP_TIMEOUT = 15.0
+MAX_RESULTS = 10
+MAX_SNIPPET_LENGTH = 300
+USER_AGENT = "autosearch/1.0 (+https://github.com/0xmariowu/autosearch)"
+REQUEST_HEADERS = {
+    "Accept": "application/rss+xml, application/xml, text/xml",
+    "User-Agent": USER_AGENT,
+}
+TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+NON_SLUG_CHAR_RE = re.compile(r"[^a-z0-9-]+")
+MULTI_HYPHEN_RE = re.compile(r"-+")
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _normalize_whitespace(text: str) -> str:
+    return WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _clean_summary(summary: object) -> str | None:
+    cleaned = html.unescape(str(summary or ""))
+    cleaned = TAG_RE.sub(" ", cleaned)
+    cleaned = _normalize_whitespace(cleaned)
+    if not cleaned:
+        return None
+    return _truncate_on_word_boundary(cleaned, max_length=MAX_SNIPPET_LENGTH) or None
+
+
+def _sanitize_publisher(publisher: str) -> str:
+    slug = html.unescape(publisher).lower().strip()
+    if not slug:
+        return ""
+
+    slug = re.sub(r"\s+", "-", slug)
+    slug = NON_SLUG_CHAR_RE.sub("", slug)
+    slug = MULTI_HYPHEN_RE.sub("-", slug).strip("-")
+    return slug
+
+
+def _publisher_title(entry: object) -> str:
+    source = getattr(entry, "source", None)
+    if isinstance(source, Mapping):
+        return str(source.get("title") or "").strip()
+
+    if source is not None:
+        return str(getattr(source, "title", "") or "").strip()
+
+    getter = getattr(entry, "get", None)
+    if callable(getter):
+        source = getter("source", {})
+        if isinstance(source, Mapping):
+            return str(source.get("title") or "").strip()
+
+    return ""
+
+
+def _to_evidence(entry: object, *, fetched_at: datetime) -> Evidence | None:
+    url = str(getattr(entry, "link", "") or "").strip()
+    if not url:
+        return None
+
+    title = _normalize_whitespace(html.unescape(str(getattr(entry, "title", "") or "").strip()))
+    snippet = _clean_summary(getattr(entry, "summary", ""))
+    publisher = _publisher_title(entry)
+    publisher_slug = _sanitize_publisher(publisher)
+    source_channel = f"google_news:{publisher_slug}" if publisher_slug else "google_news"
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=snippet,
+        source_channel=source_channel,
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    params = {
+        "q": query.text,
+        "hl": "en-US",
+        "gl": "US",
+        "ceid": "US:en",
+    }
+
+    try:
+        if http_client is not None:
+            response = await http_client.get(BASE_URL, params=params, headers=REQUEST_HEADERS)
+        else:
+            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+                response = await client.get(BASE_URL, params=params, headers=REQUEST_HEADERS)
+
+        response.raise_for_status()
+        feed = await asyncio.to_thread(feedparser.parse, response.text)
+    except Exception as exc:
+        LOGGER.warning("google_news_search_failed", reason=str(exc))
+        return []
+
+    if getattr(feed, "bozo", 0) == 1:
+        reason = str(getattr(feed, "bozo_exception", None) or "failed to parse RSS feed")
+        LOGGER.warning("google_news_search_failed", reason=reason)
+        return []
+
+    entries = list(getattr(feed, "entries", []))[:MAX_RESULTS]
+    if not entries:
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for entry in entries:
+        evidence = _to_evidence(entry, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/tests/channels/google_news/__init__.py
+++ b/tests/channels/google_news/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F202

--- a/tests/channels/google_news/test_api_search.py
+++ b/tests/channels/google_news/test_api_search.py
@@ -1,0 +1,255 @@
+# Self-written for task F202
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+RSS_FIXTURE = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test News</title>
+    <item>
+      <title>AI regulation passes EU</title>
+      <link>https://news.google.com/rss/articles/abc</link>
+      <pubDate>Mon, 15 Apr 2024 10:00:00 GMT</pubDate>
+      <description>&lt;a href="https://example.com/story"&gt;AI regulation passes EU&lt;/a&gt;&amp;nbsp;&amp;nbsp;&lt;font color="#6f6f6f"&gt;Reuters&lt;/font&gt;</description>
+      <source url="https://reuters.com">Reuters</source>
+    </item>
+    <item>
+      <title>Chip exports tighten &amp; markets react</title>
+      <link>https://news.google.com/rss/articles/def</link>
+      <pubDate>Tue, 16 Apr 2024 08:30:00 GMT</pubDate>
+      <description>&lt;a href="https://example.com/story-2"&gt;Chip exports tighten&lt;/a&gt; &lt;b&gt;Markets react&lt;/b&gt;</description>
+      <source url="https://nytimes.com">The New York Times</source>
+    </item>
+    <item>
+      <title>Brief without publisher</title>
+      <link>https://news.google.com/rss/articles/ghi</link>
+      <pubDate>Wed, 17 Apr 2024 09:15:00 GMT</pubDate>
+      <description>&lt;a href="https://example.com/story-3"&gt;Brief without publisher&lt;/a&gt;</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "google_news"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_google_news_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="AI regulation", rationale="Need recent news coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_maps_rss_items_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["q"] == "AI regulation"
+        assert request.url.params["hl"] == "en-US"
+        assert request.url.params["gl"] == "US"
+        assert request.url.params["ceid"] == "US:en"
+        return httpx.Response(200, text=RSS_FIXTURE, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 3
+
+    first = results[0]
+    assert first.url == "https://news.google.com/rss/articles/abc"
+    assert first.title == "AI regulation passes EU"
+    assert first.snippet == "AI regulation passes EU Reuters"
+    assert first.content == "AI regulation passes EU Reuters"
+    assert first.source_channel == "google_news:reuters"
+
+    second = results[1]
+    assert second.url == "https://news.google.com/rss/articles/def"
+    assert second.title == "Chip exports tighten & markets react"
+    assert second.snippet == "Chip exports tighten Markets react"
+    assert second.source_channel == "google_news:the-new-york-times"
+
+
+@pytest.mark.asyncio
+async def test_search_strips_html_from_summary() -> None:
+    rss = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Example</title>
+      <link>https://news.google.com/rss/articles/html</link>
+      <description>&lt;a href="x"&gt;Story&lt;/a&gt;&amp;nbsp;&lt;font color="#6f6f6f"&gt;Publisher&lt;/font&gt;</description>
+      <source url="https://example.com">Publisher</source>
+    </item>
+  </channel>
+</rss>
+"""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=rss, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].snippet == "Story Publisher"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_item_without_link() -> None:
+    rss = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Missing link</title>
+      <description>&lt;a href="x"&gt;Story&lt;/a&gt;</description>
+      <source url="https://example.com">Publisher</source>
+    </item>
+  </channel>
+</rss>
+"""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=rss, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_handles_missing_source_tag() -> None:
+    rss = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>No source</title>
+      <link>https://news.google.com/rss/articles/no-source</link>
+      <description>&lt;a href="x"&gt;Story&lt;/a&gt;</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=rss, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].source_channel == "google_news"
+
+
+@pytest.mark.asyncio
+async def test_search_publisher_is_sanitized_to_slug() -> None:
+    rss = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Slug test</title>
+      <link>https://news.google.com/rss/articles/slug</link>
+      <description>&lt;a href="x"&gt;Story&lt;/a&gt;</description>
+      <source url="https://nytimes.com">The New York Times</source>
+    </item>
+  </channel>
+</rss>
+"""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=rss, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].source_channel == "google_news:the-new-york-times"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_bozo_parse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="<rss><channel><item></rss>", request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "google_news_search_failed"
+    assert str(logger.events[0][1]["reason"]) != ""
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="bad gateway", request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "google_news_search_failed"
+    assert "502" in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_sends_user_agent() -> None:
+    captured: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["user_agent"] = request.headers.get("user-agent", "")
+        captured["accept"] = request.headers.get("accept", "")
+        return httpx.Response(200, text=RSS_FIXTURE, request=request)
+
+    async with _client(handler) as http_client:
+        await search(_query(), http_client=http_client)
+
+    assert captured["user_agent"].startswith("autosearch/")
+    assert captured["accept"] == "application/rss+xml, application/xml, text/xml"

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -13,10 +13,10 @@ def _load_specs():
     return load_all(_channels_root())
 
 
-def test_all_18_channels_loadable() -> None:
+def test_all_19_channels_loadable() -> None:
     specs = _load_specs()
 
-    assert len(specs) == 18
+    assert len(specs) == 19
     assert [spec.name for spec in specs] == [
         "arxiv",
         "bilibili",
@@ -24,6 +24,7 @@ def test_all_18_channels_loadable() -> None:
         "devto",
         "douyin",
         "github",
+        "google_news",
         "hackernews",
         "package_search",
         "papers",
@@ -82,6 +83,7 @@ def test_shipped_method_impls_exist_for_registry_channels() -> None:
         "ddgs": ["methods/api.py"],
         "devto": ["methods/api_search.py"],
         "github": ["methods/search_public_repos.py"],
+        "google_news": ["methods/api_search.py"],
         "hackernews": ["methods/algolia.py"],
         "package_search": ["methods/api_search.py"],
         "papers": ["methods/via_paper_search.py"],
@@ -108,6 +110,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         "ddgs",
         "devto",
         "github",
+        "google_news",
         "hackernews",
         "package_search",
         "papers",
@@ -122,6 +125,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             "arxiv": "methods/api_search.py",
             "ddgs": "methods/api.py",
             "devto": "methods/api_search.py",
+            "google_news": "methods/api_search.py",
             "hackernews": "methods/algolia.py",
             "package_search": "methods/api_search.py",
             "papers": "methods/via_paper_search.py",


### PR DESCRIPTION
## Summary

Last of Wave D. Current news via Google News RSS. google_trends originally planned here was dropped — it returns trend data not articles, and pytrends is unofficial. May revisit as a query-signal helper.

## Endpoint

```
GET https://news.google.com/rss/search?q=<query>&hl=en-US&gl=US&ceid=US:en
```

Uses feedparser (already a dep) and the same async-to-thread pattern as arxiv channel.

## Commits (3)

1. `feat(channels)` — SKILL.md + method with feedparser parsing, HTML stripping, publisher slug sanitization, bozo-feed guard, 10-item cap.
2. `test(channels)` — 8 cases covering RSS mapping, HTML/entity decoding, missing source tag fallback, publisher → slug, bozo malformed feeds, HTTP 502, UA assertion.
3. `test(unit)` — scaffold registry assertions for `google_news`.

## Evidence mapping

- url: `entry.link` (Google News redirect — NOT decoded to direct publisher URL, avoiding lossy resolution).
- title: `entry.title` entity-decoded.
- snippet/content: `entry.summary` HTML-stripped + entity-decoded + word-boundary truncated @ 300 chars.
- source_channel: `f"google_news:{publisher-slug}"` or plain `"google_news"` if no source tag.

## Test plan

- [x] 245 tests pass (237 prior + 8 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] No new runtime deps (feedparser + httpx already present)
- [x] User-Agent set on outbound requests

## Channels after Wave D

13 shipped + 1 dev: ddgs / arxiv / hackernews / papers / reddit / stackoverflow / github(public) / devto / package_search / wikipedia / wikidata / google_news + youtube(env-gated) + zhihu(TikHub). Demo dev-only.

## Next

Wave E — TikHub channels (xiaohongshu / twitter / douyin / bilibili). Proxy worker already live at autosearch-proxy.autosearch-dev.workers.dev + end-to-end verified.