### PR TITLE
fix(hooks): auto-stash unrelated work-tree changes around pre-push rebase

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,6 +7,29 @@ if [ "$branch" = "main" ]; then
   exit 0
 fi
 
+# Stash untracked/modified work-tree files (unrelated to the push) so rebase
+# doesn't abort. trap restores them on every exit path.
+STASH_MARKER="pre-push-auto-$$"
+STASH_CREATED=false
+cleanup_stash() {
+  if [ "$STASH_CREATED" = true ]; then
+    STASH_REF=$(git stash list | grep -F "$STASH_MARKER" | head -1 | cut -d: -f1)
+    if [ -n "$STASH_REF" ]; then
+      if ! git stash pop "$STASH_REF" --quiet; then
+        echo "WARNING: stash pop conflicted. Your changes are preserved in '$STASH_REF' — resolve manually."
+      fi
+    fi
+  fi
+}
+trap cleanup_stash EXIT
+
+if [ -n "$(git status --porcelain)" ]; then
+  if git stash push -u -m "$STASH_MARKER" --quiet; then
+    STASH_CREATED=true
+    echo "Stashed unrelated work-tree changes before rebase ($STASH_MARKER)"
+  fi
+fi
+
 # Rebase on main before push
 git fetch origin main --quiet
 if ! git rebase origin/main --quiet; then


### PR DESCRIPTION
## Summary

Eliminates recurring pre-push friction: when `git push` fires, the hook's `git rebase origin/main --quiet` aborted on any unrelated untracked/modified files, forcing a manual `git stash push -- <files>` / `git stash pop` dance around every push.

The fix wraps rebase with:
1. Stash (with `-u` for untracked) under a PID-keyed marker if `git status --porcelain` is non-empty.
2. `trap cleanup_stash EXIT` — restore on every exit path (success, rebase failure, test failure, version-bump block).
3. Pop by marker (not blind `stash pop`) so concurrent manual stashes aren't disturbed; warn on pop conflict so work is never silently dropped.

## Test plan

- [x] `bash -n .husky/pre-push` — syntax OK
- [x] Dry-run the stash → rebase → pop sequence with 2 entries in work tree (`M .husky/pre-push` + 1 untracked scratch file): stashed correctly, rebase ran against a clean tree, pop restored both entries intact
- [x] Live self-test: this PR's own push went through the new hook (`358 passed, 17 deselected`)
- [x] Backward-compatible: when work tree is clean (the common case), `STASH_CREATED` stays false and the hook behaves exactly as before

## Safety notes

- Stash marker uses `$$` (PID) — unique per hook invocation, never collides with user stashes
- Pop failure does not silently lose work — emits `WARNING: ... preserved in '$STASH_REF'` pointing at the exact stash to recover from manually
- `trap ... EXIT` fires on every exit path including rebase abort and test failure, so work is always returned to the tree