### PR TITLE
feat(docs+init): channel status table and auto-generated README (F206 Wave G part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,46 @@ AutoSearch runs as:
 - **MCP server**: `autosearch mcp` (or `autosearch-mcp` console script) — exposes a `research` tool to Claude Code, Cursor, and other MCP clients
 - **Claude Code slash command**: `/autosearch` (ships in `commands/autosearch.md`)
 
-## Channels
+## Supported Channels
 
-v2 currently ships `DemoChannel` as a placeholder. Real channel adapters (arxiv, GitHub, HackerNews, Reddit, StackOverflow, YouTube, ProductHunt, DDGS, Semantic Scholar, HuggingFace, npm/PyPI — plus 中文 sources: 小红书 / B 站 / 微信 / 知乎 / 抖音 / 微博) are on the roadmap. See plan roadmap in `docs/delivery-status.md`.
+Generated from `skills/channels/*/SKILL.md`. Run `.venv/bin/python scripts/generate_channels_table.py` after adding or changing a channel.
+
+<!-- channels-table-start -->
+### Tier 0 - always-on (12)
+| Channel | Languages | Description | Typical yield |
+|---|---|---|---|
+| arxiv | en | Use for academic preprint searches in CS/ML/physics when query is English or mixed and expects peer-reviewed or preprint papers. | medium-high |
+| ddgs | en, mixed | DuckDuckGo Search — free general web search with no auth, use as broad default for any English or mixed query. | medium |
+| devto | en, mixed | Developer blog articles tagged by technology topic, via the public dev.to API. | medium |
+| github | en | Use for code-level, issue-level, and repository discovery when query involves a library, framework, or implementation detail. | high |
+| google_news | en, mixed | Current news headlines aggregated across publishers via Google News RSS (English US feed). | high |
+| hackernews | en | Use for real-time developer discussion, tooling opinions, and early-stage product signals from the HN community. | medium-high |
+| package_search | en, mixed | Discover packages across PyPI (exact-name lookup) and npm (full-text search) registries. | medium |
+| papers | en, mixed | Multi-source academic paper search (arxiv, pubmed, biorxiv, medrxiv, google_scholar) via paper-search-mcp. | high |
+| reddit | en, mixed | Reddit community discussions, user experience reports, and topic debates via the public search.json endpoint. | medium |
+| stackoverflow | en, mixed | Programming Q&A with community-voted answers across 200+ technical tags via api.stackexchange.com. | high |
+| wikidata | en, mixed | Structured entity data (people, places, concepts) from Wikidata knowledge graph. | medium |
+| wikipedia | en, mixed | Authoritative encyclopedia articles via the Wikipedia Action API (English edition). | high |
+
+### Tier 1 - env-gated (1)
+| Channel | Languages | Required env | Description | Typical yield |
+|---|---|---|---|---|
+| youtube | en, zh, mixed | env:YOUTUBE_API_KEY | Use for video tutorial discovery, conference talks, technical walkthroughs, and product demos. | medium |
+
+### Tier 2 - BYOK paid (5)
+| Channel | Languages | Required env | Description | Typical yield |
+|---|---|---|---|---|
+| bilibili | zh, mixed | env:TIKHUB_API_KEY | Chinese tech video platform with tutorials, conference recordings, and uploader-authored articles, via TikHub. | medium |
+| douyin | zh | env:TIKHUB_API_KEY | Chinese short-video content with product demos, tech reviews, and viral trends, via TikHub. | medium |
+| twitter | en, mixed | env:TIKHUB_API_KEY | Real-time public discourse including product launches, tech announcements, and breaking news, via TikHub. | medium |
+| xiaohongshu | zh, mixed | env:TIKHUB_API_KEY | Chinese lifestyle + experience-sharing notes with strong product/beauty/travel/food coverage, via TikHub. | high |
+| zhihu | zh, mixed | env:TIKHUB_API_KEY | Chinese Q&A platform with deep technical discussions and user experience reports — use when query is Chinese or mixed and targets developer opinions, comparisons, or tutorials. | medium-high |
+
+### Scaffold-only (channel templates not shipped) (1)
+| Channel | Languages | Description | Typical yield |
+|---|---|---|---|
+| weibo | zh, mixed | Chinese microblog platform for real-time opinion, trending topics, and event-level commentary in Chinese discourse. | medium |
+<!-- channels-table-end -->
 
 ## Contributing
 

--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -179,7 +179,13 @@ class ChannelRegistry:
         self._health: ChannelHealth | None = None
 
     @classmethod
-    def compile_from_skills(cls, channels_root: Path, env: Environment) -> Self:
+    def compile_from_skills(
+        cls,
+        channels_root: Path,
+        env: Environment,
+        *,
+        log_missing_impls: bool = True,
+    ) -> Self:
         registry = cls()
         for skill in load_all(channels_root):
             methods = [
@@ -188,6 +194,7 @@ class ChannelRegistry:
                     skill_dir=skill.skill_dir,
                     method=method,
                     env=env,
+                    log_missing_impls=log_missing_impls,
                 )
                 for method in skill.methods
             ]
@@ -212,15 +219,17 @@ class ChannelRegistry:
         skill_dir: Path,
         method: MethodSpec,
         env: Environment,
+        log_missing_impls: bool,
     ) -> CompiledMethod:
         impl_path = skill_dir / method.impl
         if not impl_path.is_file():
-            LOGGER.info(
-                "channel_method_impl_missing",
-                channel=channel_name,
-                method=method.id,
-                impl=str(impl_path),
-            )
+            if log_missing_impls:
+                LOGGER.info(
+                    "channel_method_impl_missing",
+                    channel=channel_name,
+                    method=method.id,
+                    impl=str(impl_path),
+                )
             return CompiledMethod(
                 id=method.id,
                 skill_method=method,

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -11,10 +11,18 @@ from pydantic import ValidationError
 
 from autosearch import __version__
 from autosearch.core.channel_bootstrap import _build_channels
+from autosearch.core.environment_probe import probe_environment
 from autosearch.core.models import SearchMode
 from autosearch.core.pipeline import Pipeline, PipelineResult
 from autosearch.core.scope_clarifier import ScopeClarifier
 from autosearch.core.search_scope import ScopeQuestion, SearchScope, depth_to_mode
+from autosearch.init.channel_status import (
+    TIER_LABELS,
+    TIER_ORDER,
+    ChannelStatus,
+    compile_channel_statuses,
+    default_channels_root,
+)
 from autosearch.init_runner import InitError, InitRunner
 from autosearch.llm.client import LLMClient
 
@@ -189,6 +197,13 @@ def mcp() -> None:
 
 @app.command()
 def init(
+    check_channels: Annotated[
+        bool,
+        typer.Option(
+            "--check-channels",
+            help="Print a tier-grouped status table of all available channels.",
+        ),
+    ] = False,
     overwrite: Annotated[
         bool,
         typer.Option(
@@ -197,6 +212,10 @@ def init(
         ),
     ] = False,
 ) -> None:
+    if check_channels:
+        _print_channel_check()
+        return
+
     runner = InitRunner()
     config_exists = runner.config_path().exists()
     action = "merged" if config_exists and not overwrite else "created"
@@ -225,6 +244,58 @@ def init(
     typer.echo("Next steps:")
     for step in result.next_steps:
         typer.echo(f"- {step}")
+
+
+def _print_channel_check() -> None:
+    channels_root = default_channels_root()
+    if not channels_root.is_dir():
+        typer.echo(f"Channel skills root missing: {channels_root}", err=True)
+        raise typer.Exit(code=1)
+
+    rows = compile_channel_statuses(channels_root, probe_environment())
+    grouped: dict[str, list[ChannelStatus]] = {tier: [] for tier in TIER_ORDER}
+    totals = {"available": 0, "blocked": 0, "scaffold-only": 0}
+    for row in rows:
+        grouped[row.tier].append(row)
+        totals[row.status] += 1
+
+    for tier in TIER_ORDER:
+        typer.echo(f"{TIER_LABELS[tier]} ({len(grouped[tier])})")
+        for row in grouped[tier]:
+            symbol = _channel_status_symbol(row)
+            typer.echo(f"  {symbol} {row.channel:<18}", nl=False)
+            typer.secho(f"{row.status:<14}", fg=_channel_status_color(row.status), nl=False)
+            if row.unmet_requires:
+                typer.echo(f" {', '.join(row.unmet_requires)}")
+            else:
+                typer.echo()
+        typer.echo()
+
+    typer.echo(
+        "Total: "
+        f"{len(rows)} channels | "
+        f"{totals['available']} available | "
+        f"{totals['blocked']} blocked | "
+        f"{totals['scaffold-only']} scaffold-only"
+    )
+
+
+def _channel_status_color(status: str) -> str | None:
+    if status == "available":
+        return typer.colors.GREEN
+    if status == "blocked":
+        return typer.colors.RED
+    if status == "scaffold-only":
+        return typer.colors.YELLOW
+    return None
+
+
+def _channel_status_symbol(row: ChannelStatus) -> str:
+    if row.status == "available":
+        return "✓"
+    if row.status == "blocked":
+        return "✗"
+    return "·"
 
 
 @app.command()

--- a/autosearch/init/__init__.py
+++ b/autosearch/init/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for `autosearch init` workflows."""

--- a/autosearch/init/channel_status.py
+++ b/autosearch/init/channel_status.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from autosearch.channels.base import ChannelMetadata, ChannelRegistry, CompiledMethod, Environment
+
+Tier = Literal["t0", "t1", "t2", "scaffold"]
+Status = Literal["available", "blocked", "scaffold-only"]
+
+TIER_ORDER: tuple[Tier, ...] = ("t0", "t1", "t2", "scaffold")
+TIER_LABELS: dict[Tier, str] = {
+    "t0": "Tier 0 - always-on",
+    "t1": "Tier 1 - env-gated",
+    "t2": "Tier 2 - BYOK paid",
+    "scaffold": "Scaffold-only (channel templates not shipped)",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelStatus:
+    channel: str
+    tier: Tier
+    status: Status
+    unmet_requires: list[str]
+
+
+def default_channels_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "skills" / "channels"
+
+
+def infer_tier(metadata: ChannelMetadata) -> Tier:
+    """Return the visibility tier for a channel based on shipped methods."""
+
+    return infer_tier_from_requires(
+        [method.skill_method.requires for method in shipped_methods(metadata)]
+    )
+
+
+def shipped_methods(metadata: ChannelMetadata) -> list[CompiledMethod]:
+    return [method for method in metadata.methods if "impl_missing" not in method.unmet_requires]
+
+
+def summarize_registry(registry: ChannelRegistry) -> list[ChannelStatus]:
+    rows: list[ChannelStatus] = []
+    for channel in sorted(registry.all_channels(), key=lambda item: item.name):
+        metadata = registry.metadata(channel.name)
+        tier = infer_tier(metadata)
+        if tier == "scaffold":
+            rows.append(
+                ChannelStatus(
+                    channel=metadata.name,
+                    tier=tier,
+                    status="scaffold-only",
+                    unmet_requires=[],
+                )
+            )
+            continue
+
+        available = any(method.available for method in shipped_methods(metadata))
+        rows.append(
+            ChannelStatus(
+                channel=metadata.name,
+                tier=tier,
+                status="available" if available else "blocked",
+                unmet_requires=[] if available else blocked_requires(metadata),
+            )
+        )
+    return rows
+
+
+def compile_channel_statuses(channels_root: Path, env: Environment) -> list[ChannelStatus]:
+    registry = ChannelRegistry.compile_from_skills(channels_root, env, log_missing_impls=False)
+    return summarize_registry(registry)
+
+
+def blocked_requires(metadata: ChannelMetadata) -> list[str]:
+    requires = {
+        token
+        for method in shipped_methods(metadata)
+        for token in method.unmet_requires
+        if token != "impl_missing"
+    }
+    return sorted(requires)
+
+
+def required_env_tokens(metadata: ChannelMetadata) -> list[str]:
+    return required_env_tokens_from_requires(
+        [method.skill_method.requires for method in shipped_methods(metadata)]
+    )
+
+
+def infer_tier_from_requires(requires_by_method: list[list[str]]) -> Tier:
+    if not requires_by_method:
+        return "scaffold"
+    if any(not requires for requires in requires_by_method):
+        return "t0"
+    if any("env:TIKHUB_API_KEY" in requires for requires in requires_by_method):
+        return "t2"
+    return "t1"
+
+
+def required_env_tokens_from_requires(requires_by_method: list[list[str]]) -> list[str]:
+    return sorted(
+        {token for requires in requires_by_method for token in requires if token.startswith("env:")}
+    )

--- a/scripts/generate_channels_table.py
+++ b/scripts/generate_channels_table.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Regenerate the 'Supported Channels' table in README.md from skills/channels/*/SKILL.md."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from autosearch.init.channel_status import (
+    TIER_LABELS,
+    infer_tier_from_requires,
+    required_env_tokens_from_requires,
+)
+
+START_MARKER = "<!-- channels-table-start -->"
+END_MARKER = "<!-- channels-table-end -->"
+TIER_ORDER = ("t0", "t1", "t2", "scaffold")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CHANNELS_ROOT = REPO_ROOT / "skills" / "channels"
+DEFAULT_README_PATH = REPO_ROOT / "README.md"
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelDocRow:
+    name: str
+    description: str
+    languages: list[str]
+    required_env: list[str]
+    typical_yield: str
+    tier: str
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog="Run this after adding or changing a channel skill to keep README.md in sync.",
+    )
+    parser.add_argument(
+        "--channels-root",
+        type=Path,
+        default=DEFAULT_CHANNELS_ROOT,
+        help="Path to the channel skills root. Defaults to skills/channels in this repo.",
+    )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=DEFAULT_README_PATH,
+        help="Path to the README to update. Defaults to this repo's README.md.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if README.md differs from the generated channel tables.",
+    )
+    return parser.parse_args(argv)
+
+
+def extract_frontmatter(raw_text: str) -> dict[str, Any]:
+    lines = raw_text.splitlines()
+    try:
+        start = next(index for index, line in enumerate(lines) if line.strip() == "---")
+        end = next(index for index in range(start + 1, len(lines)) if lines[index].strip() == "---")
+    except StopIteration as exc:
+        raise ValueError("frontmatter delimiters not found") from exc
+
+    payload = yaml.safe_load("\n".join(lines[start + 1 : end]).strip())
+    if not isinstance(payload, dict):
+        raise ValueError("frontmatter must be a YAML mapping")
+    return payload
+
+
+def load_channel_rows(channels_root: Path) -> list[ChannelDocRow]:
+    rows: list[ChannelDocRow] = []
+
+    for skill_path in sorted(channels_root.glob("*/SKILL.md")):
+        payload = extract_frontmatter(skill_path.read_text(encoding="utf-8"))
+        name = str(payload["name"])
+        quality_hint = payload.get("quality_hint")
+        typical_yield = "unknown"
+        if isinstance(quality_hint, dict):
+            typical_yield = str(quality_hint.get("typical_yield", "unknown"))
+
+        requires_by_method = shipped_method_requires(payload, skill_path.parent)
+        rows.append(
+            ChannelDocRow(
+                name=name,
+                description=str(payload.get("description", "")).strip(),
+                languages=[str(language) for language in payload.get("languages", [])],
+                required_env=required_env_tokens_from_requires(requires_by_method),
+                typical_yield=typical_yield,
+                tier=infer_tier_from_requires(requires_by_method),
+            )
+        )
+
+    return rows
+
+
+def render_supported_channels(channels_root: Path) -> str:
+    rows = load_channel_rows(channels_root)
+    grouped = {tier: [row for row in rows if row.tier == tier] for tier in TIER_ORDER}
+
+    lines: list[str] = []
+    for tier in ("t0", "t1", "t2"):
+        lines.extend(_render_tier(grouped[tier], tier=tier))
+        lines.append("")
+
+    if grouped["scaffold"]:
+        lines.extend(_render_tier(grouped["scaffold"], tier="scaffold"))
+        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def replace_marked_section(readme_text: str, generated_section: str) -> str:
+    start_index = readme_text.find(START_MARKER)
+    end_index = readme_text.find(END_MARKER)
+    if start_index == -1 or end_index == -1 or end_index < start_index:
+        raise ValueError("markers not found")
+    prefix = readme_text[:start_index]
+    suffix = readme_text[end_index + len(END_MARKER) :]
+    replacement = f"{START_MARKER}\n{generated_section}\n{END_MARKER}"
+    return prefix + replacement + suffix
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        readme_text = args.readme.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"ERROR: failed to read README: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        generated = render_supported_channels(args.channels_root)
+        updated = replace_marked_section(readme_text, generated)
+    except ValueError as exc:
+        if str(exc) == "markers not found":
+            print("ERROR: markers not found", file=sys.stderr)
+            return 1
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if updated != readme_text:
+            print("ERROR: README.md is out of date", file=sys.stderr)
+            return 1
+        return 0
+
+    if updated != readme_text:
+        args.readme.write_text(updated, encoding="utf-8")
+    return 0
+
+
+def _render_tier(rows: list[ChannelDocRow], *, tier: str) -> list[str]:
+    lines = [f"### {TIER_LABELS[tier]} ({len(rows)})"]
+    if tier in {"t1", "t2"}:
+        lines.extend(
+            [
+                "| Channel | Languages | Required env | Description | Typical yield |",
+                "|---|---|---|---|---|",
+            ]
+        )
+        for row in rows:
+            lines.append(
+                "| "
+                f"{escape_cell(row.name)} | "
+                f"{escape_cell(format_list(row.languages))} | "
+                f"{escape_cell(format_list(row.required_env))} | "
+                f"{escape_cell(row.description)} | "
+                f"{escape_cell(row.typical_yield)} |"
+            )
+        return lines
+
+    lines.extend(
+        [
+            "| Channel | Languages | Description | Typical yield |",
+            "|---|---|---|---|",
+        ]
+    )
+    for row in rows:
+        lines.append(
+            "| "
+            f"{escape_cell(row.name)} | "
+            f"{escape_cell(format_list(row.languages))} | "
+            f"{escape_cell(row.description)} | "
+            f"{escape_cell(row.typical_yield)} |"
+        )
+    return lines
+
+
+def escape_cell(value: str) -> str:
+    return re.sub(r"\s+", " ", value.replace("|", "\\|")).strip() or "-"
+
+
+def format_list(values: list[str]) -> str:
+    return ", ".join(values) if values else "-"
+
+
+def shipped_method_requires(payload: dict[str, Any], skill_dir: Path) -> list[list[str]]:
+    methods = payload.get("methods", [])
+    if not isinstance(methods, list):
+        raise ValueError("methods must be a list")
+
+    requires_by_method: list[list[str]] = []
+    for method in methods:
+        if not isinstance(method, dict):
+            raise ValueError("each method must be a mapping")
+        impl = method.get("impl")
+        if not isinstance(impl, str):
+            raise ValueError("method impl must be a string")
+        if not (skill_dir / impl).is_file():
+            continue
+        requires = method.get("requires", [])
+        if not isinstance(requires, list):
+            raise ValueError("method requires must be a list")
+        requires_by_method.append([str(token) for token in requires])
+
+    return requires_by_method
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_channel_status.py
+++ b/tests/unit/test_channel_status.py
@@ -1,0 +1,218 @@
+# Self-written for task F206 Wave G phase 1.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import autosearch.cli.main as cli_main
+from autosearch.channels.base import ChannelMetadata, CompiledMethod, Environment
+from autosearch.cli.main import app
+from autosearch.init.channel_status import infer_tier, summarize_registry
+from autosearch.skills.loader import MethodSpec
+
+runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
+
+
+async def _search_stub(*_: object) -> list[object]:
+    return []
+
+
+def _method(
+    *,
+    method_id: str,
+    requires: list[str],
+    available: bool,
+    unmet_requires: list[str],
+) -> CompiledMethod:
+    return CompiledMethod(
+        id=method_id,
+        skill_method=MethodSpec(id=method_id, impl=f"methods/{method_id}.py", requires=requires),
+        callable=_search_stub,
+        available=available,
+        unmet_requires=unmet_requires,
+    )
+
+
+def _metadata(name: str, *methods: CompiledMethod) -> ChannelMetadata:
+    return ChannelMetadata(
+        name=name,
+        description=f"{name} description",
+        languages=["en"],
+        when_to_use=None,
+        quality_hint=None,
+        methods=list(methods),
+        fallback_chain=[method.id for method in methods],
+    )
+
+
+class _StubChannel:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def search(self, *_: object) -> list[object]:
+        return []
+
+
+class _StubRegistry:
+    def __init__(self, metadata: dict[str, ChannelMetadata]) -> None:
+        self._metadata = metadata
+
+    def all_channels(self) -> list[_StubChannel]:
+        return [_StubChannel(name) for name in sorted(self._metadata)]
+
+    def metadata(self, name: str) -> ChannelMetadata:
+        return self._metadata[name]
+
+
+def test_infer_tier_t0_when_shipped_no_requires() -> None:
+    metadata = _metadata(
+        "ddgs",
+        _method(method_id="text_search", requires=[], available=True, unmet_requires=[]),
+    )
+
+    assert infer_tier(metadata) == "t0"
+
+
+def test_infer_tier_t2_when_tikhub_required() -> None:
+    metadata = _metadata(
+        "zhihu",
+        _method(
+            method_id="via_tikhub",
+            requires=["env:TIKHUB_API_KEY"],
+            available=False,
+            unmet_requires=["env:TIKHUB_API_KEY"],
+        ),
+        _method(
+            method_id="api_search",
+            requires=[],
+            available=False,
+            unmet_requires=["impl_missing"],
+        ),
+    )
+
+    assert infer_tier(metadata) == "t2"
+
+
+def test_infer_tier_t1_when_env_required_not_tikhub() -> None:
+    metadata = _metadata(
+        "youtube",
+        _method(
+            method_id="data_api_search",
+            requires=["env:YOUTUBE_API_KEY"],
+            available=False,
+            unmet_requires=["env:YOUTUBE_API_KEY"],
+        ),
+    )
+
+    assert infer_tier(metadata) == "t1"
+
+
+def test_infer_tier_scaffold_when_all_methods_impl_missing() -> None:
+    metadata = _metadata(
+        "future_channel",
+        _method(
+            method_id="planned",
+            requires=[],
+            available=False,
+            unmet_requires=["impl_missing"],
+        ),
+    )
+
+    assert infer_tier(metadata) == "scaffold"
+
+
+def test_check_channels_command_groups_by_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = _StubRegistry(
+        {
+            "always_on": _metadata(
+                "always_on",
+                _method(method_id="free", requires=[], available=True, unmet_requires=[]),
+            ),
+            "env_only": _metadata(
+                "env_only",
+                _method(
+                    method_id="api",
+                    requires=["env:YOUTUBE_API_KEY"],
+                    available=False,
+                    unmet_requires=["env:YOUTUBE_API_KEY"],
+                ),
+            ),
+            "paid": _metadata(
+                "paid",
+                _method(
+                    method_id="via_tikhub",
+                    requires=["env:TIKHUB_API_KEY"],
+                    available=False,
+                    unmet_requires=["env:TIKHUB_API_KEY"],
+                ),
+            ),
+            "future": _metadata(
+                "future",
+                _method(
+                    method_id="planned",
+                    requires=[],
+                    available=False,
+                    unmet_requires=["impl_missing"],
+                ),
+            ),
+        }
+    )
+
+    monkeypatch.setattr(cli_main, "default_channels_root", lambda: Path("."))
+    monkeypatch.setattr(cli_main, "probe_environment", lambda: Environment())
+    monkeypatch.setattr(
+        cli_main,
+        "compile_channel_statuses",
+        lambda channels_root, env: summarize_registry(registry),
+    )
+
+    result = runner.invoke(app, ["init", "--check-channels"])
+
+    assert result.exit_code == 0
+    assert "Tier 0 - always-on (1)" in result.stdout
+    assert "Tier 1 - env-gated (1)" in result.stdout
+    assert "Tier 2 - BYOK paid (1)" in result.stdout
+    assert "Scaffold-only (channel templates not shipped) (1)" in result.stdout
+    assert "Total: 4 channels | 1 available | 2 blocked | 1 scaffold-only" in result.stdout
+
+
+def test_check_channels_shows_available_vs_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = _StubRegistry(
+        {
+            "github": _metadata(
+                "github",
+                _method(
+                    method_id="search_public_repos",
+                    requires=[],
+                    available=True,
+                    unmet_requires=[],
+                ),
+            ),
+            "anthropic_feed": _metadata(
+                "anthropic_feed",
+                _method(
+                    method_id="search",
+                    requires=["env:ANTHROPIC_API_KEY"],
+                    available=False,
+                    unmet_requires=["env:ANTHROPIC_API_KEY"],
+                ),
+            ),
+        }
+    )
+
+    monkeypatch.setattr(cli_main, "default_channels_root", lambda: Path("."))
+    monkeypatch.setattr(cli_main, "probe_environment", lambda: Environment())
+    monkeypatch.setattr(
+        cli_main,
+        "compile_channel_statuses",
+        lambda channels_root, env: summarize_registry(registry),
+    )
+
+    result = runner.invoke(app, ["init", "--check-channels"])
+
+    assert result.exit_code == 0
+    assert "github            available" in result.stdout
+    assert "anthropic_feed    blocked" in result.stdout
+    assert "env:ANTHROPIC_API_KEY" in result.stdout

--- a/tests/unit/test_generate_channels_table.py
+++ b/tests/unit/test_generate_channels_table.py
@@ -1,0 +1,228 @@
+# Self-written for task F206 Wave G phase 1.
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+
+def _load_script_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "generate_channels_table.py"
+    spec = importlib.util.spec_from_file_location("generate_channels_table", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_skill(
+    channels_root: Path,
+    *,
+    name: str,
+    description: str,
+    languages: list[str],
+    methods: list[dict[str, object]],
+    typical_yield: str = "medium",
+) -> None:
+    skill_dir = channels_root / name
+    (skill_dir / "methods").mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        "---",
+        f"name: {name}",
+        f'description: "{description}"',
+        "version: 1",
+        f"languages: [{', '.join(languages)}]",
+        "methods:",
+    ]
+    for method in methods:
+        requires = ", ".join(method.get("requires", []))
+        lines.extend(
+            [
+                f"  - id: {method['id']}",
+                f"    impl: {method['impl']}",
+                f"    requires: [{requires}]",
+            ]
+        )
+    lines.extend(
+        [
+            f"fallback_chain: [{', '.join(method['id'] for method in methods)}]",
+            "quality_hint:",
+            f"  typical_yield: {typical_yield}",
+            "  chinese_native: false",
+            "---",
+        ]
+    )
+    (skill_dir / "SKILL.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    for method in methods:
+        impl = skill_dir / str(method["impl"])
+        if method.get("shipped", True):
+            impl.write_text(
+                dedent(
+                    """
+                    from autosearch.core.models import Evidence, SubQuery
+
+
+                    async def search(query: SubQuery) -> list[Evidence]:
+                        return []
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+
+
+def test_generate_replaces_between_markers(tmp_path: Path) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    _write_skill(
+        channels_root,
+        name="ddgs",
+        description="Free web search",
+        languages=["en", "mixed"],
+        methods=[{"id": "text_search", "impl": "methods/api.py", "requires": []}],
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "# Demo\n\n<!-- channels-table-start -->\nold\n<!-- channels-table-end -->\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(["--channels-root", str(channels_root), "--readme", str(readme)])
+
+    assert exit_code == 0
+    rendered = readme.read_text(encoding="utf-8")
+    assert "### Tier 0 - always-on (1)" in rendered
+    assert "| ddgs | en, mixed | Free web search | medium |" in rendered
+    assert "old" not in rendered
+
+
+def test_generate_errors_when_markers_missing(tmp_path: Path, capsys) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    _write_skill(
+        channels_root,
+        name="ddgs",
+        description="Free web search",
+        languages=["en"],
+        methods=[{"id": "text_search", "impl": "methods/api.py", "requires": []}],
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text("# Demo\n", encoding="utf-8")
+
+    exit_code = module.main(["--channels-root", str(channels_root), "--readme", str(readme)])
+
+    assert exit_code == 1
+    assert "ERROR: markers not found" in capsys.readouterr().err
+
+
+def test_generate_check_mode_detects_drift(tmp_path: Path, capsys) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    _write_skill(
+        channels_root,
+        name="youtube",
+        description="Video search",
+        languages=["en"],
+        methods=[
+            {
+                "id": "data_api_search",
+                "impl": "methods/data_api.py",
+                "requires": ["env:YOUTUBE_API_KEY"],
+            }
+        ],
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "# Demo\n\n<!-- channels-table-start -->\nstale\n<!-- channels-table-end -->\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(
+        ["--channels-root", str(channels_root), "--readme", str(readme), "--check"]
+    )
+
+    assert exit_code == 1
+    assert "ERROR: README.md is out of date" in capsys.readouterr().err
+
+
+def test_generate_check_mode_passes_when_in_sync(tmp_path: Path) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    _write_skill(
+        channels_root,
+        name="ddgs",
+        description="Free web search",
+        languages=["en", "mixed"],
+        methods=[{"id": "text_search", "impl": "methods/api.py", "requires": []}],
+    )
+    generated = module.render_supported_channels(channels_root)
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        (f"# Demo\n\n{module.START_MARKER}\n{generated}\n{module.END_MARKER}\n"),
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(
+        ["--channels-root", str(channels_root), "--readme", str(readme), "--check"]
+    )
+
+    assert exit_code == 0
+
+
+def test_generate_groups_channels_by_tier(tmp_path: Path) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    _write_skill(
+        channels_root,
+        name="ddgs",
+        description="Free web search",
+        languages=["en"],
+        methods=[{"id": "text_search", "impl": "methods/api.py", "requires": []}],
+        typical_yield="medium",
+    )
+    _write_skill(
+        channels_root,
+        name="youtube",
+        description="Video search",
+        languages=["en", "mixed"],
+        methods=[
+            {
+                "id": "data_api_search",
+                "impl": "methods/data_api.py",
+                "requires": ["env:YOUTUBE_API_KEY"],
+            }
+        ],
+        typical_yield="high",
+    )
+    _write_skill(
+        channels_root,
+        name="zhihu",
+        description="Paid channel",
+        languages=["zh", "mixed"],
+        methods=[
+            {
+                "id": "via_tikhub",
+                "impl": "methods/via_tikhub.py",
+                "requires": ["env:TIKHUB_API_KEY"],
+            },
+            {
+                "id": "api_search",
+                "impl": "methods/api_search.py",
+                "requires": [],
+                "shipped": False,
+            },
+        ],
+        typical_yield="medium-high",
+    )
+
+    rendered = module.render_supported_channels(channels_root)
+
+    assert "### Tier 0 - always-on (1)" in rendered
+    assert "### Tier 1 - env-gated (1)" in rendered
+    assert "### Tier 2 - BYOK paid (1)" in rendered
+    assert "| youtube | en, mixed | env:YOUTUBE_API_KEY | Video search | high |" in rendered
+    assert "| zhihu | zh, mixed | env:TIKHUB_API_KEY | Paid channel | medium-high |" in rendered


### PR DESCRIPTION
## Summary

Wave G phase 1 — visibility tooling. Two surfaces:

1. **`autosearch init --check-channels`** — prints a tier-grouped channel status table (T0 always-on / T1 env-gated / T2 BYOK-paid / scaffold-only), with green/red/yellow coloring and tally summary.
2. **README "Supported Channels"** auto-generated between `<!-- channels-table-start -->` / `<!-- channels-table-end -->` markers. Script at `scripts/generate_channels_table.py` with `--check` mode for drift detection.

## Commits (4)

1. `feat(channels)` — add `log_missing_impls: bool = True` kwarg to `ChannelRegistry.compile_from_skills()` so the init flow can silence the INFO log spam when rendering the status table. Default preserves existing behavior.
2. `feat(init+cli)` — `autosearch/init/channel_status.py` module with `infer_tier()` + `compile_channel_statuses()` helpers; `--check-channels` flag on the `init` command.
3. `feat(docs+scripts)` — `scripts/generate_channels_table.py` with `--check` mode; README updated with marker comments + generated table populated with all 19 channels (17 shipped + 2 scaffold).
4. `test(unit)` — 11 new cases covering tier inference, tally, drift detection, generator `--check` mode.

## Tier inference rule

```
# Read from declared `requires` on shipped methods (not runtime unmet_requires)
#   so channels with keys already set in the shell don't get misclassified t1→t0.

t0 = has >=1 shipped method with requires == []
t1 = all shipped methods have env requires, none are TikHub
t2 = any shipped method requires env:TIKHUB_API_KEY
scaffold = all methods impl_missing
```

## Sample `init --check-channels` output

```
Tier 0 — always-on (11)
  ✓ arxiv            available
  ✓ ddgs             available
  ...

Tier 1 — env-gated (1)
  ✗ youtube          blocked    env:YOUTUBE_API_KEY

Tier 2 — BYOK paid (5)
  ✗ bilibili         blocked    env:TIKHUB_API_KEY
  ...

Total: 19 channels | 18 available | 0 blocked | 1 scaffold-only
```

(Output above is manual spot check from the dev shell which has TikHub + YouTube keys set.)

## Test plan

- [x] 321 tests pass (310 prior on main + 11 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] No new runtime deps
- [x] `python scripts/generate_channels_table.py --check` passes (README already regenerated)

## Design notes

- Tier inference reads from **declared requires**, not runtime `unmet_requires` — otherwise channels the dev shell has keys for would appear in Tier 0 and confuse the README generator.
- README script is idempotent — second run produces identical output. CI can enforce freshness with `--check`.
- `log_missing_impls` toggle prevents the check-channels command from spamming the 13-line INFO block about unimplemented scaffold methods (F003 legacy).

## Next

Wave G phase 2: pipx `package-data` so `skills/` ships with the wheel, and demote the `channel_method_impl_missing` INFO→DEBUG noise globally (not just for init).