### PR TITLE
feat(cli): scope flags + TTY interactive prompt + html render (F102 Wave F part 2)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -7,11 +7,14 @@ from typing import Annotated
 import click
 import typer
 import uvicorn
+from pydantic import ValidationError
 
 from autosearch import __version__
 from autosearch.core.channel_bootstrap import _build_channels
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline, PipelineResult
+from autosearch.core.scope_clarifier import ScopeClarifier
+from autosearch.core.search_scope import ScopeQuestion, SearchScope
 from autosearch.init_runner import InitError, InitRunner
 from autosearch.llm.client import LLMClient
 
@@ -69,6 +72,40 @@ def query(
         bool,
         typer.Option("--json", help="Emit a machine-readable JSON response envelope."),
     ] = False,
+    languages: Annotated[
+        str | None,
+        typer.Option(
+            "--languages",
+            help='Channel scope: "all" (default), "en_only", "zh_only", or "mixed".',
+            case_sensitive=False,
+        ),
+    ] = None,
+    depth: Annotated[
+        str | None,
+        typer.Option(
+            "--depth",
+            help='Search depth: "fast" (default), "deep", or "comprehensive".',
+            case_sensitive=False,
+        ),
+    ] = None,
+    output_format: Annotated[
+        str | None,
+        typer.Option(
+            "--format",
+            help='Output format: "md" (default) or "html".',
+            case_sensitive=False,
+        ),
+    ] = None,
+    interactive: Annotated[
+        bool | None,
+        typer.Option(
+            "--interactive/--no-interactive",
+            help=(
+                "Force (or suppress) the interactive prompt when flags are missing. "
+                "Defaults to auto-detect based on TTY."
+            ),
+        ),
+    ] = None,
     stream: Annotated[
         bool,
         typer.Option(
@@ -77,6 +114,20 @@ def query(
         ),
     ] = True,
 ) -> None:
+    if mode is not None and depth is not None:
+        typer.echo("--mode ignored because --depth was also provided", err=True)
+
+    provided = {
+        "channel_scope": _normalize_option_value(languages),
+        "depth": _normalize_option_value(depth) or (mode.value if mode is not None else None),
+        "output_format": _normalize_option_value(output_format),
+    }
+    scope = _resolve_scope(
+        provided=provided,
+        interactive=interactive,
+        json_output=json_output,
+    )
+    resolved_mode = _depth_to_mode(scope.depth, mode)
     stream_callback = _stderr_event_writer if stream and not json_output else None
     try:
         result = asyncio.run(
@@ -85,7 +136,7 @@ def query(
                 channels=_build_channels(),
                 top_k_evidence=top_k,
                 on_event=stream_callback,
-            ).run(query, mode_hint=mode)
+            ).run(query, mode_hint=resolved_mode)
         )
     except Exception as exc:
         typer.echo(str(exc), err=True)
@@ -95,23 +146,38 @@ def query(
         typer.echo(result.clarification.question or "More detail is required.", err=True)
         raise typer.Exit(code=2)
 
+    try:
+        rendered_output = _render_output(
+            markdown_text=result.markdown or "",
+            title=query,
+            output_format=scope.output_format,
+        )
+    except Exception as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
     if json_output:
         typer.echo(
             json.dumps(
                 {
                     "status": result.status,
-                    "markdown": result.markdown,
+                    "markdown": rendered_output,
                     "iterations": result.iterations,
                     "quality_grade": (
                         result.quality.grade.value if result.quality is not None else None
                     ),
                     "sources": _json_sources(result),
+                    "scope": {
+                        "channel_scope": scope.channel_scope,
+                        "depth": scope.depth,
+                        "output_format": scope.output_format,
+                    },
                 }
             )
         )
         return
 
-    typer.echo(result.markdown or "")
+    typer.echo(rendered_output)
 
 
 @app.command()
@@ -178,6 +244,119 @@ def serve(
 def _stderr_event_writer(event: dict[str, object]) -> None:
     sys.stderr.write(json.dumps(event, ensure_ascii=False) + "\n")
     sys.stderr.flush()
+
+
+def _normalize_option_value(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return value.lower()
+
+
+def _resolve_scope(
+    *,
+    provided: dict[str, str | None],
+    interactive: bool | None,
+    json_output: bool,
+) -> SearchScope:
+    provided_non_none = {key: value for key, value in provided.items() if value is not None}
+    try:
+        if _should_prompt_for_scope(interactive=interactive, json_output=json_output):
+            clarifier = ScopeClarifier()
+            answers = _prompt_for_scope_answers(clarifier.questions_for(provided))
+            return clarifier.apply_answers(SearchScope(), {**provided_non_none, **answers})
+        return SearchScope(**provided_non_none)
+    except ValidationError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+def _should_prompt_for_scope(*, interactive: bool | None, json_output: bool) -> bool:
+    if interactive is True:
+        return True
+    if interactive is False:
+        return False
+    return sys.stdin.isatty() and sys.stdout.isatty() and not json_output
+
+
+def _prompt_for_scope_answers(questions: list[ScopeQuestion]) -> dict[str, str]:
+    answers: dict[str, str] = {}
+    for question in questions:
+        answers[question.field] = _prompt_for_scope_question(question)
+    return answers
+
+
+def _prompt_for_scope_question(question: ScopeQuestion) -> str:
+    choices_text = ", ".join(
+        f"{index}. {option}" for index, option in enumerate(question.options, start=1)
+    )
+    prompt_text = f"{question.prompt} [{choices_text}]"
+    for _ in range(3):
+        answer = typer.prompt(prompt_text).strip()
+        resolved = _resolve_prompt_answer(answer, question.options)
+        if resolved is not None:
+            return resolved
+        typer.echo(
+            f"Invalid choice. Enter 1-{len(question.options)} or one of: "
+            f"{', '.join(question.options)}",
+            err=True,
+        )
+    raise typer.Exit(code=2)
+
+
+def _resolve_prompt_answer(answer: str, options: list[str]) -> str | None:
+    normalized = answer.strip().lower()
+    if not normalized:
+        return None
+    if normalized.isdigit():
+        index = int(normalized) - 1
+        if 0 <= index < len(options):
+            return options[index]
+        return None
+    for option in options:
+        if normalized == option.lower():
+            return option
+    return None
+
+
+def _depth_to_mode(depth: str | None, fallback: SearchMode | None) -> SearchMode | None:
+    if depth is None:
+        return fallback
+    normalized = depth.lower()
+    if normalized == "fast":
+        return SearchMode.FAST
+    if normalized == "deep":
+        return SearchMode.DEEP
+    if normalized == "comprehensive":
+        return SearchMode.COMPREHENSIVE
+    raise typer.BadParameter(f"invalid --depth: {depth}")
+
+
+def _render_output(markdown_text: str, title: str, output_format: str) -> str:
+    if output_format == "html":
+        return _render_html(markdown_text=markdown_text, title=title)
+    return markdown_text
+
+
+def _render_html(markdown_text: str, title: str) -> str:
+    import html as html_lib
+
+    try:
+        import markdown as md
+    except ImportError as exc:
+        try:
+            from markdown_it import MarkdownIt
+        except ImportError:
+            raise RuntimeError("markdown package is required for --format html") from exc
+        body = MarkdownIt("js-default").render(markdown_text or "")
+    else:
+        body = md.markdown(markdown_text or "", extensions=["tables", "fenced_code"])
+    safe_title = html_lib.escape(title)
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        '<head><meta charset="utf-8"><title>{title}</title></head>\n'
+        "<body><article>\n{body}\n</article></body>\n"
+        "</html>\n"
+    ).format(title=safe_title, body=body)
 
 
 def _json_sources(result: PipelineResult) -> list[dict[str, str]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "feedparser",
   "httpx",
   "mcp",
+  "markdown",
   "paper-search-mcp",
   "pydantic",
   "pytest",

--- a/tests/unit/test_cli_interactive_prompt.py
+++ b/tests/unit/test_cli_interactive_prompt.py
@@ -1,0 +1,171 @@
+# Self-written for F102 CLI interactive prompt flow
+import json
+
+import click.testing
+from typer.testing import CliRunner
+
+from autosearch.cli.main import app
+from autosearch.core.models import (
+    ClarifyResult,
+    EvaluationResult,
+    GradeOutcome,
+    SearchMode,
+)
+from autosearch.core.pipeline import PipelineResult
+
+runner = CliRunner()
+
+
+def _ok_result() -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown="# Test\n\nBody",
+        quality=EvaluationResult(
+            grade=GradeOutcome.PASS,
+            follow_up_gaps=[],
+        ),
+        iterations=1,
+    )
+
+
+def _install_cli_spy(monkeypatch, pipeline_result: PipelineResult) -> list[SearchMode | None]:
+    import autosearch.cli.main as cli_main
+
+    calls: list[SearchMode | None] = []
+
+    class StubPipeline:
+        def __init__(self, llm, channels, top_k_evidence: int, on_event=None) -> None:
+            self.llm = llm
+            self.channels = channels
+            self.top_k_evidence = top_k_evidence
+            self.on_event = on_event
+
+        async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+            _ = query
+            calls.append(mode_hint)
+            return pipeline_result
+
+    monkeypatch.setattr(cli_main, "Pipeline", StubPipeline)
+    monkeypatch.setattr(cli_main, "LLMClient", lambda: object())
+    monkeypatch.setattr(cli_main, "_build_channels", lambda: [object()])
+
+    return calls
+
+
+def _set_tty(monkeypatch, value: bool) -> None:
+    monkeypatch.setattr(click.testing._NamedTextIOWrapper, "isatty", lambda self: value)
+
+
+def test_interactive_prompts_for_missing_fields(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+    _set_tty(monkeypatch, True)
+
+    import autosearch.cli.main as cli_main
+
+    prompts: list[str] = []
+    answers = iter(["mixed", "comprehensive", "html"])
+
+    def fake_prompt(text: str) -> str:
+        prompts.append(text)
+        return next(answers)
+
+    monkeypatch.setattr(cli_main.typer, "prompt", fake_prompt)
+
+    result = runner.invoke(app, ["query", "test", "--interactive", "--json"])
+
+    assert result.exit_code == 0
+    assert len(prompts) == 3
+    assert calls == [SearchMode.COMPREHENSIVE]
+    assert json.loads(result.stdout)["scope"] == {
+        "channel_scope": "mixed",
+        "depth": "comprehensive",
+        "output_format": "html",
+    }
+
+
+def test_interactive_accepts_index_or_value(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+    _set_tty(monkeypatch, True)
+
+    import autosearch.cli.main as cli_main
+
+    answers = iter(["zh_only", "2", "2"])
+    monkeypatch.setattr(cli_main.typer, "prompt", lambda text: next(answers))
+
+    result = runner.invoke(app, ["query", "test", "--interactive", "--json"])
+
+    assert result.exit_code == 0
+    assert calls == [SearchMode.DEEP]
+    assert json.loads(result.stdout)["scope"] == {
+        "channel_scope": "zh_only",
+        "depth": "deep",
+        "output_format": "html",
+    }
+
+
+def test_interactive_rejects_invalid_answer_three_times_then_exits(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+    _set_tty(monkeypatch, True)
+
+    import autosearch.cli.main as cli_main
+
+    answers = iter(["bogus", "bogus", "bogus"])
+    monkeypatch.setattr(cli_main.typer, "prompt", lambda text: next(answers))
+
+    result = runner.invoke(app, ["query", "test", "--interactive", "--json"])
+
+    assert result.exit_code == 2
+    assert calls == []
+
+
+def test_interactive_skipped_when_not_tty(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+    _set_tty(monkeypatch, False)
+
+    import autosearch.cli.main as cli_main
+
+    monkeypatch.setattr(
+        cli_main.typer,
+        "prompt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("prompt should not run")),
+    )
+
+    result = runner.invoke(app, ["query", "test", "--json"])
+
+    assert result.exit_code == 0
+    assert calls == [SearchMode.FAST]
+    assert json.loads(result.stdout)["scope"] == {
+        "channel_scope": "all",
+        "depth": "fast",
+        "output_format": "md",
+    }
+
+
+def test_interactive_skipped_in_json_mode(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+    _set_tty(monkeypatch, True)
+
+    import autosearch.cli.main as cli_main
+
+    monkeypatch.setattr(
+        cli_main.typer,
+        "prompt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("prompt should not run")),
+    )
+
+    result = runner.invoke(app, ["query", "test", "--json"])
+
+    assert result.exit_code == 0
+    assert calls == [SearchMode.FAST]
+    assert json.loads(result.stdout)["scope"] == {
+        "channel_scope": "all",
+        "depth": "fast",
+        "output_format": "md",
+    }

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -129,6 +129,11 @@ def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
         "iterations": 2,
         "quality_grade": "pass",
         "sources": [],
+        "scope": {
+            "channel_scope": "all",
+            "depth": "fast",
+            "output_format": "md",
+        },
     }
 
 

--- a/tests/unit/test_cli_scope_flags.py
+++ b/tests/unit/test_cli_scope_flags.py
@@ -1,0 +1,206 @@
+# Self-written for F102 CLI scope flags
+import json
+
+import click.testing
+from typer.testing import CliRunner
+
+from autosearch.cli.main import app
+from autosearch.core.models import (
+    ClarifyResult,
+    EvaluationResult,
+    GradeOutcome,
+    SearchMode,
+)
+from autosearch.core.pipeline import PipelineResult
+
+runner = CliRunner()
+
+
+def _ok_result(markdown: str = "# Test\n\nBody") -> PipelineResult:
+    return PipelineResult(
+        status="ok",
+        clarification=ClarifyResult(
+            need_clarification=False,
+            question=None,
+            verification="Enough information to proceed.",
+            rubrics=[],
+            mode=SearchMode.FAST,
+        ),
+        markdown=markdown,
+        quality=EvaluationResult(
+            grade=GradeOutcome.PASS,
+            follow_up_gaps=[],
+        ),
+        iterations=2,
+    )
+
+
+def _install_cli_spy(monkeypatch, pipeline_result: PipelineResult) -> list[dict[str, object]]:
+    import autosearch.cli.main as cli_main
+
+    calls: list[dict[str, object]] = []
+
+    class StubPipeline:
+        def __init__(self, llm, channels, top_k_evidence: int, on_event=None) -> None:
+            self.llm = llm
+            self.channels = channels
+            self.top_k_evidence = top_k_evidence
+            self.on_event = on_event
+
+        async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+            calls.append(
+                {
+                    "query": query,
+                    "mode_hint": mode_hint,
+                    "top_k_evidence": self.top_k_evidence,
+                }
+            )
+            return pipeline_result
+
+    monkeypatch.setattr(cli_main, "Pipeline", StubPipeline)
+    monkeypatch.setattr(cli_main, "LLMClient", lambda: object())
+    monkeypatch.setattr(cli_main, "_build_channels", lambda: [object()])
+
+    return calls
+
+
+def _set_tty(monkeypatch, value: bool) -> None:
+    monkeypatch.setattr(click.testing._NamedTextIOWrapper, "isatty", lambda self: value)
+
+
+def test_query_accepts_all_new_flags_noninteractive(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+
+    result = runner.invoke(
+        app,
+        [
+            "query",
+            "test",
+            "--languages",
+            "MIXED",
+            "--depth",
+            "DEEP",
+            "--format",
+            "HTML",
+            "--no-interactive",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "query": "test",
+            "mode_hint": SearchMode.DEEP,
+            "top_k_evidence": 20,
+        }
+    ]
+    assert json.loads(result.stdout)["scope"] == {
+        "channel_scope": "mixed",
+        "depth": "deep",
+        "output_format": "html",
+    }
+
+
+def test_query_depth_maps_to_search_mode_comprehensive(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+
+    result = runner.invoke(
+        app,
+        ["query", "test", "--depth", "comprehensive", "--no-stream"],
+    )
+
+    assert result.exit_code == 0
+    assert calls[0]["mode_hint"] is SearchMode.COMPREHENSIVE
+
+
+def test_query_mode_and_depth_conflict_depth_wins(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+
+    result = runner.invoke(
+        app,
+        [
+            "query",
+            "test",
+            "--mode",
+            "fast",
+            "--depth",
+            "comprehensive",
+            "--no-stream",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls[0]["mode_hint"] is SearchMode.COMPREHENSIVE
+    assert "--mode ignored because --depth was also provided" in result.stderr
+
+
+def test_query_invalid_depth_is_bad_parameter() -> None:
+    result = runner.invoke(app, ["query", "test", "--depth", "bogus"])
+
+    assert result.exit_code == 2
+    assert "Error" in result.stderr
+
+
+def test_query_invalid_languages_is_bad_parameter() -> None:
+    result = runner.invoke(app, ["query", "test", "--languages", "bogus"])
+
+    assert result.exit_code == 2
+    assert "channel_scope" in result.stderr
+
+
+def test_query_format_html_renders_html_output(monkeypatch) -> None:
+    markdown = "# Report\n\n| A | B |\n| - | - |\n| 1 | 2 |\n\n```python\nprint('hello')\n```\n"
+    _install_cli_spy(monkeypatch, _ok_result(markdown=markdown))
+
+    result = runner.invoke(
+        app,
+        ["query", "html-test", "--format", "html", "--no-stream"],
+    )
+
+    assert result.exit_code == 0
+    assert "<!doctype html>" in result.stdout
+    assert "<title>html-test</title>" in result.stdout
+    assert "<article>" in result.stdout
+    assert "<table>" in result.stdout
+    assert "<pre><code" in result.stdout
+
+
+def test_query_format_md_passes_through(monkeypatch) -> None:
+    markdown = "# Test\n\nBody"
+    _install_cli_spy(monkeypatch, _ok_result(markdown=markdown))
+
+    result = runner.invoke(
+        app,
+        ["query", "md-test", "--format", "md", "--no-stream"],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == f"{markdown}\n"
+    assert "<!doctype html>" not in result.stdout
+
+
+def test_query_interactive_false_skips_prompt_even_in_tty(monkeypatch) -> None:
+    calls = _install_cli_spy(monkeypatch, _ok_result())
+    _set_tty(monkeypatch, True)
+
+    import autosearch.cli.main as cli_main
+
+    monkeypatch.setattr(
+        cli_main.typer,
+        "prompt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("prompt should not run")),
+    )
+
+    result = runner.invoke(
+        app,
+        ["query", "test", "--depth", "deep", "--no-interactive", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert calls[0]["mode_hint"] is SearchMode.DEEP
+    assert json.loads(result.stdout)["scope"] == {
+        "channel_scope": "all",
+        "depth": "deep",
+        "output_format": "md",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -86,6 +86,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "httpx" },
+    { name = "markdown" },
     { name = "mcp" },
     { name = "paper-search-mcp" },
     { name = "pydantic" },
@@ -109,6 +110,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "httpx" },
+    { name = "markdown" },
     { name = "mcp" },
     { name = "paper-search-mcp" },
     { name = "pydantic" },
@@ -899,6 +901,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/a4/5c62acfacd69ff4f5db395100f5cfb9b54e7ac8c69a235e4e939fd13f021/lxml_html_clean-0.4.4.tar.gz", hash = "sha256:58f39a9d632711202ed1d6d0b9b47a904e306c85de5761543b90e3e3f736acfb", size = 23899, upload-time = "2026-02-27T09:35:52.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/76/7ffc1d3005cf7749123bc47cb3ea343cd97b0ac2211bab40f57283577d0e/lxml_html_clean-0.4.4-py3-none-any.whl", hash = "sha256:ce2ef506614ecb85ee1c5fe0a2aa45b06a19514ec7949e9c8f34f06925cfabcb", size = 14565, upload-time = "2026-02-27T09:35:51.86Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wave F phase 2 — CLI wiring for M0.5 scope clarification. `autosearch query` now accepts `--languages`, `--depth`, `--format`, `--interactive`, runs `ScopeClarifier` when TTY detects missing flags, and converts M7 markdown → HTML when `--format html`.

No pipeline surgery yet — scope values are consumed at CLI level only. F103 will push scope into Pipeline/API/MCP.

## What F102 ships

| Flag | Type | Default | Behavior |
|---|---|---|---|
| `--languages` | `all` / `en_only` / `zh_only` / `mixed` | None (unset) | Captured + serialized into JSON envelope's `scope` field. Channel filtering by language is future pipeline work. |
| `--depth` | `fast` / `deep` / `comprehensive` | None | Maps to `SearchMode`. If both `--mode` and `--depth` passed, `--depth` wins + stderr warn. |
| `--format` | `md` / `html` | None (=md) | `html` lazy-imports `markdown` lib and wraps in minimal HTML5 doc. |
| `--interactive` | bool (nullable) | None (= auto) | Auto = prompt only when stdin+stdout are TTY and not JSON mode. |

## Clarifier flow

1. Build `provided = {field: value if user passed flag else None}`.
2. Decide `should_prompt` per `--interactive` + TTY + `--json` rules.
3. If prompting: `ScopeClarifier().questions_for(provided)` → `typer.prompt` each with index-or-value accept, 3-retry abort.
4. Merge via `ScopeClarifier.apply_answers(SearchScope(), {...non_none, **answers})`.

## Commits (4)

1. `chore(deps)` — add `markdown` to pyproject.
2. `feat(cli)` — CLI flag plumbing + `ScopeClarifier` invocation + `_render_html()` helper (+182 / −3 on `autosearch/cli/main.py`).
3. `test(cli)` — 13 new cases across two new test files + update existing `test_cli_query` for the `scope` field in JSON envelope.
4. `chore(deps)` — sync `uv.lock` (+11 lines).

## Test plan

- [x] 296 tests pass (283 prior + 13 new: 8 scope-flag + 5 interactive)
- [x] `ruff check` + `ruff format --check` clean
- [x] New runtime dep `markdown` (~5 KB) — for html output only, lazy-imported
- [x] Existing CLI flags (`--mode`, `--top-k`, `--json`, `--stream/--no-stream`) unchanged
- [x] `--mode` / `--depth` precedence verified in test

## Design notes

- `typer.prompt` mocking under `CliRunner` required patching at the `autosearch.cli.main` module scope rather than process-wide `sys.stdin`, since CliRunner substitutes stdio.
- `_render_html()` lazy-imports `markdown` so CLI startup isn't slowed when html output isn't requested.
- `channel_scope` is currently accepted but not wired to channel filtering — that's Pipeline surgery deferred to a later PR (need a channel language-filter pass in M3).

## Next

- F103: API (`/search` SSE `scope_needed` event + `/v1/chat/completions` metadata) + MCP `research` tool param.