### PR TITLE
feat(channels): add douyin + bilibili via TikHub (F205 Wave E final)

### DIFF
--- a/skills/channels/bilibili/SKILL.md
+++ b/skills/channels/bilibili/SKILL.md
@@ -3,10 +3,14 @@
 
 ---
 name: bilibili
-description: Chinese video platform for tech tutorials, comparison videos, gaming/ACG, and expert breakdowns — use for visual content in Chinese.
+description: Chinese tech video platform with tutorials, conference recordings, and uploader-authored articles, via TikHub.
 version: 1
 languages: [zh, mixed]
 methods:
+  - id: via_tikhub
+    impl: methods/via_tikhub.py
+    requires: [env:TIKHUB_API_KEY]
+    rate_limit: {per_min: 60, per_hour: 1000}
   - id: api_search
     impl: methods/api_search.py
     requires: []
@@ -15,7 +19,7 @@ methods:
     impl: methods/api_video_detail.py
     requires: [cookie:bilibili]
     rate_limit: {per_min: 20, per_hour: 300}
-fallback_chain: [api_search, api_video_detail]
+fallback_chain: [via_tikhub, api_search, api_video_detail]
 when_to_use:
   query_languages: [zh, mixed]
   query_types: [tutorial-video, comparison, breakdown, tech-opinion]
@@ -41,12 +45,17 @@ For autosearch coverage, this channel fills a gap between global video search an
 
 ## How To Search (Planned)
 
+- `via_tikhub` - Use TikHub's paid Bilibili general search API to retrieve mixed result groups, then map only video and article results into normalized evidence.
+- `via_tikhub` - Strip Bilibili search-hit HTML markers, normalize uploader identity, and derive canonical video or article URLs from `bvid` / article ids when needed.
 - `api_search` - Call Bilibili search endpoints for videos and creators using Chinese or mixed query text, then rank by topical relevance and engagement.
 - `api_video_detail` - Fetch richer metadata for shortlisted videos with authenticated detail access when `cookie:bilibili` is available.
 - `api_video_detail` - Normalize title, uploader, publish time, duration, play stats, and canonical video URL.
 
 ## Known Quirks
 
+- TikHub billing applies per request, so this route should avoid wasteful exploratory fan-out.
+- Search titles and descriptions can include `<em class="keyword">` hit markers that must be stripped before ranking or display.
+- Only `video` and `article` result types are mapped today; user, live, and topic-style results are intentionally ignored.
 - Basic search works without auth, but video detail and richer metadata are more stable with a valid cookie.
 - Many results are entertainment-adjacent, so ranking must distinguish tech and tutorial intent carefully.
 - Some high-signal tutorials use slang or fandom terminology that generic keyword matching may miss.

--- a/skills/channels/bilibili/methods/via_tikhub.py
+++ b/skills/channels/bilibili/methods/via_tikhub.py
@@ -1,0 +1,225 @@
+# Self-written for task F205
+from __future__ import annotations
+
+import html
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="bilibili")
+SEARCH_PATH = "/api/v1/bilibili/web/fetch_general_search"
+MAX_SNIPPET_LENGTH = 300
+SUPPORTED_RESULT_TYPES = frozenset({"article", "video"})
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+NON_SLUG_CHAR_RE = re.compile(r"[^\w-]+", re.UNICODE)
+MULTI_HYPHEN_RE = re.compile(r"-+")
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _clean_text(value: object) -> str:
+    text = html.unescape(str(value or ""))
+    text = HTML_TAG_RE.sub(" ", text)
+    return _normalize_whitespace(text)
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _sanitize_source_token(value: str) -> str:
+    slug = value.lower().strip()
+    if not slug:
+        return ""
+
+    slug = re.sub(r"\s+", "-", slug)
+    slug = slug.replace("_", "-")
+    slug = NON_SLUG_CHAR_RE.sub("", slug)
+    slug = MULTI_HYPHEN_RE.sub("-", slug).strip("-")
+    return slug
+
+
+def _build_source_channel(result_type: str, author_name: str) -> str:
+    base = f"bilibili:{result_type}"
+    author_slug = _sanitize_source_token(author_name)
+    return f"{base}:{author_slug}" if author_slug else base
+
+
+def _extract_result_groups(
+    payload: Mapping[str, object],
+) -> list[tuple[str, list[Mapping[str, object]]]] | None:
+    data = payload.get("data")
+    if not isinstance(data, Mapping):
+        return None
+
+    nested_data = data.get("data")
+    if not isinstance(nested_data, Mapping):
+        return None
+
+    result_groups = nested_data.get("result")
+    if not isinstance(result_groups, list):
+        return None
+
+    groups: list[tuple[str, list[Mapping[str, object]]]] = []
+    for group in result_groups:
+        if not isinstance(group, Mapping):
+            continue
+        result_type = str(group.get("result_type") or "").strip().lower()
+        if result_type not in SUPPORTED_RESULT_TYPES:
+            continue
+
+        items = group.get("data")
+        if not isinstance(items, list):
+            continue
+
+        groups.append(
+            (result_type, [item for item in items if isinstance(item, Mapping)]),
+        )
+
+    return groups
+
+
+def _build_video_url(item: Mapping[str, object]) -> str:
+    raw_url = str(item.get("arcurl") or item.get("url") or "").strip()
+    if raw_url.startswith("http://") or raw_url.startswith("https://"):
+        return raw_url
+    if raw_url.startswith("//"):
+        return f"https:{raw_url}"
+    if raw_url.startswith("/"):
+        return f"https://www.bilibili.com{raw_url}"
+
+    bvid = str(item.get("bvid") or "").strip()
+    if bvid:
+        return f"https://www.bilibili.com/video/{bvid}"
+
+    return ""
+
+
+def _normalize_article_id(value: object) -> str:
+    article_id = str(value or "").strip()
+    if not article_id:
+        return ""
+
+    lowered = article_id.lower()
+    if lowered.startswith("cv"):
+        suffix = article_id[2:].strip()
+        return f"cv{suffix}" if suffix else ""
+    if article_id.isdigit():
+        return f"cv{article_id}"
+    return ""
+
+
+def _build_article_url(item: Mapping[str, object]) -> str:
+    for key in ("url", "arcurl", "uri", "jump_url"):
+        raw_url = str(item.get(key) or "").strip()
+        if raw_url.startswith("http://") or raw_url.startswith("https://"):
+            return raw_url
+        if raw_url.startswith("//"):
+            return f"https:{raw_url}"
+        if raw_url.startswith("/"):
+            return f"https://www.bilibili.com{raw_url}"
+
+        article_id = _normalize_article_id(raw_url)
+        if article_id:
+            return f"https://www.bilibili.com/read/{article_id}/"
+
+    for key in ("id", "article_id", "cvid"):
+        article_id = _normalize_article_id(item.get(key))
+        if article_id:
+            return f"https://www.bilibili.com/read/{article_id}/"
+
+    return ""
+
+
+def _to_video_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    url = _build_video_url(item)
+    if not url:
+        return None
+
+    title = _clean_text(item.get("title")) or "Bilibili video"
+    description = _clean_text(item.get("description"))
+    snippet = _truncate_on_word_boundary(description, max_length=MAX_SNIPPET_LENGTH) or None
+    author_name = _clean_text(item.get("author"))
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=description or snippet,
+        source_channel=_build_source_channel("video", author_name),
+        fetched_at=fetched_at,
+    )
+
+
+def _to_article_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    url = _build_article_url(item)
+    if not url:
+        return None
+
+    title = _clean_text(item.get("title")) or "Bilibili article"
+    summary = _clean_text(item.get("summary") or item.get("description") or item.get("desc"))
+    content = _clean_text(item.get("content")) or summary
+    snippet = _truncate_on_word_boundary(summary or content, max_length=MAX_SNIPPET_LENGTH) or None
+    author_name = _clean_text(item.get("author_name") or item.get("author") or item.get("uname"))
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=content or snippet,
+        source_channel=_build_source_channel("article", author_name),
+        fetched_at=fetched_at,
+    )
+
+
+async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Evidence]:
+    try:
+        tikhub_client = client or TikhubClient()
+        payload = await tikhub_client.get(
+            SEARCH_PATH,
+            {
+                "keyword": query.text,
+                "order": "totalrank",
+                "page": 1,
+                "page_size": 10,
+            },
+        )
+    except (TikhubError, ValueError) as exc:
+        LOGGER.warning("bilibili_tikhub_search_failed", reason=str(exc))
+        return []
+
+    result_groups = _extract_result_groups(payload)
+    if result_groups is None:
+        LOGGER.warning("bilibili_tikhub_search_failed", reason="invalid_payload_shape")
+        return []
+
+    fetched_at = datetime.now(UTC)
+    results: list[Evidence] = []
+    for result_type, items in result_groups:
+        for item in items:
+            evidence = (
+                _to_video_evidence(item, fetched_at=fetched_at)
+                if result_type == "video"
+                else _to_article_evidence(item, fetched_at=fetched_at)
+            )
+            if evidence is not None:
+                results.append(evidence)
+
+    return results

--- a/skills/channels/douyin/SKILL.md
+++ b/skills/channels/douyin/SKILL.md
@@ -3,15 +3,19 @@
 
 ---
 name: douyin
-description: Chinese short-form video platform for trending content, product launches, consumer commentary, and lifestyle segments in Chinese.
+description: Chinese short-video content with product demos, tech reviews, and viral trends, via TikHub.
 version: 1
 languages: [zh]
 methods:
+  - id: via_tikhub
+    impl: methods/via_tikhub.py
+    requires: [env:TIKHUB_API_KEY]
+    rate_limit: {per_min: 60, per_hour: 1000}
   - id: via_douyin_mcp
     impl: methods/via_douyin_mcp.py
     requires: [mcp:douyin-mcp-server, cookie:douyin]
     rate_limit: {per_min: 10, per_hour: 120}
-fallback_chain: [via_douyin_mcp]
+fallback_chain: [via_tikhub, via_douyin_mcp]
 when_to_use:
   query_languages: [zh]
   query_types: [trending, short-form, product-launch, consumer-commentary, lifestyle]
@@ -37,12 +41,17 @@ For autosearch coverage, this channel adds a format and audience segment that ne
 
 ## How To Search (Planned)
 
+- `via_tikhub` - Use TikHub's paid Douyin search API to discover public video results by keyword without relying on local session cookies.
+- `via_tikhub` - Normalize caption text, creator nickname, canonical share URL, and fallback video URL from `aweme_id` when the share link is missing.
 - `via_douyin_mcp` - Use the `douyin-mcp-server` route with authenticated session access to search clips, creators, and topical results.
 - `via_douyin_mcp` - Normalize clip title or caption, creator identity, publish time, engagement counts, and canonical share URL.
 - `via_douyin_mcp` - Keep extraction lightweight and ranking recency-aware because the platform is heavily short-form and trend-driven.
 
 ## Known Quirks
 
+- TikHub billing applies per request, so this route should stay deliberate rather than broad exploratory search.
+- TikHub search currently exposes caption text only; it does not provide transcript or in-video OCR extraction.
+- Engagement stats are present in the payload but are not yet mapped into `Evidence`; they remain a future rerank signal.
 - The planned route depends on both `mcp:douyin-mcp-server` and `cookie:douyin`.
 - Short-form content is high-noise and can be weak on factual detail without corroboration.
 - Trend vocabulary changes quickly, so rigid keyword matching will miss some relevant clips.

--- a/skills/channels/douyin/methods/via_tikhub.py
+++ b/skills/channels/douyin/methods/via_tikhub.py
@@ -1,0 +1,122 @@
+# Self-written for task F205
+from __future__ import annotations
+
+import html
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="douyin")
+SEARCH_PATH = "/api/v1/douyin/web/fetch_video_search_result_v2"
+MAX_TITLE_LENGTH = 80
+MAX_SNIPPET_LENGTH = 300
+NON_SLUG_CHAR_RE = re.compile(r"[^\w-]+", re.UNICODE)
+MULTI_HYPHEN_RE = re.compile(r"-+")
+
+
+def _clean_text(value: object) -> str:
+    return " ".join(html.unescape(str(value or "")).split())
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _sanitize_source_token(value: str) -> str:
+    slug = value.lower().strip()
+    if not slug:
+        return ""
+
+    slug = re.sub(r"\s+", "-", slug)
+    slug = slug.replace("_", "-")
+    slug = NON_SLUG_CHAR_RE.sub("", slug)
+    slug = MULTI_HYPHEN_RE.sub("-", slug).strip("-")
+    return slug
+
+
+def _build_source_channel(nickname: str) -> str:
+    nickname_slug = _sanitize_source_token(nickname)
+    return f"douyin:{nickname_slug}" if nickname_slug else "douyin"
+
+
+def _build_video_url(video: Mapping[str, object]) -> str:
+    share_url = str(video.get("share_url") or "").strip()
+    if share_url:
+        return share_url
+
+    aweme_id = str(video.get("aweme_id") or "").strip()
+    if aweme_id:
+        return f"https://www.douyin.com/video/{aweme_id}"
+
+    return ""
+
+
+def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    aweme_info = item.get("aweme_info")
+    if not isinstance(aweme_info, Mapping):
+        return None
+
+    aweme_id = str(aweme_info.get("aweme_id") or "").strip()
+    url = _build_video_url(aweme_info)
+    if not url:
+        return None
+
+    description = _clean_text(aweme_info.get("desc"))
+    title = _truncate_on_word_boundary(description, max_length=MAX_TITLE_LENGTH)
+    if not title:
+        title = f"Douyin video {aweme_id}" if aweme_id else "Douyin video"
+
+    snippet = _truncate_on_word_boundary(description, max_length=MAX_SNIPPET_LENGTH) or None
+    author = aweme_info.get("author")
+    author_map = author if isinstance(author, Mapping) else {}
+    nickname = _clean_text(author_map.get("nickname"))
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=description or snippet,
+        source_channel=_build_source_channel(nickname),
+        fetched_at=fetched_at,
+    )
+
+
+async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Evidence]:
+    try:
+        tikhub_client = client or TikhubClient()
+        payload = await tikhub_client.get(SEARCH_PATH, {"keyword": query.text})
+    except (TikhubError, ValueError) as exc:
+        LOGGER.warning("douyin_tikhub_search_failed", reason=str(exc))
+        return []
+
+    data = payload.get("data")
+    items = data.get("data") if isinstance(data, Mapping) else None
+    if not isinstance(items, list):
+        LOGGER.warning("douyin_tikhub_search_failed", reason="invalid_payload_shape")
+        return []
+
+    fetched_at = datetime.now(UTC)
+    results: list[Evidence] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        evidence = _to_evidence(item, fetched_at=fetched_at)
+        if evidence is not None:
+            results.append(evidence)
+
+    return results

--- a/tests/channels/bilibili/__init__.py
+++ b/tests/channels/bilibili/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F205

--- a/tests/channels/bilibili/test_via_tikhub.py
+++ b/tests/channels/bilibili/test_via_tikhub.py
@@ -1,0 +1,263 @@
+# Self-written for task F205
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from autosearch.core.models import SubQuery
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "bilibili"
+        / "methods"
+        / "via_tikhub.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_bilibili_via_tikhub", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+SEARCH_PATH = MODULE.SEARCH_PATH
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+class _FakeTikhubClient:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def get(self, path: str, params: dict[str, object]) -> dict[str, object]:
+        self.calls.append((path, params))
+        return self.payload
+
+
+class _FailingTikhubClient:
+    async def get(self, path: str, params: dict[str, object]) -> dict[str, object]:
+        raise TikhubError(f"request failed for {path} with {params!r}")
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="AI教程", rationale="Need Bilibili video and article coverage")
+
+
+def _payload(result_groups: list[dict[str, object]]) -> dict[str, object]:
+    return {"data": {"data": {"result": result_groups}}}
+
+
+def _group(result_type: str, items: list[dict[str, object]]) -> dict[str, object]:
+    return {"result_type": result_type, "data": items}
+
+
+def _video_item(
+    *,
+    bvid: str,
+    title: str,
+    description: str,
+    author: str,
+    arcurl: str | None = None,
+) -> dict[str, object]:
+    item = {
+        "bvid": bvid,
+        "aid": 1234567890,
+        "title": title,
+        "description": description,
+        "author": author,
+        "mid": 12345,
+        "play": 123456,
+        "video_review": 89,
+        "pubdate": 1713546000,
+        "duration": "5:32",
+    }
+    if arcurl is not None:
+        item["arcurl"] = arcurl
+    return item
+
+
+def _article_item(
+    *,
+    article_id: int | str,
+    title: str,
+    summary: str,
+    author_name: str,
+    url: str | None = None,
+) -> dict[str, object]:
+    item = {
+        "id": article_id,
+        "title": title,
+        "summary": summary,
+        "author_name": author_name,
+    }
+    if url is not None:
+        item["url"] = url
+    return item
+
+
+@pytest.mark.asyncio
+async def test_search_extracts_videos_from_result_groups() -> None:
+    client = _FakeTikhubClient(
+        _payload(
+            [
+                _group(
+                    "video",
+                    [
+                        _video_item(
+                            bvid="BV1abc123",
+                            title="Video title one",
+                            description="First description.",
+                            author="UP One",
+                            arcurl="https://www.bilibili.com/video/BV1abc123",
+                        ),
+                        _video_item(
+                            bvid="BV2xyz456",
+                            title="Video title two",
+                            description="Second description.",
+                            author="UP Two",
+                        ),
+                    ],
+                )
+            ]
+        )
+    )
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert client.calls == [
+        (
+            SEARCH_PATH,
+            {"keyword": "AI教程", "order": "totalrank", "page": 1, "page_size": 10},
+        )
+    ]
+    assert len(results) == 2
+    assert results[0].url == "https://www.bilibili.com/video/BV1abc123"
+    assert results[1].url == "https://www.bilibili.com/video/BV2xyz456"
+    assert results[0].source_channel == "bilibili:video:up-one"
+    assert results[1].source_channel == "bilibili:video:up-two"
+
+
+@pytest.mark.asyncio
+async def test_search_extracts_articles_from_result_groups() -> None:
+    client = _FakeTikhubClient(
+        _payload(
+            [
+                _group(
+                    "article",
+                    [
+                        _article_item(
+                            article_id=445566,
+                            title="Article title",
+                            summary="Article summary text.",
+                            author_name="Tech Writer",
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert len(results) == 1
+    assert results[0].url == "https://www.bilibili.com/read/cv445566/"
+    assert results[0].source_channel == "bilibili:article:tech-writer"
+
+
+@pytest.mark.asyncio
+async def test_search_strips_em_markers_from_title_and_description() -> None:
+    client = _FakeTikhubClient(
+        _payload(
+            [
+                _group(
+                    "video",
+                    [
+                        _video_item(
+                            bvid="BV3strip789",
+                            title="<em class='keyword'>foo</em> bar",
+                            description="desc <em class='keyword'>foo</em> bar",
+                            author="Markup Cleaner",
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert len(results) == 1
+    assert results[0].title == "foo bar"
+    assert results[0].snippet == "desc foo bar"
+    assert results[0].content == "desc foo bar"
+
+
+@pytest.mark.asyncio
+async def test_search_ignores_user_and_live_result_types() -> None:
+    client = _FakeTikhubClient(
+        _payload(
+            [
+                _group("bili_user", [{"uname": "Not evidence"}]),
+                _group("live", [{"title": "Live stream"}]),
+                _group(
+                    "video",
+                    [
+                        _video_item(
+                            bvid="BV4keep111",
+                            title="Kept result",
+                            description="Only this one should survive.",
+                            author="Signal Only",
+                        )
+                    ],
+                ),
+            ]
+        )
+    )
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert len(results) == 1
+    assert results[0].title == "Kept result"
+    assert results[0].source_channel == "bilibili:video:signal-only"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_tikhub_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    results = await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "bilibili_tikhub_search_failed"
+    assert SEARCH_PATH in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_malformed_payload() -> None:
+    client = _FakeTikhubClient({"data": {"data": {"unexpected": []}}})
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert results == []

--- a/tests/channels/douyin/__init__.py
+++ b/tests/channels/douyin/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task F205

--- a/tests/channels/douyin/test_via_tikhub.py
+++ b/tests/channels/douyin/test_via_tikhub.py
@@ -1,0 +1,196 @@
+# Self-written for task F205
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from autosearch.core.models import SubQuery
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "skills"
+        / "channels"
+        / "douyin"
+        / "methods"
+        / "via_tikhub.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_douyin_via_tikhub", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+SEARCH_PATH = MODULE.SEARCH_PATH
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+class _FakeTikhubClient:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def get(self, path: str, params: dict[str, object]) -> dict[str, object]:
+        self.calls.append((path, params))
+        return self.payload
+
+
+class _FailingTikhubClient:
+    async def get(self, path: str, params: dict[str, object]) -> dict[str, object]:
+        raise TikhubError(f"request failed for {path} with {params!r}")
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="科技评测", rationale="Need Douyin short-video review coverage")
+
+
+def _video_entry(
+    *,
+    aweme_id: str,
+    desc: str,
+    nickname: str | None,
+    share_url: str | None = None,
+) -> dict[str, object]:
+    author: dict[str, object] = {"sec_uid": "MS4w..."}
+    if nickname is not None:
+        author["nickname"] = nickname
+
+    aweme_info: dict[str, object] = {
+        "aweme_id": aweme_id,
+        "desc": desc,
+        "author": author,
+        "statistics": {"digg_count": 1200, "comment_count": 45},
+        "video": {"cover": {"url_list": ["https://example.com/cover.jpg"]}},
+    }
+    if share_url is not None:
+        aweme_info["share_url"] = share_url
+
+    return {"type": 1, "aweme_info": aweme_info}
+
+
+@pytest.mark.asyncio
+async def test_search_maps_douyin_videos_to_evidence() -> None:
+    client = _FakeTikhubClient(
+        {
+            "data": {
+                "data": [
+                    _video_entry(
+                        aweme_id="7234567890",
+                        desc="First &amp; latest phone teardown clip.",
+                        nickname="Tech Reviewer",
+                        share_url="https://v.douyin.com/abc123/",
+                    ),
+                    _video_entry(
+                        aweme_id="7234567891",
+                        desc="Second comparison video for a new gadget.",
+                        nickname="Device Lab",
+                        share_url="https://v.douyin.com/def456/",
+                    ),
+                ]
+            }
+        }
+    )
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert client.calls == [(SEARCH_PATH, {"keyword": "科技评测"})]
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://v.douyin.com/abc123/"
+    assert first.title == "First & latest phone teardown clip."
+    assert first.source_channel == "douyin:tech-reviewer"
+    assert first.fetched_at.tzinfo is MODULE.UTC
+
+    second = results[1]
+    assert second.url == "https://v.douyin.com/def456/"
+    assert second.title == "Second comparison video for a new gadget."
+    assert second.source_channel == "douyin:device-lab"
+
+
+@pytest.mark.asyncio
+async def test_search_uses_aweme_id_fallback_when_share_url_missing() -> None:
+    client = _FakeTikhubClient(
+        {
+            "data": {
+                "data": [
+                    _video_entry(
+                        aweme_id="7234567892",
+                        desc="Fallback URL example.",
+                        nickname="Fallback Creator",
+                    )
+                ]
+            }
+        }
+    )
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert len(results) == 1
+    assert results[0].url == "https://www.douyin.com/video/7234567892"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_entry_without_aweme_info() -> None:
+    client = _FakeTikhubClient({"data": {"data": [{"type": 4, "mix_info": {"id": "mix-1"}}]}})
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_tikhub_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    results = await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "douyin_tikhub_search_failed"
+    assert SEARCH_PATH in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_handles_empty_desc_with_placeholder_title() -> None:
+    client = _FakeTikhubClient(
+        {
+            "data": {
+                "data": [
+                    _video_entry(
+                        aweme_id="7234567893",
+                        desc="",
+                        nickname="Placeholder Creator",
+                        share_url="https://v.douyin.com/ghi789/",
+                    )
+                ]
+            }
+        }
+    )
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert len(results) == 1
+    assert results[0].title == "Douyin video 7234567893"
+    assert results[0].snippet is None
+    assert results[0].content is None

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -80,8 +80,10 @@ def test_chinese_native_channels_cover_5() -> None:
 def test_shipped_method_impls_exist_for_registry_channels() -> None:
     expected_impls = {
         "arxiv": ["methods/api_search.py"],
+        "bilibili": ["methods/via_tikhub.py"],
         "ddgs": ["methods/api.py"],
         "devto": ["methods/api_search.py"],
+        "douyin": ["methods/via_tikhub.py"],
         "github": ["methods/search_public_repos.py"],
         "google_news": ["methods/api_search.py"],
         "hackernews": ["methods/algolia.py"],
@@ -194,6 +196,28 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             assert methods["via_tikhub"].unmet_requires == ["env:TIKHUB_API_KEY"]
             assert methods["api_search"].available is False
             assert methods["api_search"].unmet_requires == ["impl_missing"]
+            continue
+        if spec.name == "douyin":
+            methods = {method.id: method for method in metadata.methods}
+
+            assert metadata.available_methods() == []
+            assert methods["via_tikhub"].available is False
+            assert methods["via_tikhub"].unmet_requires == ["env:TIKHUB_API_KEY"]
+            for other_id, method in methods.items():
+                if other_id != "via_tikhub":
+                    assert method.available is False
+                    assert method.unmet_requires == ["impl_missing"]
+            continue
+        if spec.name == "bilibili":
+            methods = {method.id: method for method in metadata.methods}
+
+            assert metadata.available_methods() == []
+            assert methods["via_tikhub"].available is False
+            assert methods["via_tikhub"].unmet_requires == ["env:TIKHUB_API_KEY"]
+            for other_id, method in methods.items():
+                if other_id != "via_tikhub":
+                    assert method.available is False
+                    assert method.unmet_requires == ["impl_missing"]
             continue
 
         assert metadata.available_methods() == []


### PR DESCRIPTION
## Summary

Wave E collectors complete. Douyin short-video search + Bilibili mixed (video + article) search via TikHub.

| Channel | TikHub endpoint | Notes |
|---|---|---|
| douyin | `/api/v1/douyin/web/fetch_video_search_result_v2` | Video captions; engagement stats not mapped to Evidence |
| bilibili | `/api/v1/bilibili/web/fetch_general_search?order=totalrank` | Extracts `result_type in (video, article)` — users/lives skipped |

Both route through the existing `TikhubClient`. Proxy mode via `AUTOSEARCH_PROXY_URL` already deployed via F205a + Cloudflare Worker.

## Commits (5)

1. `feat` douyin — SKILL.md adds `via_tikhub` method + reorders fallback_chain. Method (122 LOC): handles entries without `aweme_info`, placeholder title when `desc` empty, `share_url → aweme_id` URL fallback.
2. `test` douyin — 5 cases via `_FakeTikhubClient` injection.
3. `feat` bilibili — SKILL.md adds `via_tikhub`. Method (225 LOC) walks `data.data.result[]` with `result_type` filter; strips `<em class="keyword">` markers from title + description.
4. `test` bilibili — 6 cases covering video extraction, article extraction, em-marker stripping, mixed result types filtering.
5. `test(unit)` scaffold — both registered with `env:TIKHUB_API_KEY` gating; legacy scaffold methods stay `impl_missing`.

## Rebase conflict resolved

Scaffold test had parallel additions on main (xhs+twitter from #136) vs local (douyin+bilibili). Merged: kept xhs+twitter's explicit method-id assertions, kept douyin+bilibili's generic `for other_id in methods` loop. Both styles valid — chose to preserve each branch's original structure.

## Test plan

- [x] 267 tests pass (256 prior on main + 11 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] Zero live TikHub calls in tests (mock only)
- [x] Pre-push rebase + regression ~3s

## Channel inventory after Wave E final

**17 shipped channels + 1 dev-only demo**
- Free English: ddgs / arxiv / hackernews / reddit / stackoverflow / github(public fallback) / devto / package_search / wikipedia / wikidata / google_news
- Aggregated: papers (arxiv/pubmed/biorxiv/medrxiv/google_scholar)
- Env-gated: youtube (YOUTUBE_API_KEY)
- TikHub paid: zhihu / xiaohongshu / twitter / douyin / bilibili

## What's next

- **Wave F**: M0.5 Scope Clarification (追问机制) — CLI + API + MCP changes per plan. Three PRs.
- **Wave G polish**: `autosearch init --check-channels` update, README channels table, pipx package-data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TikHub-powered search integration for Bilibili and Douyin channels.
  * Requires TIKHUB_API_KEY; rate-limited to 60 requests/min, 1000/hour.

* **Documentation**
  * Updated search documentation with TikHub integration workflows and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->