### PR TITLE
feat(core): SearchScope schema and ScopeClarifier for M0.5 (F101 Wave F part 1)

### DIFF
--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class SearchMode(StrEnum):
     FAST = "fast"
     DEEP = "deep"
+    COMPREHENSIVE = "comprehensive"
 
 
 class SubQuery(BaseModel):

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -562,6 +562,8 @@ class _TrackingIterationController(IterationController):
 def _initial_subquery_count(mode: SearchMode) -> int:
     if mode is SearchMode.FAST:
         return 3
+    if mode is SearchMode.COMPREHENSIVE:
+        return 7
     return 5
 
 

--- a/autosearch/core/scope_clarifier.py
+++ b/autosearch/core/scope_clarifier.py
@@ -1,0 +1,66 @@
+# Self-written, plan autosearch-0419-channels-scope-proxy.md § F101
+from __future__ import annotations
+
+from autosearch.core.search_scope import ScopeQuestion, SearchScope
+
+_CHANNEL_SCOPE_QUESTION = ScopeQuestion(
+    field="channel_scope",
+    prompt="Which channel scope should the search cover?",
+    options=["all", "en_only", "zh_only", "mixed"],
+)
+
+_DEPTH_QUESTION = ScopeQuestion(
+    field="depth",
+    prompt="How deep should the search go?",
+    options=["fast", "deep", "comprehensive"],
+)
+
+_FORMAT_QUESTION = ScopeQuestion(
+    field="output_format",
+    prompt="Output format for the report?",
+    options=["md", "html"],
+)
+
+
+class ScopeClarifier:
+    """Return clarification questions for SearchScope fields the caller omitted.
+
+    Domain follow-ups are handled later by the domain clarifier; this class only manages
+    the explicit UX scope fields collected before the pipeline runs.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def questions_for(
+        self,
+        provided: dict[str, object] | None = None,
+    ) -> list[ScopeQuestion]:
+        """Return ordered questions for fields the caller did not explicitly provide.
+
+        `provided` is a flat dict of field names the caller asserts were explicitly set.
+        Missing keys or None values trigger a question for that field.
+        """
+        provided = provided or {}
+        questions: list[ScopeQuestion] = []
+
+        if provided.get("channel_scope") is None:
+            questions.append(_CHANNEL_SCOPE_QUESTION)
+        if provided.get("depth") is None:
+            questions.append(_DEPTH_QUESTION)
+        if provided.get("output_format") is None:
+            questions.append(_FORMAT_QUESTION)
+
+        return questions
+
+    @staticmethod
+    def apply_answers(
+        base: SearchScope,
+        answers: dict[str, object],
+    ) -> SearchScope:
+        """Return a new SearchScope with non-None answers applied over `base`.
+
+        Raises ValidationError if any provided value does not satisfy the target field.
+        """
+        merged = base.model_dump() | {k: v for k, v in answers.items() if v is not None}
+        return SearchScope(**merged)

--- a/autosearch/core/search_scope.py
+++ b/autosearch/core/search_scope.py
@@ -1,0 +1,38 @@
+# Self-written, plan autosearch-0419-channels-scope-proxy.md § F101
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ChannelScope = Literal["all", "en_only", "zh_only", "mixed"]
+Depth = Literal["fast", "deep", "comprehensive"]
+OutputFormat = Literal["md", "html"]
+
+
+class SearchScope(BaseModel):
+    """User-facing scope parameters collected before the pipeline runs.
+
+    M0.5 clarifier produces one ScopeQuestion per missing field; once filled, downstream
+    modules (M1 domain clarifier, M2 strategy, M3 channel filter, M7 synthesizer) consume it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    domain_followups: list[str] = Field(default_factory=list)
+    channel_scope: ChannelScope = "all"
+    depth: Depth = "fast"
+    output_format: OutputFormat = "md"
+
+
+class ScopeQuestion(BaseModel):
+    """A single clarification question raised when a scope field is unspecified.
+
+    Produced by `ScopeClarifier.questions_for()` and serialized into API/MCP/CLI flows.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    field: Literal["domain_followups", "channel_scope", "depth", "output_format"]
+    prompt: str
+    options: list[str] = Field(default_factory=list)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -121,6 +121,7 @@ def test_models_validate_and_are_frozen(
 def test_search_mode_parses_valid_values() -> None:
     assert SearchMode("fast") is SearchMode.FAST
     assert SearchMode("deep") is SearchMode.DEEP
+    assert SearchMode("comprehensive") is SearchMode.COMPREHENSIVE
 
 
 def test_search_mode_rejects_invalid_values() -> None:

--- a/tests/unit/test_pipeline_initial_subquery_count.py
+++ b/tests/unit/test_pipeline_initial_subquery_count.py
@@ -1,0 +1,15 @@
+# Self-written, plan autosearch-0419-channels-scope-proxy.md § F101
+from autosearch.core.models import SearchMode
+from autosearch.core.pipeline import _initial_subquery_count
+
+
+def test_initial_subquery_count_fast_returns_3() -> None:
+    assert _initial_subquery_count(SearchMode.FAST) == 3
+
+
+def test_initial_subquery_count_deep_returns_5() -> None:
+    assert _initial_subquery_count(SearchMode.DEEP) == 5
+
+
+def test_initial_subquery_count_comprehensive_returns_7() -> None:
+    assert _initial_subquery_count(SearchMode.COMPREHENSIVE) == 7

--- a/tests/unit/test_scope_clarifier.py
+++ b/tests/unit/test_scope_clarifier.py
@@ -1,0 +1,69 @@
+# Self-written, plan autosearch-0419-channels-scope-proxy.md § F101
+import pytest
+from pydantic import ValidationError
+
+from autosearch.core.scope_clarifier import ScopeClarifier
+from autosearch.core.search_scope import SearchScope
+
+
+def test_questions_for_empty_returns_three_questions() -> None:
+    questions = ScopeClarifier().questions_for({})
+
+    assert [question.field for question in questions] == [
+        "channel_scope",
+        "depth",
+        "output_format",
+    ]
+
+
+def test_questions_for_all_provided_returns_empty() -> None:
+    questions = ScopeClarifier().questions_for(
+        {
+            "channel_scope": "mixed",
+            "depth": "deep",
+            "output_format": "html",
+        }
+    )
+
+    assert questions == []
+
+
+def test_questions_for_partial_skips_provided_fields() -> None:
+    questions = ScopeClarifier().questions_for({"depth": "deep"})
+
+    assert [question.field for question in questions] == ["channel_scope", "output_format"]
+
+
+def test_questions_for_none_value_triggers_question() -> None:
+    questions = ScopeClarifier().questions_for({"depth": None})
+
+    assert [question.field for question in questions] == [
+        "channel_scope",
+        "depth",
+        "output_format",
+    ]
+
+
+def test_apply_answers_merges_onto_base() -> None:
+    base = SearchScope(depth="deep")
+
+    result = ScopeClarifier.apply_answers(base, {"channel_scope": "zh_only"})
+
+    assert result.depth == "deep"
+    assert result.channel_scope == "zh_only"
+    assert result.output_format == "md"
+
+
+def test_apply_answers_ignores_none_values() -> None:
+    base = SearchScope(depth="deep")
+
+    result = ScopeClarifier.apply_answers(base, {"depth": None})
+
+    assert result.depth == "deep"
+
+
+def test_apply_answers_raises_on_invalid_literal() -> None:
+    base = SearchScope()
+
+    with pytest.raises(ValidationError):
+        ScopeClarifier.apply_answers(base, {"depth": "invalid"})

--- a/tests/unit/test_search_scope.py
+++ b/tests/unit/test_search_scope.py
@@ -1,0 +1,51 @@
+# Self-written, plan autosearch-0419-channels-scope-proxy.md § F101
+import pytest
+from pydantic import ValidationError
+
+from autosearch.core.search_scope import ScopeQuestion, SearchScope
+
+
+def test_search_scope_defaults() -> None:
+    scope = SearchScope()
+
+    assert scope.domain_followups == []
+    assert scope.channel_scope == "all"
+    assert scope.depth == "fast"
+    assert scope.output_format == "md"
+    assert SearchScope.model_config["frozen"] is True
+
+
+def test_search_scope_validates_channel_scope_literal() -> None:
+    with pytest.raises(ValidationError):
+        SearchScope(channel_scope="bogus")
+
+
+def test_search_scope_validates_depth_literal() -> None:
+    with pytest.raises(ValidationError):
+        SearchScope(depth="bogus")
+
+
+def test_search_scope_validates_output_format_literal() -> None:
+    with pytest.raises(ValidationError):
+        SearchScope(output_format="bogus")
+
+
+def test_search_scope_frozen_rejects_mutation() -> None:
+    scope = SearchScope()
+
+    with pytest.raises(ValidationError):
+        scope.depth = "deep"
+
+
+def test_scope_question_frozen_and_serializable() -> None:
+    question = ScopeQuestion(
+        field="depth",
+        prompt="How deep should the search go?",
+        options=["fast", "deep", "comprehensive"],
+    )
+
+    dumped = question.model_dump()
+    loaded = ScopeQuestion.model_validate(dumped)
+
+    assert ScopeQuestion.model_config["frozen"] is True
+    assert loaded == question


### PR DESCRIPTION
## Summary

Wave F phase 1 — pure schema + clarifier for the upcoming M0.5 scope clarification. No CLI/API/pipeline wiring yet (F102 + F103 follow-ups).

## What F101 ships

| Component | Purpose |
|---|---|
| `autosearch/core/search_scope.py` | `SearchScope` + `ScopeQuestion` pydantic models (frozen). 4 fields: `domain_followups` / `channel_scope` / `depth` / `output_format` |
| `autosearch/core/scope_clarifier.py` | `ScopeClarifier.questions_for(provided)` returns ordered list of unanswered questions; `apply_answers(base, answers)` merges answers into a new SearchScope |
| `autosearch/core/models.py` | `SearchMode.COMPREHENSIVE = "comprehensive"` (third enum value) |
| `autosearch/core/pipeline.py` | `_initial_subquery_count(SearchMode.COMPREHENSIVE)` returns 7 (vs FAST=3, DEEP=5) |

## Field schema

```python
channel_scope: Literal["all", "en_only", "zh_only", "mixed"] = "all"
depth: Literal["fast", "deep", "comprehensive"] = "fast"
output_format: Literal["md", "html"] = "md"
domain_followups: list[str] = []  # filled by M1 DomainClarifier, not M0.5
```

Unknown values raise pydantic `ValidationError` — Literal type is enforced.

## Commits (3)

1. `feat(core)` — SearchMode enum + pipeline subquery count (2 files, +3 lines).
2. `feat(core)` — SearchScope + ScopeClarifier (2 new files, +104 LOC).
3. `test(unit)` — 16 new test cases across 4 test files (schema validation, clarifier empty/partial/full coverage, apply_answers merge, SearchMode COMPREHENSIVE parse, pipeline subquery count extension).

## Test plan

- [x] 283 tests pass (267 prior + 16 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] No new runtime deps
- [x] SearchMode addition is additive — existing FAST/DEEP behavior unchanged

## Design note

`questions_for(provided)` takes a **flat dict** rather than a partial `SearchScope`, because the defaults on `SearchScope` are indistinguishable from "unset" (both show as `"fast"` / `"all"` / `"md"`). The dict-with-`None`-means-missing contract preserves the distinction between "user explicitly picked fast" and "user didn't say — ask them."

## Not in this PR (deferred to F102 + F103)

- CLI flags `--languages` / `--depth` / `--format` / `--interactive`
- API `scope_needed` SSE event + `/v1/chat/completions` metadata
- MCP `research` tool parameters
- html render on `--format html`

## Next

- F102: CLI wiring (TTY interactive prompt, flag parsing, html render).
- F103: API + MCP surface.