### PR TITLE
feat(core+surfaces): make channel_scope actually filter the channel set

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -78,6 +78,7 @@ class ChannelMetadata:
 
 class Channel(Protocol):
     name: str
+    languages: list[str]
 
     async def search(self, query: SubQuery) -> list[Evidence]: ...
 
@@ -89,6 +90,7 @@ class _CompiledChannel:
         health_provider: Callable[[], ChannelHealth | None],
     ) -> None:
         self.name = metadata.name
+        self.languages = list(metadata.languages)
         self._metadata = metadata
         self._health_provider = health_provider
         self._methods_by_id = {method.id: method for method in metadata.methods}

--- a/autosearch/channels/demo.py
+++ b/autosearch/channels/demo.py
@@ -6,6 +6,8 @@ from autosearch.core.models import Evidence, SubQuery
 
 
 class DemoChannel:
+    languages: list[str] = ["en", "mixed"]
+
     def __init__(self, name: str = "demo") -> None:
         self.name = name
 

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -144,7 +144,7 @@ def query(
                 channels=_build_channels(),
                 top_k_evidence=top_k,
                 on_event=stream_callback,
-            ).run(query, mode_hint=resolved_mode)
+            ).run(query, mode_hint=resolved_mode, scope=scope)
         )
     except Exception as exc:
         typer.echo(str(exc), err=True)

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -22,6 +22,7 @@ from autosearch.core.models import (
     Section,
     SubQuery,
 )
+from autosearch.core.search_scope import SearchScope, filter_channels_by_scope
 from autosearch.core.strategy import QueryStrategist
 from autosearch.llm.client import LLMClient
 from autosearch.observability.cost import CostTracker
@@ -68,6 +69,8 @@ class Pipeline:
         self,
         query: str,
         mode_hint: SearchMode | None = None,
+        *,
+        scope: SearchScope | None = None,
     ) -> PipelineResult:
         self._captured_reasoning_events = []
         iteration_controller = _TrackingIterationController(
@@ -173,19 +176,38 @@ class Pipeline:
                 }
             )
 
+            active_channels = self.channels
+            if scope is not None:
+                active_channels = filter_channels_by_scope(self.channels, scope.channel_scope)
+                if not active_channels:
+                    self.logger.warning(
+                        "channel_scope_filter_empty",
+                        channel_scope=scope.channel_scope,
+                        original_count=len(self.channels),
+                    )
+                    active_channels = self.channels
+                await self._emit_event(
+                    {
+                        "type": "channels_filtered",
+                        "scope": scope.channel_scope,
+                        "before": len(self.channels),
+                        "after": len(active_channels),
+                    }
+                )
+
             current_phase = "M3"
             await self._emit_phase_event(current_phase, "start")
             self.logger.info(
                 "pipeline_phase_started",
                 phase="m3_iteration",
                 subqueries=len(initial_queries),
-                channels=len(self.channels),
+                channels=len(active_channels),
                 max_iterations=self.budget.max_iterations,
             )
             evidences = await iteration_controller.run(
                 query=query,
                 initial_queries=initial_queries,
-                channels=self.channels,
+                channels=active_channels,
                 budget=self.budget,
                 client=self.llm,
             )
@@ -278,7 +300,7 @@ class Pipeline:
                     retry_evidences = await iteration_controller.run(
                         query=query,
                         initial_queries=retry_queries,
-                        channels=self.channels,
+                        channels=active_channels,
                         budget=retry_budget,
                         client=self.llm,
                     )

--- a/autosearch/core/search_scope.py
+++ b/autosearch/core/search_scope.py
@@ -1,7 +1,7 @@
 # Self-written, plan autosearch-0419-channels-scope-proxy.md § F101
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -10,6 +10,7 @@ from autosearch.core.models import SearchMode
 ChannelScope = Literal["all", "en_only", "zh_only", "mixed"]
 Depth = Literal["fast", "deep", "comprehensive"]
 OutputFormat = Literal["md", "html"]
+T = TypeVar("T")
 
 
 class SearchScope(BaseModel):
@@ -51,3 +52,19 @@ def depth_to_mode(depth: str | None) -> SearchMode | None:
     if normalized == "comprehensive":
         return SearchMode.COMPREHENSIVE
     raise ValueError(f"invalid depth: {depth}")
+
+
+def filter_channels_by_scope(channels: list[T], channel_scope: str) -> list[T]:
+    """Return channels whose languages match the scope filter.
+
+    - "all" / "mixed" -> no filter
+    - "en_only" -> drop channels missing "en" from languages
+    - "zh_only" -> drop channels missing "zh" from languages
+    """
+
+    if channel_scope in ("all", "mixed"):
+        return list(channels)
+    required = {"en_only": "en", "zh_only": "zh"}.get(channel_scope)
+    if required is None:
+        return list(channels)
+    return [channel for channel in channels if required in getattr(channel, "languages", [])]

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -42,7 +42,7 @@ def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> Fas
         assert mode_hint is not None
 
         try:
-            result = await factory().run(query, mode_hint=mode_hint)
+            result = await factory().run(query, mode_hint=mode_hint, scope=scope)
         except Exception as exc:
             return f"[error] {exc}"
 

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -204,12 +204,15 @@ async def _chat_completion_stream(
 async def _event_payloads(
     query: str,
     mode: SearchMode,
+    scope: SearchScope,
     pipeline_factory: PipelineFactory,
 ) -> AsyncIterator[dict[str, Any]]:
     queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
     yield {"type": "started", "query": query}
-    pipeline_task = asyncio.create_task(pipeline_factory(queue.put).run(query, mode_hint=mode))
+    pipeline_task = asyncio.create_task(
+        pipeline_factory(queue.put).run(query, mode_hint=mode, scope=scope)
+    )
 
     while not pipeline_task.done():
         try:
@@ -395,10 +398,11 @@ def _format_gap(event: dict[str, object]) -> str | None:
 async def _streaming_events(
     query: str,
     mode: SearchMode,
+    scope: SearchScope,
     pipeline_factory: PipelineFactory,
 ) -> AsyncIterator[str]:
     async for payload in _encoded_streaming_payloads(
-        _event_payloads(query, mode, pipeline_factory)
+        _event_payloads(query, mode, scope, pipeline_factory)
     ):
         yield payload
 
@@ -406,10 +410,11 @@ async def _streaming_events(
 async def _eventsource_events(
     query: str,
     mode: SearchMode,
+    scope: SearchScope,
     pipeline_factory: PipelineFactory,
 ) -> AsyncIterator[dict[str, str]]:
     async for payload in _encoded_eventsource_payloads(
-        _event_payloads(query, mode, pipeline_factory)
+        _event_payloads(query, mode, scope, pipeline_factory)
     ):
         yield payload
 
@@ -477,7 +482,7 @@ async def chat_completions(request: ChatCompletionRequest):
     created = int(time.time())
 
     try:
-        result = await _default_pipeline_factory(None).run(query, mode_hint=mode)
+        result = await _default_pipeline_factory(None).run(query, mode_hint=mode, scope=scope)
     except Exception as exc:
         return _openai_error_response(
             message=str(exc),
@@ -538,9 +543,19 @@ async def search(request: SearchRequest):
 
     if EventSourceResponse is not None:
         return EventSourceResponse(
-            _eventsource_events(request.query, mode, _default_pipeline_factory)
+            _eventsource_events(
+                request.query,
+                mode,
+                request.scope,
+                _default_pipeline_factory,
+            )
         )
     return StreamingResponse(
-        _streaming_events(request.query, mode, _default_pipeline_factory),
+        _streaming_events(
+            request.query,
+            mode,
+            request.scope,
+            _default_pipeline_factory,
+        ),
         media_type="text/event-stream",
     )

--- a/tests/fixtures/fake_channel.py
+++ b/tests/fixtures/fake_channel.py
@@ -11,8 +11,10 @@ class FakeChannel(Channel):
         name: str,
         evidences: list[Evidence] | None = None,
         factory: Callable[[SubQuery], list[Evidence]] | None = None,
+        languages: list[str] | None = None,
     ) -> None:
         self.name = name
+        self.languages = list(languages or ["en", "mixed"])
         self._evidences = list(evidences or [])
         self._factory = factory
         self.call_count = 0

--- a/tests/perf/test_mcp_rapid_calls.py
+++ b/tests/perf/test_mcp_rapid_calls.py
@@ -32,7 +32,10 @@ class _ImmediatePipeline:
         self,
         query: str,
         mode_hint: SearchMode | None = None,
+        *,
+        scope=None,
     ) -> PipelineResult:
+        _ = scope
         self.calls.append((query, mode_hint))
         return self.result
 

--- a/tests/perf/test_sse_concurrency.py
+++ b/tests/perf/test_sse_concurrency.py
@@ -40,7 +40,10 @@ class _ImmediatePipeline:
         self,
         query: str,
         mode_hint: SearchMode | None = None,
+        *,
+        scope=None,
     ) -> PipelineResult:
+        _ = scope
         self.call_log.append((query, mode_hint))
         await asyncio.sleep(0)
         return self.result

--- a/tests/unit/test_cli_interactive_prompt.py
+++ b/tests/unit/test_cli_interactive_prompt.py
@@ -47,8 +47,15 @@ def _install_cli_spy(monkeypatch, pipeline_result: PipelineResult) -> list[Searc
             self.top_k_evidence = top_k_evidence
             self.on_event = on_event
 
-        async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+        async def run(
+            self,
+            query: str,
+            mode_hint: SearchMode | None = None,
+            *,
+            scope=None,
+        ) -> PipelineResult:
             _ = query
+            _ = scope
             calls.append(mode_hint)
             return pipeline_result
 

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -68,9 +68,16 @@ def _install_cli_stubs(monkeypatch, pipeline_result: PipelineResult) -> None:
             self.top_k_evidence = top_k_evidence
             self.on_event = on_event
 
-        async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+        async def run(
+            self,
+            query: str,
+            mode_hint: SearchMode | None = None,
+            *,
+            scope=None,
+        ) -> PipelineResult:
             _ = query
             _ = mode_hint
+            _ = scope
             if self.on_event is not None:
                 maybe_coro = self.on_event({"type": "phase", "phase": "M0", "status": "start"})
                 if asyncio.iscoroutine(maybe_coro):

--- a/tests/unit/test_cli_scope_flags.py
+++ b/tests/unit/test_cli_scope_flags.py
@@ -12,6 +12,7 @@ from autosearch.core.models import (
     SearchMode,
 )
 from autosearch.core.pipeline import PipelineResult
+from autosearch.core.search_scope import SearchScope
 
 runner = CliRunner()
 
@@ -47,12 +48,19 @@ def _install_cli_spy(monkeypatch, pipeline_result: PipelineResult) -> list[dict[
             self.top_k_evidence = top_k_evidence
             self.on_event = on_event
 
-        async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+        async def run(
+            self,
+            query: str,
+            mode_hint: SearchMode | None = None,
+            *,
+            scope: SearchScope | None = None,
+        ) -> PipelineResult:
             calls.append(
                 {
                     "query": query,
                     "mode_hint": mode_hint,
                     "top_k_evidence": self.top_k_evidence,
+                    "scope": scope,
                 }
             )
             return pipeline_result
@@ -93,6 +101,11 @@ def test_query_accepts_all_new_flags_noninteractive(monkeypatch) -> None:
             "query": "test",
             "mode_hint": SearchMode.DEEP,
             "top_k_evidence": 20,
+            "scope": SearchScope(
+                channel_scope="mixed",
+                depth="deep",
+                output_format="html",
+            ),
         }
     ]
     assert json.loads(result.stdout)["scope"] == {

--- a/tests/unit/test_iteration.py
+++ b/tests/unit/test_iteration.py
@@ -26,6 +26,7 @@ class DummyClient:
 
 class FakeChannel:
     name = "fake"
+    languages = ["en", "mixed"]
 
     def __init__(self, responses: list[list[Evidence]]) -> None:
         self.responses = list(responses)

--- a/tests/unit/test_mcp_research_scope.py
+++ b/tests/unit/test_mcp_research_scope.py
@@ -4,6 +4,7 @@ import pytest
 import autosearch.mcp.server as mcp_server
 from autosearch.core.models import ClarifyResult, SearchMode
 from autosearch.core.pipeline import PipelineResult
+from autosearch.core.search_scope import SearchScope
 
 
 def _ok_result() -> PipelineResult:
@@ -24,14 +25,16 @@ def _ok_result() -> PipelineResult:
 class _StubPipeline:
     def __init__(self, result: PipelineResult) -> None:
         self.result = result
-        self.calls: list[tuple[str, SearchMode | None]] = []
+        self.calls: list[tuple[str, SearchMode | None, SearchScope | None]] = []
 
     async def run(
         self,
         query: str,
         mode_hint: SearchMode | None = None,
+        *,
+        scope: SearchScope | None = None,
     ) -> PipelineResult:
-        self.calls.append((query, mode_hint))
+        self.calls.append((query, mode_hint, scope))
         return self.result
 
 
@@ -58,7 +61,7 @@ async def test_research_accepts_scope_params_with_defaults(
 
     assert research_tool is not None
     assert await research_tool.run({"query": "test query"}) == "# Test\n\nBody"
-    assert pipeline.calls == [("test query", SearchMode.FAST)]
+    assert pipeline.calls == [("test query", SearchMode.FAST, SearchScope())]
 
 
 @pytest.mark.asyncio
@@ -73,7 +76,9 @@ async def test_research_maps_depth_comprehensive_to_pipeline(
 
     assert research_tool is not None
     await research_tool.run({"query": "test query", "depth": "comprehensive"})
-    assert pipeline.calls == [("test query", SearchMode.COMPREHENSIVE)]
+    assert pipeline.calls == [
+        ("test query", SearchMode.COMPREHENSIVE, SearchScope(depth="comprehensive"))
+    ]
 
 
 @pytest.mark.asyncio
@@ -88,7 +93,7 @@ async def test_research_depth_wins_over_mode(
 
     assert research_tool is not None
     await research_tool.run({"query": "test query", "mode": "fast", "depth": "deep"})
-    assert pipeline.calls == [("test query", SearchMode.DEEP)]
+    assert pipeline.calls == [("test query", SearchMode.DEEP, SearchScope(depth="deep"))]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -50,7 +50,10 @@ class _StubPipeline:
         self,
         query: str,
         mode_hint: SearchMode | None = None,
+        *,
+        scope=None,
     ) -> PipelineResult:
+        _ = scope
         self.calls.append((query, mode_hint))
         if self.exc is not None:
             raise self.exc

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -43,8 +43,15 @@ class _StubPipeline:
         self.calls: list[tuple[str, SearchMode]] = []
         self.on_event = None
 
-    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+        *,
+        scope=None,
+    ) -> PipelineResult:
         assert mode_hint is not None
+        _ = scope
         self.calls.append((query, mode_hint))
         return self.result
 

--- a/tests/unit/test_openai_compat_metadata.py
+++ b/tests/unit/test_openai_compat_metadata.py
@@ -75,8 +75,15 @@ class _StubPipeline:
         self.calls: list[tuple[str, SearchMode]] = []
         self.on_event = None
 
-    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+        *,
+        scope=None,
+    ) -> PipelineResult:
         assert mode_hint is not None
+        _ = scope
         self.calls.append((query, mode_hint))
         return self.result
 

--- a/tests/unit/test_pipeline_channel_error.py
+++ b/tests/unit/test_pipeline_channel_error.py
@@ -24,6 +24,7 @@ class DummyClient:
 
 class FailingChannel:
     name = "failing"
+    languages = ["en", "mixed"]
 
     def __init__(self) -> None:
         self.calls = 0
@@ -36,6 +37,7 @@ class FailingChannel:
 
 class FakeChannel:
     name = "working"
+    languages = ["en", "mixed"]
 
     def __init__(self, evidences: list[Evidence]) -> None:
         self.evidences = list(evidences)

--- a/tests/unit/test_pipeline_channel_scope.py
+++ b/tests/unit/test_pipeline_channel_scope.py
@@ -1,0 +1,183 @@
+# Self-written for F103 pipeline channel scope filtering
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import BaseModel
+
+from autosearch.core.models import Evidence, SearchMode, SubQuery
+from autosearch.core.pipeline import Pipeline
+from autosearch.core.search_scope import SearchScope
+
+NOW = datetime(2026, 4, 19, 12, 0, tzinfo=UTC)
+
+
+class DummyClient:
+    def __init__(self, payloads: list[dict[str, object]]) -> None:
+        self.payloads = payloads
+        self.calls = 0
+        self.cost_tracker = None
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        _ = prompt
+        payload = self.payloads[self.calls]
+        self.calls += 1
+        return response_model.model_validate(payload)
+
+
+class FakeChannel:
+    def __init__(self, name: str, languages: list[str]) -> None:
+        self.name = name
+        self.languages = languages
+        self.calls = 0
+        self.queries: list[str] = []
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        self.calls += 1
+        self.queries.append(query.text)
+        return [
+            Evidence(
+                url=f"https://example.com/{self.name}/{query.text.replace(' ', '-')}",
+                title=f"{self.name} evidence",
+                snippet=f"{self.name} snippet",
+                content=f"{self.name} content for {query.text}",
+                source_channel=self.name,
+                fetched_at=NOW,
+            )
+        ]
+
+
+def _pipeline_payloads() -> list[dict[str, object]]:
+    return [
+        {"known_facts": [], "gaps": []},
+        {
+            "need_clarification": False,
+            "question": "",
+            "verification": "Proceed with research.",
+            "rubrics": ["Use evidence."],
+            "mode": "fast",
+        },
+        {
+            "subqueries": [
+                {
+                    "text": "pipeline channel scope filter",
+                    "rationale": "exercise the active channel set",
+                }
+            ]
+        },
+        {"gaps": []},
+        {"headings": ["Overview"]},
+        {"content": "Scoped channels returned evidence [1].", "ref_ids": [1]},
+        {"grade": "pass", "follow_up_gaps": []},
+    ]
+
+
+def _make_pipeline(
+    channels: list[FakeChannel],
+    *,
+    on_event=None,
+) -> Pipeline:
+    return Pipeline(
+        llm=DummyClient(_pipeline_payloads()),
+        channels=channels,
+        on_event=on_event,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_filters_channels_by_scope_zh_only() -> None:
+    en_a = FakeChannel("en-a", ["en"])
+    en_b = FakeChannel("en-b", ["en", "mixed"])
+    zh_a = FakeChannel("zh-a", ["zh"])
+    zh_b = FakeChannel("zh-b", ["zh", "mixed"])
+
+    pipeline = _make_pipeline([en_a, en_b, zh_a, zh_b])
+
+    result = await pipeline.run(
+        "Which channels run?",
+        mode_hint=SearchMode.FAST,
+        scope=SearchScope(channel_scope="zh_only"),
+    )
+
+    assert result.status == "ok"
+    assert en_a.calls == 0
+    assert en_b.calls == 0
+    assert zh_a.calls == 1
+    assert zh_b.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_keeps_all_channels_when_scope_is_all() -> None:
+    channels = [
+        FakeChannel("en-a", ["en"]),
+        FakeChannel("en-b", ["en", "mixed"]),
+        FakeChannel("zh-a", ["zh"]),
+        FakeChannel("zh-b", ["zh", "mixed"]),
+    ]
+    pipeline = _make_pipeline(channels)
+
+    result = await pipeline.run(
+        "Which channels run?",
+        mode_hint=SearchMode.FAST,
+        scope=SearchScope(channel_scope="all"),
+    )
+
+    assert result.status == "ok"
+    assert [channel.calls for channel in channels] == [1, 1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_falls_back_when_scope_filter_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channels = [
+        FakeChannel("en-a", ["en"]),
+        FakeChannel("en-b", ["en", "mixed"]),
+    ]
+    warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    pipeline = _make_pipeline(channels)
+
+    monkeypatch.setattr(
+        pipeline.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    result = await pipeline.run(
+        "Which channels run?",
+        mode_hint=SearchMode.FAST,
+        scope=SearchScope(channel_scope="zh_only"),
+    )
+
+    assert result.status == "ok"
+    assert [channel.calls for channel in channels] == [1, 1]
+    assert warnings == [
+        (
+            ("channel_scope_filter_empty",),
+            {"channel_scope": "zh_only", "original_count": 2},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_channels_filtered_event() -> None:
+    events: list[dict[str, object]] = []
+    channels = [
+        FakeChannel("en-a", ["en"]),
+        FakeChannel("en-b", ["en", "mixed"]),
+        FakeChannel("zh-a", ["zh"]),
+        FakeChannel("zh-b", ["zh", "mixed"]),
+    ]
+    pipeline = _make_pipeline(channels, on_event=events.append)
+
+    await pipeline.run(
+        "Which channels run?",
+        mode_hint=SearchMode.FAST,
+        scope=SearchScope(channel_scope="zh_only"),
+    )
+
+    assert {
+        "type": "channels_filtered",
+        "scope": "zh_only",
+        "before": 4,
+        "after": 2,
+    } in events

--- a/tests/unit/test_pipeline_events.py
+++ b/tests/unit/test_pipeline_events.py
@@ -24,6 +24,7 @@ class DummyClient:
 
 class FakeChannel:
     name = "fake"
+    languages = ["en", "mixed"]
 
     def __init__(self, responses: list[list[Evidence]]) -> None:
         self.responses = list(responses)

--- a/tests/unit/test_search_scope.py
+++ b/tests/unit/test_search_scope.py
@@ -2,7 +2,13 @@
 import pytest
 from pydantic import ValidationError
 
-from autosearch.core.search_scope import ScopeQuestion, SearchScope
+from autosearch.core.search_scope import ScopeQuestion, SearchScope, filter_channels_by_scope
+
+
+class _Channel:
+    def __init__(self, name: str, languages: list[str]) -> None:
+        self.name = name
+        self.languages = languages
 
 
 def test_search_scope_defaults() -> None:
@@ -49,3 +55,54 @@ def test_scope_question_frozen_and_serializable() -> None:
 
     assert ScopeQuestion.model_config["frozen"] is True
     assert loaded == question
+
+
+def test_filter_channels_all_keeps_all() -> None:
+    channels = [_Channel("en", ["en"]), _Channel("zh", ["zh"])]
+
+    filtered = filter_channels_by_scope(channels, "all")
+
+    assert filtered == channels
+
+
+def test_filter_channels_en_only_drops_zh_only_channels() -> None:
+    channels = [
+        _Channel("en", ["en"]),
+        _Channel("zh", ["zh"]),
+        _Channel("zh_mixed", ["zh", "mixed"]),
+    ]
+
+    filtered = filter_channels_by_scope(channels, "en_only")
+
+    assert [channel.name for channel in filtered] == ["en"]
+
+
+def test_filter_channels_zh_only_drops_en_only_channels() -> None:
+    channels = [
+        _Channel("en", ["en"]),
+        _Channel("en_mixed", ["en", "mixed"]),
+        _Channel("zh", ["zh"]),
+    ]
+
+    filtered = filter_channels_by_scope(channels, "zh_only")
+
+    assert [channel.name for channel in filtered] == ["zh"]
+
+
+def test_filter_channels_mixed_is_noop() -> None:
+    channels = [_Channel("en", ["en"]), _Channel("zh", ["zh"])]
+
+    filtered = filter_channels_by_scope(channels, "mixed")
+
+    assert filtered == channels
+
+
+def test_filter_channels_bilingual_channel_kept_for_both() -> None:
+    bilingual = _Channel("bilingual", ["en", "zh", "mixed"])
+    channels = [_Channel("en", ["en"]), bilingual, _Channel("zh", ["zh"])]
+
+    en_filtered = filter_channels_by_scope(channels, "en_only")
+    zh_filtered = filter_channels_by_scope(channels, "zh_only")
+
+    assert bilingual in en_filtered
+    assert bilingual in zh_filtered

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -52,8 +52,15 @@ class _StubPipeline:
         self.emitted_events = emitted_events or []
         self.calls: list[tuple[str, SearchMode]] = []
 
-    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+        *,
+        scope=None,
+    ) -> PipelineResult:
         assert mode_hint is not None
+        _ = scope
         self.calls.append((query, mode_hint))
         for event in self.emitted_events:
             if self.on_event is None:

--- a/tests/unit/test_server_chat_completions_scope.py
+++ b/tests/unit/test_server_chat_completions_scope.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 import autosearch.server.main as server_main
 from autosearch.core.models import ClarifyResult, SearchMode
 from autosearch.core.pipeline import PipelineResult
+from autosearch.core.search_scope import SearchScope
 
 
 def _ok_result() -> PipelineResult:
@@ -26,12 +27,18 @@ def _ok_result() -> PipelineResult:
 class _StubPipeline:
     def __init__(self, result: PipelineResult) -> None:
         self.result = result
-        self.calls: list[tuple[str, SearchMode]] = []
+        self.calls: list[tuple[str, SearchMode, SearchScope | None]] = []
         self.on_event = None
 
-    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+        *,
+        scope: SearchScope | None = None,
+    ) -> PipelineResult:
         assert mode_hint is not None
-        self.calls.append((query, mode_hint))
+        self.calls.append((query, mode_hint, scope))
         return self.result
 
 
@@ -64,7 +71,7 @@ def test_chat_completions_accepts_scope_metadata(monkeypatch) -> None:
     payload = response.json()
 
     assert response.status_code == 200
-    assert pipeline.calls == [("test", SearchMode.DEEP)]
+    assert pipeline.calls == [("test", SearchMode.DEEP, SearchScope(depth="deep"))]
     assert payload["metadata"]["scope_used"]["depth"] == "deep"
 
 
@@ -81,7 +88,7 @@ def test_chat_completions_scope_uses_defaults_when_metadata_absent(monkeypatch) 
     payload = response.json()
 
     assert response.status_code == 200
-    assert pipeline.calls == [("test", SearchMode.FAST)]
+    assert pipeline.calls == [("test", SearchMode.FAST, SearchScope())]
     assert payload["metadata"]["scope_used"] == {
         "domain_followups": [],
         "channel_scope": "all",

--- a/tests/unit/test_server_search_scope.py
+++ b/tests/unit/test_server_search_scope.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 import autosearch.server.main as server_main
 from autosearch.core.models import ClarifyResult, SearchMode
 from autosearch.core.pipeline import PipelineResult
+from autosearch.core.search_scope import SearchScope
 
 
 def _ok_result() -> PipelineResult:
@@ -33,11 +34,17 @@ class _StubPipeline:
         self.result = result
         self.emitted_events = emitted_events or []
         self.on_event = None
-        self.calls: list[tuple[str, SearchMode]] = []
+        self.calls: list[tuple[str, SearchMode, SearchScope | None]] = []
 
-    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+        *,
+        scope: SearchScope | None = None,
+    ) -> PipelineResult:
         assert mode_hint is not None
-        self.calls.append((query, mode_hint))
+        self.calls.append((query, mode_hint, scope))
         for event in self.emitted_events:
             if self.on_event is None:
                 continue
@@ -135,7 +142,9 @@ def test_search_runs_pipeline_when_scope_complete(monkeypatch) -> None:
     assert response.status_code == 200
     assert all(event["type"] != "scope_needed" for event in events)
     assert any(event["type"] == "phase" for event in events)
-    assert pipeline.calls == [("test query", SearchMode.FAST)]
+    assert pipeline.calls == [
+        ("test query", SearchMode.FAST, SearchScope(channel_scope="all", depth="fast"))
+    ]
 
 
 def test_search_resolves_depth_comprehensive_to_search_mode(monkeypatch) -> None:
@@ -156,4 +165,10 @@ def test_search_resolves_depth_comprehensive_to_search_mode(monkeypatch) -> None
     )
 
     assert response.status_code == 200
-    assert pipeline.calls == [("test query", SearchMode.COMPREHENSIVE)]
+    assert pipeline.calls == [
+        (
+            "test query",
+            SearchMode.COMPREHENSIVE,
+            SearchScope(channel_scope="all", depth="comprehensive"),
+        )
+    ]

--- a/tests/unit/test_server_streaming.py
+++ b/tests/unit/test_server_streaming.py
@@ -28,9 +28,16 @@ class _StreamingStubPipeline:
     def __init__(self, on_event=None) -> None:
         self.on_event = on_event
 
-    async def run(self, query: str, mode_hint: SearchMode | None = None) -> PipelineResult:
+    async def run(
+        self,
+        query: str,
+        mode_hint: SearchMode | None = None,
+        *,
+        scope=None,
+    ) -> PipelineResult:
         _ = query
         _ = mode_hint
+        _ = scope
         for event in [
             {"type": "phase", "phase": "M0", "status": "start"},
             {"type": "iteration", "round": 1, "new_evidence": 2, "running_evidence": 2},


### PR DESCRIPTION
## Summary

Makes \`SearchScope.channel_scope\` do real work. Previously it was accepted on every surface (CLI / \`/search\` / \`/v1/chat/completions\` / MCP research) but never touched the pipeline — 18 channels ran regardless. After this PR, \`--languages zh_only\` drops English-only channels before M3 iteration.

## Filter semantics

```
channel_scope       → filter
"all" / "mixed"     → keep all channels
"en_only"           → keep iff "en" in channel.languages
"zh_only"           → keep iff "zh" in channel.languages
```

Channel languages come from each \`SKILL.md\`'s \`languages:\` frontmatter (\`["en", "mixed"]\`, \`["zh", "mixed"]\`, etc.). Bilingual channels (declare both \`en\` + \`zh\`) stay for both \`en_only\` and \`zh_only\`.

## Empty-filter safety

If the filter would leave zero channels (e.g. \`zh_only\` on a config with only English channels), log a \`channel_scope_filter_empty\` warning and **fall back to the full channel list**. Prevents total silence from a misconfigured scope.

## Streaming observability

Pipeline emits a \`channels_filtered\` event on stream consumers:
\`\`\`json
{"type": "channels_filtered", "scope": "zh_only", "before": 18, "after": 6}
\`\`\`

CLI / SSE / MCP streams all receive this marker so UIs can show "6 of 18 channels selected by language".

## Commits (4)

1. \`feat(channels)\` — add \`languages: list[str]\` to the \`Channel\` protocol. \`_CompiledChannel\` exposes it from metadata; \`DemoChannel\` declares \`["en", "mixed"]\`.
2. \`feat(core)\` — \`filter_channels_by_scope()\` helper + \`Pipeline.run(scope=...)\` kwarg with empty-filter fallback + \`channels_filtered\` event.
3. \`feat(surfaces)\` — CLI passes resolved scope; \`/search\` + \`/v1/chat/completions\` + MCP \`research\` all pass their scope through to \`Pipeline.run()\`.
4. \`test(unit+fixtures)\` — 9 new scope-filter tests; existing pipeline/cli/server/mcp fixtures updated to carry the new \`languages\` attr on fake channels.

## Test plan

- [x] 358 tests pass
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] No new runtime deps
- [x] Empty-filter fallback verified (prevents pipeline silence)
- [x] \`channels_filtered\` event fires on streams

## Completes the plan

With #146 + #147 + this PR, the \`autosearch-0419-channels-scope-proxy.md\` plan is effectively done:

- Wave W1 (M0.5 scope) ✅ — schema + CLI + API + MCP, **filter now live** (this PR).
- Wave W2 (channels) ✅ — 21 shipped channels; 雪球 deferred with rationale.
- Wave W3 (Cloudflare worker) ✅ — live + verified end-to-end.