### PR TITLE
fix(channels): skip live channels in dummy mode to keep smoke fast

### DIFF
--- a/autosearch/core/channel_bootstrap.py
+++ b/autosearch/core/channel_bootstrap.py
@@ -1,6 +1,7 @@
 # Self-written, plan autosearch-0418-channels-and-skills.md § F003
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import structlog
@@ -21,6 +22,9 @@ def _build_channels(
     channels_root: Path | None = None,
     env: Environment | None = None,
 ) -> list[Channel]:
+    if os.getenv("AUTOSEARCH_LLM_MODE") == "dummy":
+        return [DemoChannel()]
+
     root = channels_root or _default_channels_root()
     if not root.is_dir():
         # TODO: fall back to importlib.resources once skills/ ships as package data for pipx.


### PR DESCRIPTION
## Context

With 18 live channels wired and main's smoke budget at 30s for \`test_cli_query_smoke\`, any slightly-slower machine (non-CI) or added latency crossed the ceiling. Local runs were taking 120-180s. CI was passing but at 51s total smoke-job duration (fragile — one more channel would break it).

## Root cause

Smoke tests set \`AUTOSEARCH_LLM_MODE=dummy\` to short-circuit the LLM, but channels still ran 18 real HTTP calls per iteration × 5 iterations. The papers channel already had its own dummy-mode short-circuit (merged in #131). Extending that contract to **all** channels at the bootstrap layer is the right consolidation.

## Fix

\`autosearch/core/channel_bootstrap.py\`:

\`\`\`python
if os.getenv("AUTOSEARCH_LLM_MODE") == "dummy":
    return [DemoChannel()]
\`\`\`

In dummy mode, \`_build_channels()\` returns only the \`DemoChannel\` (unit-test-only placeholder). Smoke tests verify CLI/serve/mcp wiring, not channel quality — they don't need real network.

## Test plan

- [x] Smoke: 5 pass in **5.6s** (was 186s, previously failing at 30s timeout)
- [x] Regression: 321 pass (\`not real_llm and not perf and not slow and not network\`)
- [x] Ruff clean

## Worth doing later

The papers channel's own dummy-mode short-circuit is now redundant. Future cleanup PR can remove it. Leaving it in place for belt-and-suspenders — no behavioral conflict.