### PR TITLE
chore(channels): demote channel_method_impl_missing to debug (F206 Wave G part 2a)

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -224,7 +224,7 @@ class ChannelRegistry:
         impl_path = skill_dir / method.impl
         if not impl_path.is_file():
             if log_missing_impls:
-                LOGGER.info(
+                LOGGER.debug(
                     "channel_method_impl_missing",
                     channel=channel_name,
                     method=method.id,


### PR DESCRIPTION
## Summary

Tiny noise cleanup. The registry's \`channel_method_impl_missing\` log fires once per unimplemented scaffold method during every pipeline startup — on a full channel lineup that's 13 INFO lines before any query runs. Demoting to DEBUG removes cosmetic noise without losing observability (DEBUG reveals it when needed).

## What changed

\`autosearch/channels/base.py\` — one line, \`LOGGER.info\` → \`LOGGER.debug\`.

## Kept

- \`log_missing_impls\` kwarg on \`compile_from_skills\` (added in #141) stays — still a way for callers to suppress entirely if they want DEBUG off too.

## Test plan

- [x] 321 tests pass (no test was asserting the INFO level — checked)
- [x] ruff clean
- [x] No new deps

## Wave G remaining

Wave G part 2b (pipx \`package-data\` so \`skills/\` ships with the wheel): separate PR — that change requires moving \`skills/\` under \`autosearch/\` and updating ~10 path references. Higher risk, deserves its own review.