### PR TITLE
fix(channels): restore arxiv + devto T0 channels (2 silent failures)

### DIFF
--- a/autosearch/skills/channels/arxiv/methods/api_search.py
+++ b/autosearch/skills/channels/arxiv/methods/api_search.py
@@ -12,7 +12,7 @@ LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="arxiv
 
 MAX_RESULTS = 10
 HTTP_TIMEOUT = 30.0
-BASE_URL = "http://export.arxiv.org/api/query"
+BASE_URL = "https://export.arxiv.org/api/query"
 
 
 def _normalize_whitespace(text: str) -> str:
@@ -21,7 +21,7 @@ def _normalize_whitespace(text: str) -> str:
 
 async def search(query: SubQuery) -> list[Evidence]:
     try:
-        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
             response = await client.get(
                 BASE_URL,
                 params={

--- a/autosearch/skills/channels/devto/methods/api_search.py
+++ b/autosearch/skills/channels/devto/methods/api_search.py
@@ -51,7 +51,7 @@ async def search(
             response = await http_client.get(
                 BASE_URL,
                 params={
-                    "tag": query.text,
+                    "search": query.text,
                     "per_page": MAX_RESULTS,
                 },
             )
@@ -60,7 +60,7 @@ async def search(
                 response = await client.get(
                     BASE_URL,
                     params={
-                        "tag": query.text,
+                        "search": query.text,
                         "per_page": MAX_RESULTS,
                     },
                 )

--- a/tests/channels/devto/test_api_search.py
+++ b/tests/channels/devto/test_api_search.py
@@ -52,7 +52,7 @@ def _client(handler) -> httpx.AsyncClient:
 @pytest.mark.asyncio
 async def test_search_maps_devto_articles_to_evidence() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.params["tag"] == "python"
+        assert request.url.params["search"] == "python"
         assert request.url.params["per_page"] == "10"
         return httpx.Response(
             200,

--- a/tests/unit/test_arxiv_channel.py
+++ b/tests/unit/test_arxiv_channel.py
@@ -35,7 +35,7 @@ def _response(
     text: str,
     *,
     status_code: int = 200,
-    url: str = "http://export.arxiv.org/api/query",
+    url: str = "https://export.arxiv.org/api/query",
     params: dict[str, object] | None = None,
 ) -> httpx.Response:
     return httpx.Response(
@@ -68,7 +68,7 @@ async def test_search_returns_evidence_from_atom_feed(
     assert all(isinstance(item, Evidence) for item in results)
     assert re.compile(r"^https?://arxiv\.org/abs/").search(results[0].url)
     assert all(re.compile(r"^https?://arxiv\.org/abs/").search(item.url) for item in results)
-    assert captured["url"] == "http://export.arxiv.org/api/query"
+    assert captured["url"] == "https://export.arxiv.org/api/query"
     assert captured["params"] == {
         "search_query": "all:retrieval augmented generation",
         "start": 0,


### PR DESCRIPTION
## Summary

Fixes two T0 channels that were returning 0 evidence with no exception — both flagged by PR #156's perf baseline test. Root causes were different despite the same symptom.

### arxiv — http→https redirect not followed

- `BASE_URL = "http://export.arxiv.org/api/query"` hardcoded. arxiv enforces HTTPS and returns 301.
- `httpx.AsyncClient` default does not follow redirects → request returns `<html>` redirect page, feedparser fails silently.
- Fix: `BASE_URL → "https://export.arxiv.org/api/query"` + `httpx.AsyncClient(follow_redirects=True)` (double safety for any future redirect).
- Verified: `arxiv: 10 evidences` on live probe against query "machine learning models".

### devto — `tag=` param doesn't accept multi-word queries

- Channel was sending `?tag=<query.text>`. `tag` param only accepts a single tag slug (`react`, `python`). For queries like "retrieval augmented generation" devto returns 404 (no such tag).
- Fix: switch to `?search=<query.text>` which accepts any free-text query.
- Verified: `devto: 10 evidences` on live probe against "retrieval augmented generation".

## Test plan

- [x] `pytest tests/unit/test_arxiv_channel.py tests/channels/devto/` — 11 tests green (fixture URL updated `http://` → `https://`; param assertion `tag` → `search`)
- [x] Full suite: `382 passed, 18 deselected` (pre-push hook)
- [x] `ruff check` green
- [x] Live end-to-end probe: both channels return 10 evidence with non-trivial titles
- [x] #156 perf baseline will be re-measured on next run (expect arxiv + devto to move from `evidences=0` to `evidences>=5`)

## Follow-ups (not this PR)

- arxiv back-to-back requests trigger rate-limit ("Rate exceeded" body, HTTP 200). Pipeline-level per-channel rate limit or cache would mitigate. Out of scope here — separate concern from the 301 redirect bug.
- devto: `tag` vs `search` param distinction worth documenting in SKILL.md Known Quirks. Trivial follow-up.