### PR TITLE
refactor: rename PipelineResult.status to delivery_status

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -150,7 +150,7 @@ def query(
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1) from exc
 
-    if result.status == "needs_clarification":
+    if result.delivery_status == "needs_clarification":
         typer.echo(result.clarification.question or "More detail is required.", err=True)
         raise typer.Exit(code=2)
 
@@ -168,7 +168,7 @@ def query(
         typer.echo(
             json.dumps(
                 {
-                    "status": result.status,
+                    "delivery_status": result.delivery_status,
                     "markdown": rendered_output,
                     "iterations": result.iterations,
                     "quality_grade": (

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -92,7 +92,7 @@ class EvaluationResult(BaseModel):
 
 @dataclass(frozen=True)
 class PipelineResult:
-    status: Literal["ok", "needs_clarification"]
+    delivery_status: Literal["ok", "needs_clarification"]
     clarification: ClarifyResult
     markdown: str | None = None
     evidences: list[Evidence] = field(default_factory=list)

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -139,7 +139,7 @@ class Pipeline:
                 prompt_tokens, completion_tokens = self._current_token_usage()
                 self.logger.info("pipeline_run_completed", status=final_status)
                 return PipelineResult(
-                    status=final_status,
+                    delivery_status=final_status,
                     clarification=clarification,
                     iterations=0,
                     reasoning_events=list(self._captured_reasoning_events or []),
@@ -336,7 +336,7 @@ class Pipeline:
             )
             prompt_tokens, completion_tokens = self._current_token_usage()
             return PipelineResult(
-                status=final_status,
+                delivery_status=final_status,
                 clarification=clarification,
                 markdown=markdown,
                 evidences=processed_evidences,

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -46,7 +46,7 @@ def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> Fas
         except Exception as exc:
             return f"[error] {exc}"
 
-        if result.status == "needs_clarification":
+        if result.delivery_status == "needs_clarification":
             question = result.clarification.question or "More detail is required."
             return f"[clarification needed] {question}"
 

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -84,9 +84,9 @@ def _terminal_payload(result: PipelineResult) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "type": "finished",
         "iterations": result.iterations,
-        "status": result.status,
+        "delivery_status": result.delivery_status,
     }
-    if result.status == "needs_clarification":
+    if result.delivery_status == "needs_clarification":
         payload["question"] = result.clarification.question or "More detail is required."
         return payload
     payload["markdown"] = result.markdown or ""
@@ -491,7 +491,7 @@ async def chat_completions(request: ChatCompletionRequest):
             code="internal_error",
         )
 
-    if result.status == "needs_clarification":
+    if result.delivery_status == "needs_clarification":
         question = result.clarification.question or "More detail is required."
         return _openai_error_response(
             message=f"Clarification needed: {question}",

--- a/tests/integration/test_pipeline_clarification_exit.py
+++ b/tests/integration/test_pipeline_clarification_exit.py
@@ -74,7 +74,7 @@ async def test_pipeline_exits_early_when_clarification_is_required() -> None:
 
     result = await Pipeline(llm=llm, channels=[channel]).run("best search tool")
 
-    assert result.status == "needs_clarification"
+    assert result.delivery_status == "needs_clarification"
     assert result.markdown is None
     assert result.evidences == []
     assert result.quality is None

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -186,7 +186,7 @@ async def test_pipeline_run_produces_report_and_quality_pass() -> None:
         "Should I still use BM25 for lexical search?",
     )
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert result.markdown is not None
     assert "## References" in result.markdown
     assert "## Sources" in result.markdown

--- a/tests/perf/test_mcp_rapid_calls.py
+++ b/tests/perf/test_mcp_rapid_calls.py
@@ -10,7 +10,7 @@ from autosearch.core.pipeline import PipelineResult
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/perf/test_pipeline_large_evidence.py
+++ b/tests/perf/test_pipeline_large_evidence.py
@@ -167,7 +167,7 @@ async def test_pipeline_handles_five_hundred_evidence_items_quickly() -> None:
     result = await pipeline.run(QUERY)
     elapsed = time.perf_counter() - started_at
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert result.markdown
     assert elapsed < 15.0
     assert channel.call_count == 3

--- a/tests/perf/test_sse_concurrency.py
+++ b/tests/perf/test_sse_concurrency.py
@@ -12,7 +12,7 @@ from autosearch.core.pipeline import PipelineResult
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/real_llm/test_pipeline_demo.py
+++ b/tests/real_llm/test_pipeline_demo.py
@@ -84,7 +84,7 @@ async def test_pipeline_demo_roundtrip_uses_real_llm() -> None:
 
     async with asyncio.timeout(300):
         result = await pipeline.run("retrieval augmented generation")
-        if result.status == "needs_clarification":
+        if result.delivery_status == "needs_clarification":
             # Some providers treat the bare phrase as underspecified. Retry once with an explicit
             # report request instead of looping indefinitely.
             result = await pipeline.run(
@@ -92,7 +92,7 @@ async def test_pipeline_demo_roundtrip_uses_real_llm() -> None:
                 "covering what it is, key architecture tradeoffs, and cited sources."
             )
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert result.markdown is not None
     assert "## References" in result.markdown
     assert "## Sources" in result.markdown

--- a/tests/unit/test_cli_interactive_prompt.py
+++ b/tests/unit/test_cli_interactive_prompt.py
@@ -18,7 +18,7 @@ runner = CliRunner()
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -18,7 +18,7 @@ runner = CliRunner()
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,
@@ -37,7 +37,7 @@ def _ok_result() -> PipelineResult:
 
 def _clarification_result() -> PipelineResult:
     return PipelineResult(
-        status="needs_clarification",
+        delivery_status="needs_clarification",
         clarification=ClarifyResult(
             need_clarification=True,
             question="Which deployment target do you care about?",
@@ -131,7 +131,7 @@ def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
     assert result.exit_code == 0
     assert result.stderr == ""
     assert json.loads(result.stdout) == {
-        "status": "ok",
+        "delivery_status": "ok",
         "markdown": "# Test\n\nBody",
         "iterations": 2,
         "quality_grade": "pass",

--- a/tests/unit/test_cli_scope_flags.py
+++ b/tests/unit/test_cli_scope_flags.py
@@ -19,7 +19,7 @@ runner = CliRunner()
 
 def _ok_result(markdown: str = "# Test\n\nBody") -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/unit/test_mcp_research_scope.py
+++ b/tests/unit/test_mcp_research_scope.py
@@ -9,7 +9,7 @@ from autosearch.core.search_scope import SearchScope
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -9,7 +9,7 @@ from autosearch.core.pipeline import PipelineResult
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,
@@ -24,7 +24,7 @@ def _ok_result() -> PipelineResult:
 
 def _clarification_result() -> PipelineResult:
     return PipelineResult(
-        status="needs_clarification",
+        delivery_status="needs_clarification",
         clarification=ClarifyResult(
             need_clarification=True,
             question="Which deployment target matters most?",

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -8,7 +8,7 @@ from autosearch.core.pipeline import PipelineResult
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,
@@ -25,7 +25,7 @@ def _ok_result() -> PipelineResult:
 
 def _clarification_result() -> PipelineResult:
     return PipelineResult(
-        status="needs_clarification",
+        delivery_status="needs_clarification",
         clarification=ClarifyResult(
             need_clarification=True,
             question="Which deployment target do you care about?",

--- a/tests/unit/test_openai_compat_metadata.py
+++ b/tests/unit/test_openai_compat_metadata.py
@@ -22,7 +22,7 @@ def _evidence(url: str, title: str) -> Evidence:
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/unit/test_pipeline_channel_error.py
+++ b/tests/unit/test_pipeline_channel_error.py
@@ -104,7 +104,7 @@ async def test_pipeline_continues_after_channel_error_and_emits_error_event() ->
         on_event=events.append,
     ).run("How should channel failures behave?", mode_hint=SearchMode.FAST)
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert [evidence.url for evidence in result.evidences] == ["https://example.com/working"]
     assert "Working evidence supports the answer" in (result.markdown or "")
     assert failing_channel.calls == 1

--- a/tests/unit/test_pipeline_channel_scope.py
+++ b/tests/unit/test_pipeline_channel_scope.py
@@ -98,7 +98,7 @@ async def test_pipeline_filters_channels_by_scope_zh_only() -> None:
         scope=SearchScope(channel_scope="zh_only"),
     )
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert en_a.calls == 0
     assert en_b.calls == 0
     assert zh_a.calls == 1
@@ -121,7 +121,7 @@ async def test_pipeline_keeps_all_channels_when_scope_is_all() -> None:
         scope=SearchScope(channel_scope="all"),
     )
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert [channel.calls for channel in channels] == [1, 1, 1, 1]
 
 
@@ -148,7 +148,7 @@ async def test_pipeline_falls_back_when_scope_filter_empty(
         scope=SearchScope(channel_scope="zh_only"),
     )
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert [channel.calls for channel in channels] == [1, 1]
     assert warnings == [
         (

--- a/tests/unit/test_pipeline_events.py
+++ b/tests/unit/test_pipeline_events.py
@@ -113,7 +113,7 @@ async def test_pipeline_emits_phase_iteration_gap_and_quality_events() -> None:
     phase_starts = {(event["phase"], event["status"]) for event in phase_events}
     iteration_events = [event for event in events if event["type"] == "iteration"]
 
-    assert result.status == "ok"
+    assert result.delivery_status == "ok"
     assert len(phase_events) >= 10
     assert {
         ("M0", "start"),

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -11,7 +11,7 @@ from autosearch.core.pipeline import PipelineResult
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,
@@ -26,7 +26,7 @@ def _ok_result() -> PipelineResult:
 
 def _clarification_result() -> PipelineResult:
     return PipelineResult(
-        status="needs_clarification",
+        delivery_status="needs_clarification",
         clarification=ClarifyResult(
             need_clarification=True,
             question="Which deployment target do you care about?",
@@ -131,7 +131,7 @@ def test_search_streams_started_and_finished_events(monkeypatch) -> None:
         "type": "finished",
         "markdown": "# Test\n\nBody",
         "iterations": 2,
-        "status": "ok",
+        "delivery_status": "ok",
     } in events
     assert pipeline.calls == [("test query", SearchMode.FAST)]
 
@@ -159,7 +159,7 @@ def test_search_streams_needs_clarification_event(monkeypatch) -> None:
     assert response.status_code == 200
     assert {
         "type": "finished",
-        "status": "needs_clarification",
+        "delivery_status": "needs_clarification",
         "iterations": 0,
         "question": "Which deployment target do you care about?",
     } in events

--- a/tests/unit/test_server_chat_completions_scope.py
+++ b/tests/unit/test_server_chat_completions_scope.py
@@ -9,7 +9,7 @@ from autosearch.core.search_scope import SearchScope
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/unit/test_server_search_scope.py
+++ b/tests/unit/test_server_search_scope.py
@@ -12,7 +12,7 @@ from autosearch.core.search_scope import SearchScope
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,

--- a/tests/unit/test_server_streaming.py
+++ b/tests/unit/test_server_streaming.py
@@ -11,7 +11,7 @@ from autosearch.core.pipeline import PipelineResult
 
 def _ok_result() -> PipelineResult:
     return PipelineResult(
-        status="ok",
+        delivery_status="ok",
         clarification=ClarifyResult(
             need_clarification=False,
             question=None,


### PR DESCRIPTION
## Summary

Renames `PipelineResult.status` → `PipelineResult.delivery_status` end-to-end. **Breaking change, no compat shim** (pre-1.0 project, CalVer).

### Why

The previous session's experience note flagged the ambiguity: a response with `status="ok"` and `quality_grade="fail"` was reaching API clients, and the overloaded `status` word was being read as "overall success" when it only described delivery flow. `quality_grade` is orthogonal and stays as-is. Renaming the delivery field makes the two dimensions unmistakable.

### What changes

- **Core**: `PipelineResult.status: Literal["ok", "needs_clarification"]` → `delivery_status`
- **Server** (`/search` JSON + `/v1/chat/completions` metadata): JSON key `"status"` → `"delivery_status"`
- **CLI** (`autosearch query --json`): JSON key `"status"` → `"delivery_status"`
- **MCP** (`research` tool response): `"status"` → `"delivery_status"`
- **All test fixtures/assertions** updated accordingly (20 test files)

### What is NOT touched

- HTTP `status_code` handling (unrelated)
- `/health` endpoint's `{"status": "ok"}` (unrelated server health)
- Phase event stream's `"status"` key in `_emit_phase_event` (per-phase started/completed)
- Channel-level `ChannelStatus.status` (channel registry availability, unrelated)
- TikHub client's HTTP status handling

The literal values `"ok"` / `"needs_clarification"` are unchanged.

## Test plan

- [x] `pytest -x -q -m "not real_llm and not perf and not slow and not network"` — `358 passed, 17 deselected`
- [x] `ruff check` + `ruff format --check` all green
- [x] Pre-push hook full suite green
- [x] Scope audit: reviewed Codex diff, reverted 3 files (`tests/real_llm/test_provider_roundtrip.py`, `tests/real_llm/test_spike_1_harness.py`, `tests/smoke/conftest.py`) that contained sandbox-skip logic outside the rename scope

## Migration for downstream consumers

Any client reading the JSON envelope from `/search`, `/v1/chat/completions`, `autosearch query --json`, or the MCP `research` tool must rename the key from `status` to `delivery_status`.

```diff
- result["status"] == "ok"
+ result["delivery_status"] == "ok"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed status field to `delivery_status` in API responses. The field maintains the same allowed values ("ok", "needs_clarification") and behavior; only the output key name has changed. This affects CLI JSON output and all server API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->