### PR TITLE
refactor: migrate hardcoded prompts to skills/prompts/ loader

### DIFF
--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -1,7 +1,6 @@
 # Source: open_deep_research/src/legacy/graph.py:L235-L354 (adapted)
 import asyncio
 from dataclasses import dataclass
-from textwrap import dedent
 
 import structlog
 from pydantic import BaseModel, Field
@@ -10,80 +9,10 @@ from autosearch.channels.base import Channel
 from autosearch.core.evidence import EvidenceProcessor
 from autosearch.core.models import Evidence, Gap, SubQuery
 from autosearch.llm.client import LLMClient
+from autosearch.skills.prompts import load_prompt
 
-GAP_REFLECTION_PROMPT = dedent(
-    """\
-    Review the current research progress and identify only the most important remaining gaps.
-
-    <Original user query>
-    {query}
-    </Original user query>
-
-    <Current iteration>
-    {iteration} of {max_iterations}
-    </Current iteration>
-
-    <Queries already executed>
-    {subqueries}
-    </Queries already executed>
-
-    <Collected evidence>
-    {evidence_context}
-    </Collected evidence>
-
-    Respond in valid JSON with this exact schema:
-    {{
-      "gaps": [
-        {{
-          "topic": "missing research topic",
-          "reason": "why this missing information matters"
-        }}
-      ]
-    }}
-
-    Rules:
-    - Return at most 3 gaps
-    - Return an empty list if the evidence already covers the query well enough to draft a report
-    - Focus on missing evidence, missing comparisons, missing time-sensitive details, or unanswered
-      sub-questions
-    - Keep each topic concrete enough to search directly
-    - Do not repeat gaps that are already covered by the collected evidence
-    """
-).strip()
-
-FOLLOW_UP_QUERY_PROMPT = dedent(
-    """\
-    Convert the identified research gaps into focused follow-up search queries.
-
-    <Original user query>
-    {query}
-    </Original user query>
-
-    <Research gaps>
-    {gap_context}
-    </Research gaps>
-
-    <Collected evidence so far>
-    {evidence_context}
-    </Collected evidence so far>
-
-    Respond in valid JSON with this exact schema:
-    {{
-      "subqueries": [
-        {{
-          "text": "search query",
-          "rationale": "why this query helps close a specific gap"
-        }}
-      ]
-    }}
-
-    Rules:
-    - Return at most one subquery per gap
-    - Keep the queries specific, concrete, and non-redundant
-    - Use date terms only when the gap is clearly time-sensitive
-    - Make each rationale concise and directly tied to a gap
-    """
-).strip()
+GAP_REFLECTION_PROMPT = load_prompt("m3_gap_reflection")
+FOLLOW_UP_QUERY_PROMPT = load_prompt("m3_follow_up_query")
 
 
 @dataclass(frozen=True)

--- a/autosearch/core/strategy.py
+++ b/autosearch/core/strategy.py
@@ -1,46 +1,15 @@
 # Source: gpt-researcher/gpt_researcher/prompts.py:L213-L255 (adapted)
 # Source: gpt-researcher/gpt_researcher/actions/query_processing.py:L37-L80 (adapted)
 from datetime import datetime, timezone
-from textwrap import dedent
 
 import structlog
 from pydantic import BaseModel, Field
 
 from autosearch.core.models import ClarifyResult, KnowledgeRecall, SubQuery
 from autosearch.llm.client import LLMClient
+from autosearch.skills.prompts import load_prompt
 
-SEARCH_QUERY_PROMPT = dedent(
-    """\
-    Write {n} search queries to search online that form an objective view of the following task:
-    "{task}"
-
-    Assume the current date is {today} if required.
-
-    Context:
-    {context}
-
-    Use this context to inform and refine your search queries. The context provides task guidance,
-    evaluation criteria, and known information gaps that should shape more specific and relevant
-    searches.
-
-    Respond in valid JSON with this exact schema:
-    {{
-      "subqueries": [
-        {{
-          "text": "search query",
-          "rationale": "why this query helps cover the task"
-        }}
-      ]
-    }}
-
-    Rules:
-    - Return exactly {n} subqueries
-    - Make the queries mutually complementary rather than redundant
-    - Prefer concrete search terms over vague natural-language questions
-    - Use current-year or date terms only when the task is time-sensitive
-    - Keep each rationale concise and specific
-    """
-).strip()
+SEARCH_QUERY_PROMPT = load_prompt("m2_search_query")
 
 
 class _SubQueryBatch(BaseModel):

--- a/autosearch/quality/gate.py
+++ b/autosearch/quality/gate.py
@@ -1,56 +1,12 @@
 # Source: open_deep_research/src/legacy/prompts.py:L168-L198 (adapted)
 # Source: open_deep_research/src/legacy/state.py:L32-L38 (adapted)
-from textwrap import dedent
-
 import structlog
 
 from autosearch.core.models import EvaluationResult, Evidence, Gap, GradeOutcome, Rubric, Section
 from autosearch.llm.client import LLMClient
+from autosearch.skills.prompts import load_prompt
 
-SECTION_GRADER_PROMPT = dedent(
-    """\
-    Review a report section relative to the specified topic:
-
-    <Report topic>
-    {topic}
-    </Report topic>
-
-    <section topic>
-    {section_topic}
-    </section topic>
-
-    <section content>
-    {section}
-    </section content>
-
-    <quality rubrics>
-    {rubrics}
-    </quality rubrics>
-
-    <supporting evidence>
-    {evidence_context}
-    </supporting evidence>
-
-    <task>
-    Evaluate whether the section content adequately addresses the section topic.
-    Use the rubrics and supporting evidence as the grading standard.
-    If the section content does not adequately address the section topic, generate
-    {number_of_follow_up_gaps} follow-up gaps that describe the missing research needed.
-    </task>
-
-    <format>
-    Respond in valid JSON with these exact keys:
-    - "grade": "pass" or "fail"
-    - "follow_up_gaps": a list of objects with exact keys "topic" and "reason"
-
-    Rules:
-    - Return "pass" only when the section materially covers the topic and rubrics.
-    - Return an empty "follow_up_gaps" list when grade is "pass".
-    - When grade is "fail", return at least one follow-up gap.
-    - Focus follow-up gaps on missing research, missing evidence, or missing comparisons.
-    </format>
-    """
-).strip()
+SECTION_GRADER_PROMPT = load_prompt("m8_section_grader")
 
 
 class QualityGate:

--- a/autosearch/skills/prompts/__init__.py
+++ b/autosearch/skills/prompts/__init__.py
@@ -1,0 +1,39 @@
+"""Packaged prompt library shipped with autosearch."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+_PROMPTS_DIR = Path(__file__).resolve().parent
+
+
+class PromptNotFoundError(FileNotFoundError):
+    """Raised when a packaged prompt file cannot be found."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"Prompt '{name}' not found at {_PROMPTS_DIR / f'{name}.md'}")
+        self.name = name
+
+
+@lru_cache(maxsize=None)
+def load_prompt(name: str) -> str:
+    """Load prompt body from autosearch/skills/prompts/<name>.md, stripping frontmatter."""
+
+    prompt_path = _PROMPTS_DIR / f"{name}.md"
+    if not prompt_path.is_file():
+        raise PromptNotFoundError(name)
+
+    raw_text = prompt_path.read_text(encoding="utf-8")
+    lines = raw_text.splitlines(keepends=True)
+    delimiters = [index for index, line in enumerate(lines) if line.strip() == "---"]
+    if len(delimiters) < 2:
+        raise ValueError(f"{prompt_path} is missing frontmatter delimiters")
+
+    body = "".join(lines[delimiters[1] + 1 :])
+    if body.endswith("\n"):
+        body = body[:-1]
+    return body
+
+
+__all__ = ["PromptNotFoundError", "load_prompt"]

--- a/autosearch/skills/prompts/m2_search_query.md
+++ b/autosearch/skills/prompts/m2_search_query.md
@@ -1,0 +1,33 @@
+---
+name: m2_search_query
+phase: M2
+description: Generate N diverse search queries from a user task, context, and knowledge recall.
+---
+Write {n} search queries to search online that form an objective view of the following task:
+"{task}"
+
+Assume the current date is {today} if required.
+
+Context:
+{context}
+
+Use this context to inform and refine your search queries. The context provides task guidance,
+evaluation criteria, and known information gaps that should shape more specific and relevant
+searches.
+
+Respond in valid JSON with this exact schema:
+{{
+  "subqueries": [
+    {{
+      "text": "search query",
+      "rationale": "why this query helps cover the task"
+    }}
+  ]
+}}
+
+Rules:
+- Return exactly {n} subqueries
+- Make the queries mutually complementary rather than redundant
+- Prefer concrete search terms over vague natural-language questions
+- Use current-year or date terms only when the task is time-sensitive
+- Keep each rationale concise and specific

--- a/autosearch/skills/prompts/m3_follow_up_query.md
+++ b/autosearch/skills/prompts/m3_follow_up_query.md
@@ -1,0 +1,34 @@
+---
+name: m3_follow_up_query
+phase: M3
+description: Convert identified research gaps into focused follow-up search queries.
+---
+Convert the identified research gaps into focused follow-up search queries.
+
+<Original user query>
+{query}
+</Original user query>
+
+<Research gaps>
+{gap_context}
+</Research gaps>
+
+<Collected evidence so far>
+{evidence_context}
+</Collected evidence so far>
+
+Respond in valid JSON with this exact schema:
+{{
+  "subqueries": [
+    {{
+      "text": "search query",
+      "rationale": "why this query helps close a specific gap"
+    }}
+  ]
+}}
+
+Rules:
+- Return at most one subquery per gap
+- Keep the queries specific, concrete, and non-redundant
+- Use date terms only when the gap is clearly time-sensitive
+- Make each rationale concise and directly tied to a gap

--- a/autosearch/skills/prompts/m3_gap_reflection.md
+++ b/autosearch/skills/prompts/m3_gap_reflection.md
@@ -1,0 +1,40 @@
+---
+name: m3_gap_reflection
+phase: M3
+description: Identify the most important remaining research gaps from executed queries and evidence.
+---
+Review the current research progress and identify only the most important remaining gaps.
+
+<Original user query>
+{query}
+</Original user query>
+
+<Current iteration>
+{iteration} of {max_iterations}
+</Current iteration>
+
+<Queries already executed>
+{subqueries}
+</Queries already executed>
+
+<Collected evidence>
+{evidence_context}
+</Collected evidence>
+
+Respond in valid JSON with this exact schema:
+{{
+  "gaps": [
+    {{
+      "topic": "missing research topic",
+      "reason": "why this missing information matters"
+    }}
+  ]
+}}
+
+Rules:
+- Return at most 3 gaps
+- Return an empty list if the evidence already covers the query well enough to draft a report
+- Focus on missing evidence, missing comparisons, missing time-sensitive details, or unanswered
+  sub-questions
+- Keep each topic concrete enough to search directly
+- Do not repeat gaps that are already covered by the collected evidence

--- a/autosearch/skills/prompts/m7_outline.md
+++ b/autosearch/skills/prompts/m7_outline.md
@@ -1,0 +1,26 @@
+---
+name: m7_outline
+phase: M7
+description: Create a concise report outline from the user query and collected evidence.
+---
+Create a concise report outline for the research task below.
+
+<User query>
+{query}
+</User query>
+
+<Evidence>
+{evidence_context}
+</Evidence>
+
+Respond in valid JSON with this exact schema:
+{{
+  "headings": ["section heading", "section heading"]
+}}
+
+Rules:
+- Return 2 to 6 section headings when possible
+- Make the headings complementary rather than redundant
+- Use the same language as the user query
+- Return headings only, without markdown markers or numbering
+- Prefer headings that reflect the evidence already collected

--- a/autosearch/skills/prompts/m7_section_write.md
+++ b/autosearch/skills/prompts/m7_section_write.md
@@ -1,0 +1,28 @@
+---
+name: m7_section_write
+phase: M7
+description: Write a report section using only the provided evidence and inline citations.
+---
+Write the body content for this report section using only the provided evidence.
+
+<Section heading>
+{heading}
+</Section heading>
+
+<Evidence list>
+{evidence_context}
+</Evidence list>
+
+Respond in valid JSON with this exact schema:
+{{
+  "content": "section body in markdown",
+  "ref_ids": [1, 2]
+}}
+
+Rules:
+- Use inline citations like [1], [2], ... directly in the prose
+- The citation number must equal the evidence list index plus 1
+- Use only citation numbers that exist in the provided evidence list
+- Do not include the section heading line itself in the content
+- Do not add a references section
+- Return "ref_ids" as the 1-based evidence indexes actually cited in the content

--- a/autosearch/skills/prompts/m8_section_grader.md
+++ b/autosearch/skills/prompts/m8_section_grader.md
@@ -1,0 +1,45 @@
+---
+name: m8_section_grader
+phase: M8
+description: Grade a report section against its topic, rubrics, and supporting evidence.
+---
+Review a report section relative to the specified topic:
+
+<Report topic>
+{topic}
+</Report topic>
+
+<section topic>
+{section_topic}
+</section topic>
+
+<section content>
+{section}
+</section content>
+
+<quality rubrics>
+{rubrics}
+</quality rubrics>
+
+<supporting evidence>
+{evidence_context}
+</supporting evidence>
+
+<task>
+Evaluate whether the section content adequately addresses the section topic.
+Use the rubrics and supporting evidence as the grading standard.
+If the section content does not adequately address the section topic, generate
+{number_of_follow_up_gaps} follow-up gaps that describe the missing research needed.
+</task>
+
+<format>
+Respond in valid JSON with these exact keys:
+- "grade": "pass" or "fail"
+- "follow_up_gaps": a list of objects with exact keys "topic" and "reason"
+
+Rules:
+- Return "pass" only when the section materially covers the topic and rubrics.
+- Return an empty "follow_up_gaps" list when grade is "pass".
+- When grade is "fail", return at least one follow-up gap.
+- Focus follow-up gaps on missing research, missing evidence, or missing comparisons.
+</format>

--- a/autosearch/synthesis/outline.py
+++ b/autosearch/synthesis/outline.py
@@ -1,37 +1,12 @@
 # Source: storm/knowledge_storm/storm_wiki/modules/outline_generation.py:L128-L167 (adapted)
-from textwrap import dedent
-
 import structlog
 from pydantic import BaseModel, Field
 
 from autosearch.core.models import Evidence
 from autosearch.llm.client import LLMClient
+from autosearch.skills.prompts import load_prompt
 
-OUTLINE_PROMPT = dedent(
-    """\
-    Create a concise report outline for the research task below.
-
-    <User query>
-    {query}
-    </User query>
-
-    <Evidence>
-    {evidence_context}
-    </Evidence>
-
-    Respond in valid JSON with this exact schema:
-    {{
-      "headings": ["section heading", "section heading"]
-    }}
-
-    Rules:
-    - Return 2 to 6 section headings when possible
-    - Make the headings complementary rather than redundant
-    - Use the same language as the user query
-    - Return headings only, without markdown markers or numbering
-    - Prefer headings that reflect the evidence already collected
-    """
-).strip()
+OUTLINE_PROMPT = load_prompt("m7_outline")
 
 
 class OutlineResponse(BaseModel):

--- a/autosearch/synthesis/section.py
+++ b/autosearch/synthesis/section.py
@@ -1,40 +1,14 @@
 # Source: storm/knowledge_storm/storm_wiki/modules/article_generation.py:L136-L177 (adapted)
 import re
-from textwrap import dedent
 
 import structlog
 from pydantic import BaseModel, Field
 
 from autosearch.core.models import Evidence, Section
 from autosearch.llm.client import LLMClient
+from autosearch.skills.prompts import load_prompt
 
-SECTION_WRITE_PROMPT = dedent(
-    """\
-    Write the body content for this report section using only the provided evidence.
-
-    <Section heading>
-    {heading}
-    </Section heading>
-
-    <Evidence list>
-    {evidence_context}
-    </Evidence list>
-
-    Respond in valid JSON with this exact schema:
-    {{
-      "content": "section body in markdown",
-      "ref_ids": [1, 2]
-    }}
-
-    Rules:
-    - Use inline citations like [1], [2], ... directly in the prose
-    - The citation number must equal the evidence list index plus 1
-    - Use only citation numbers that exist in the provided evidence list
-    - Do not include the section heading line itself in the content
-    - Do not add a references section
-    - Return "ref_ids" as the 1-based evidence indexes actually cited in the content
-    """
-).strip()
+SECTION_WRITE_PROMPT = load_prompt("m7_section_write")
 
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ include-package-data = true
 
 [tool.setuptools.package-data]
 "autosearch.skills.channels" = ["**/*.md", "**/*.py"]
+"autosearch.skills.prompts" = ["*.md"]
 
 [tool.setuptools.packages.find]
 include = ["autosearch*"]

--- a/tests/unit/test_prompt_loader.py
+++ b/tests/unit/test_prompt_loader.py
@@ -1,0 +1,86 @@
+import re
+from pathlib import Path
+
+import pytest
+
+import autosearch.skills.prompts as prompt_loader_module
+from autosearch.skills.prompts import PromptNotFoundError, load_prompt
+
+PROMPT_NAMES = [
+    "m2_search_query",
+    "m3_gap_reflection",
+    "m3_follow_up_query",
+    "m7_outline",
+    "m7_section_write",
+    "m8_section_grader",
+]
+PLACEHOLDER_RE = re.compile(r"(?<!\{)\{[a-zA-Z0-9_]+\}(?!\})")
+
+
+@pytest.fixture(autouse=True)
+def clear_prompt_cache() -> None:
+    load_prompt.cache_clear()
+    yield
+    load_prompt.cache_clear()
+
+
+def _write_prompt(tmp_path: Path, name: str, body: str) -> None:
+    (tmp_path / f"{name}.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                "phase: M0",
+                "description: Test prompt.",
+                "---",
+                body,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_prompt_returns_body_without_frontmatter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_prompt(tmp_path, "example", "Line one\n\nLine two")
+    monkeypatch.setattr(prompt_loader_module, "_PROMPTS_DIR", tmp_path)
+
+    assert load_prompt("example") == "Line one\n\nLine two"
+
+
+def test_load_prompt_raises_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(prompt_loader_module, "_PROMPTS_DIR", tmp_path)
+
+    with pytest.raises(PromptNotFoundError, match="does_not_exist"):
+        load_prompt("does_not_exist")
+
+
+def test_load_prompt_handles_placeholders(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_prompt(
+        tmp_path,
+        "placeholder_example",
+        '{{\n  "value": "{x}"\n}}',
+    )
+    monkeypatch.setattr(prompt_loader_module, "_PROMPTS_DIR", tmp_path)
+
+    prompt = load_prompt("placeholder_example")
+
+    assert prompt == '{{\n  "value": "{x}"\n}}'
+    assert prompt.format(x=1) == '{\n  "value": "1"\n}'
+
+
+def test_all_six_prompts_load_and_contain_placeholders() -> None:
+    for name in PROMPT_NAMES:
+        prompt = load_prompt(name)
+
+        assert prompt
+        assert PLACEHOLDER_RE.search(prompt)


### PR DESCRIPTION
## Summary

Extracts 6 hardcoded `dedent(...)` Python prompt strings into markdown files under `autosearch/skills/prompts/`, loaded via a new cached `load_prompt()` helper. Mirrors the existing `autosearch/skills/channels/` package-data pattern.

### Why

Prompts embedded as Python strings are:
- Hard to edit without grep-hunting through `core/`, `synthesis/`, `quality/`
- Not shippable as standalone assets for evolution or prompt-level tooling
- Invisible to skill-level discovery (channels already self-describe via SKILL.md; prompts didn't)

Moving to `.md` files with frontmatter makes prompts first-class skills, matches the channel pattern, and unblocks future prompt A/B or AVO-style evolution.

### Migrated prompts

| Source | Constant | → markdown |
|---|---|---|
| `autosearch/core/strategy.py` | `SEARCH_QUERY_PROMPT` | `m2_search_query.md` |
| `autosearch/core/iteration.py` | `GAP_REFLECTION_PROMPT` | `m3_gap_reflection.md` |
| `autosearch/core/iteration.py` | `FOLLOW_UP_QUERY_PROMPT` | `m3_follow_up_query.md` |
| `autosearch/synthesis/outline.py` | `OUTLINE_PROMPT` | `m7_outline.md` |
| `autosearch/synthesis/section.py` | `SECTION_WRITE_PROMPT` | `m7_section_write.md` |
| `autosearch/quality/gate.py` | `SECTION_GRADER_PROMPT` | `m8_section_grader.md` |

Prompt text is byte-identical to the previous `dedent(...).strip()` output (verified via `load_prompt(name).strip() == old_dedent_output.strip()`).

### Loader

`autosearch/skills/prompts/__init__.py::load_prompt(name)`:
- Reads `<name>.md`, strips frontmatter, returns body
- `@functools.lru_cache` so each prompt is loaded once per process
- Raises `PromptNotFoundError` — no silent fallbacks
- Uses `Path(__file__).resolve().parent` (not `importlib.resources` — Semgrep blocks)

### pyproject

`[tool.setuptools.package-data]` extended with `"autosearch.skills.prompts" = ["*.md"]` — same mechanism channels already use for wheel install compatibility.

## Test plan

- [x] `pytest -x -q -m "not real_llm and not perf and not slow and not network"` — `382 passed, 17 deselected` (4 new loader tests)
- [x] `ruff check` + `ruff format --check` green
- [x] Pre-push hook full suite green
- [x] Scope audit: reverted 4 sandbox-skip drift files that Codex added outside the migration scope
- [x] New `tests/unit/test_prompt_loader.py` covers: frontmatter stripping, missing-file error, placeholder round-trip, all 6 real prompts load + contain placeholders

## No backwards compat

Old `dedent(...)` blocks deleted from the 5 source files. Module-level constants (`SEARCH_QUERY_PROMPT`, etc.) keep their names — downstream `.format(...)` call sites unchanged. Pre-1.0 CalVer project, breaking change acceptable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Externalized prompt templates from code to dedicated configuration files for improved maintainability and centralized management of system prompts used across search, gap reflection, and report generation phases.

* **Tests**
  * Added comprehensive test suite for prompt loading and frontmatter parsing functionality.

* **Chores**
  * Updated package configuration to include prompt template files in distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->