### PR TITLE
feat(channels): ship v2ex T0 channel (Chinese developer community)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ AutoSearch runs as:
 Generated from `autosearch/skills/channels/*/SKILL.md`. Run `.venv/bin/python scripts/generate_channels_table.py` after adding or changing a channel.
 
 <!-- channels-table-start -->
-### Tier 0 - always-on (19)
+### Tier 0 - always-on (20)
 | Channel | Languages | Description | Typical yield |
 |---|---|---|---|
 | arxiv | en | Use for academic preprint searches in CS/ML/physics when query is English or mixed and expects peer-reviewed or preprint papers. | medium-high |
@@ -113,6 +113,7 @@ Generated from `autosearch/skills/channels/*/SKILL.md`. Run `.venv/bin/python sc
 | sec_edgar | en | US public company filings (10-K, 10-Q, 8-K) via SEC EDGAR full-text search — financial and regulatory disclosures for research. | medium |
 | sogou_weixin | zh, mixed | Chinese WeChat Official Account articles via the public Sogou WeChat search SERP. | high |
 | stackoverflow | en, mixed | Programming Q&A with community-voted answers across 200+ technical tags via api.stackexchange.com. | high |
+| v2ex | zh, mixed | Chinese developer community discussions on programming, tech, and career — useful for native-zh developer sentiment and niche technical troubleshooting. | medium |
 | wikidata | en, mixed | Structured entity data (people, places, concepts) from Wikidata knowledge graph. | medium |
 | wikipedia | en, mixed | Authoritative encyclopedia articles via the Wikipedia Action API (English edition). | high |
 

--- a/autosearch/skills/channels/v2ex/SKILL.md
+++ b/autosearch/skills/channels/v2ex/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: v2ex
+description: Chinese developer community discussions on programming, tech, and career — useful for native-zh developer sentiment and niche technical troubleshooting.
+version: 1
+languages: [zh, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [zh, mixed]
+  query_types: [developer, programming, career, community, tech-discussion]
+  avoid_for: [academic, multimedia, social-lifestyle]
+quality_hint:
+  typical_yield: medium
+  chinese_native: true
+---
+
+## Overview
+
+V2EX (www.v2ex.com) is a long-standing Chinese developer community centered on programming, career, products, and niche technical discussion. This channel queries sov2ex.com, a third-party ElasticSearch-style search index over V2EX threads.
+
+## When to Choose It
+
+- Choose it for Chinese developer-scene queries (programming opinions, framework tradeoffs, career discussions, niche troubleshooting).
+- Choose it when the query implies programmer-audience in Chinese discourse but zhihu is too broad and weibo is too noisy.
+- Avoid for academic, multimedia, or general consumer lifestyle queries.
+
+## How To Search
+
+- `api_search` — Queries `https://www.sov2ex.com/api/search?q=<q>&size=10`. Extracts threads from `hits[*]._source` and constructs canonical thread URLs as `https://www.v2ex.com/t/{id}`.
+
+## Known Quirks
+
+- sov2ex.com is a third-party index, not V2EX's official search. Index freshness depends on that operator; thread titles/bodies are usually current but index lag can be hours.
+- V2EX itself has no public search API — the site relies on external indexes or Google site-search. This channel picks sov2ex as the most stable JSON option.
+- Developer community, so Chinese + English code snippets mix naturally in content. Language tag is `[zh, mixed]`.

--- a/autosearch/skills/channels/v2ex/methods/api_search.py
+++ b/autosearch/skills/channels/v2ex/methods/api_search.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import html
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="v2ex")
+
+BASE_URL = "https://www.sov2ex.com/api/search"
+HTTP_TIMEOUT = 15.0
+MAX_RESULTS = 10
+MAX_SNIPPET_LENGTH = 300
+TITLE_FALLBACK_LENGTH = 60
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _normalize_whitespace(text: str) -> str:
+    return WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _clean_text(value: object) -> str:
+    text = HTML_TAG_RE.sub(" ", str(value or ""))
+    return _normalize_whitespace(html.unescape(text))
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _fallback_title(content: str | None) -> str:
+    if not content:
+        return ""
+
+    excerpt = content[:TITLE_FALLBACK_LENGTH].strip()
+    if not excerpt:
+        return ""
+    if len(content) > TITLE_FALLBACK_LENGTH:
+        return f"{excerpt}…"
+    return excerpt
+
+
+def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    thread_id = str(item.get("id") or "").strip()
+    if not thread_id:
+        return None
+
+    content = _clean_text(item.get("content")) or None
+    title = _clean_text(item.get("title")) or _fallback_title(content) or "V2EX thread"
+    snippet = (
+        _truncate_on_word_boundary(content, max_length=MAX_SNIPPET_LENGTH) if content else None
+    )
+
+    return Evidence(
+        url=f"https://www.v2ex.com/t/{thread_id}",
+        title=title,
+        snippet=snippet,
+        content=content,
+        source_channel="v2ex",
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    try:
+        if http_client is not None:
+            response = await http_client.get(
+                BASE_URL,
+                params={"q": query.text, "size": MAX_RESULTS},
+            )
+        else:
+            async with httpx.AsyncClient(
+                timeout=HTTP_TIMEOUT,
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(
+                    BASE_URL,
+                    params={"q": query.text, "size": MAX_RESULTS},
+                )
+
+        response.raise_for_status()
+        payload = response.json()
+        hits = payload.get("hits")
+        if not isinstance(hits, list):
+            raise ValueError("invalid hits payload")
+    except Exception as exc:
+        LOGGER.warning("v2ex_search_failed", reason=str(exc))
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for hit in hits:
+        if not isinstance(hit, Mapping):
+            continue
+
+        source = hit.get("_source")
+        if not isinstance(source, Mapping):
+            continue
+
+        evidence = _to_evidence(source, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/tests/channels/v2ex/__init__.py
+++ b/tests/channels/v2ex/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for v2ex channel tests.

--- a/tests/channels/v2ex/test_api_search.py
+++ b/tests/channels/v2ex/test_api_search.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "autosearch"
+        / "skills"
+        / "channels"
+        / "v2ex"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_v2ex_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="react hooks", rationale="Need V2EX developer discussion coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_maps_v2ex_hits_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["q"] == "react hooks"
+        assert request.url.params["size"] == "10"
+        return httpx.Response(
+            200,
+            json={
+                "took": 5,
+                "total": 2,
+                "hits": [
+                    {
+                        "_id": "630175",
+                        "_source": {
+                            "id": 630175,
+                            "title": "大家写 React 项目都用 React hooks 吗",
+                            "content": "我感觉 React hooks 更适合颗粒度小的组件。",
+                        },
+                    },
+                    {
+                        "_id": "630176",
+                        "_source": {
+                            "id": 630176,
+                            "title": "另一篇讨论",
+                            "content": "这里有更多关于状态管理和组件拆分的经验。",
+                        },
+                    },
+                ],
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://www.v2ex.com/t/630175"
+    assert first.title == "大家写 React 项目都用 React hooks 吗"
+    assert first.snippet == "我感觉 React hooks 更适合颗粒度小的组件。"
+    assert first.content == "我感觉 React hooks 更适合颗粒度小的组件。"
+    assert first.source_channel == "v2ex"
+
+    second = results[1]
+    assert second.url == "https://www.v2ex.com/t/630176"
+    assert second.title == "另一篇讨论"
+    assert second.snippet == "这里有更多关于状态管理和组件拆分的经验。"
+    assert second.content == "这里有更多关于状态管理和组件拆分的经验。"
+    assert second.source_channel == "v2ex"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_hits_without_source() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "hits": [
+                    {"_id": "missing-source"},
+                    {
+                        "_id": "630177",
+                        "_source": {
+                            "id": 630177,
+                            "title": "有效帖子",
+                            "content": "保留这个结果。",
+                        },
+                    },
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://www.v2ex.com/t/630177"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_hits_without_thread_id() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "hits": [
+                    {
+                        "_id": "missing-id",
+                        "_source": {
+                            "title": "没有 id 的帖子",
+                            "content": "这个结果应该被跳过。",
+                        },
+                    },
+                    {
+                        "_id": "630178",
+                        "_source": {
+                            "id": 630178,
+                            "title": "保留下来的帖子",
+                            "content": "这个结果应该保留。",
+                        },
+                    },
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://www.v2ex.com/t/630178"
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_content_excerpt_when_title_empty() -> None:
+    content = "x" * 70
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "hits": [
+                    {
+                        "_id": "630179",
+                        "_source": {
+                            "id": 630179,
+                            "title": "   ",
+                            "content": content,
+                        },
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].title == f"{'x' * 60}…"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "server error"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "v2ex_search_failed"
+    assert "500" in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_truncates_snippet_at_300_chars() -> None:
+    content = ("word " * 60) + "tail beyond the snippet limit"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "hits": [
+                    {
+                        "_id": "630180",
+                        "_source": {
+                            "id": 630180,
+                            "title": "Long content thread",
+                            "content": content,
+                        },
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].snippet == f"{('word ' * 60).strip()}…"
+    assert results[0].content == content

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -16,7 +16,7 @@ def _load_specs():
 def test_all_channels_loadable() -> None:
     specs = _load_specs()
 
-    assert len(specs) == 28
+    assert len(specs) == 29
     assert [spec.name for spec in specs] == [
         "arxiv",
         "bilibili",
@@ -40,6 +40,7 @@ def test_all_channels_loadable() -> None:
         "stackoverflow",
         "tiktok",
         "twitter",
+        "v2ex",
         "weibo",
         "wikidata",
         "wikipedia",
@@ -69,7 +70,7 @@ def test_fallback_chain_matches_methods() -> None:
         assert set(spec.fallback_chain).issubset(method_ids)
 
 
-def test_chinese_native_channels_cover_10() -> None:
+def test_chinese_native_channels_cover_11() -> None:
     chinese_native = {
         spec.name
         for spec in _load_specs()
@@ -84,11 +85,12 @@ def test_chinese_native_channels_cover_10() -> None:
         "kr36",
         "podcast_cn",
         "sogou_weixin",
+        "v2ex",
         "weibo",
         "xiaohongshu",
         "zhihu",
     }
-    assert len(chinese_native) == 10
+    assert len(chinese_native) == 11
 
 
 def test_shipped_method_impls_exist_for_registry_channels() -> None:
@@ -115,6 +117,7 @@ def test_shipped_method_impls_exist_for_registry_channels() -> None:
         "stackoverflow": ["methods/api_search.py"],
         "tiktok": ["methods/via_tikhub.py"],
         "twitter": ["methods/via_tikhub.py"],
+        "v2ex": ["methods/api_search.py"],
         "weibo": ["methods/via_tikhub.py"],
         "wikidata": ["methods/api_search.py"],
         "wikipedia": ["methods/api_search.py"],
@@ -151,6 +154,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         "sec_edgar",
         "sogou_weixin",
         "stackoverflow",
+        "v2ex",
         "wikidata",
         "wikipedia",
     ]
@@ -173,6 +177,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             "sec_edgar": "methods/api_search.py",
             "sogou_weixin": "methods/api_search.py",
             "stackoverflow": "methods/api_search.py",
+            "v2ex": "methods/api_search.py",
             "wikidata": "methods/api_search.py",
             "wikipedia": "methods/api_search.py",
         }

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -181,6 +181,7 @@ def test_search_endpoint_returns_channel_empty_calls_in_json(monkeypatch) -> Non
         json={
             "query": "test query",
             "scope": {
+                "domain_followups": [],
                 "channel_scope": "all",
                 "depth": "fast",
                 "output_format": "md",


### PR DESCRIPTION
## Summary

Adds `v2ex` T0 channel — Chinese developer community discussions via sov2ex.com (third-party ElasticSearch index over V2EX).

- Endpoint `https://www.sov2ex.com/api/search?q=<q>&size=10`
- Items at `hits[*]._source` (note: direct `hits` list, not `hits.hits`)
- URL: `https://www.v2ex.com/t/{id}` canonical thread link
- Title fallback to 60-char content excerpt when title empty
- Chinese-native (`chinese_native: true`), fills a niche zhihu/weibo don't cover (programmer-audience discourse)

## Test plan

- [x] `pytest tests/channels/v2ex/ tests/unit/test_channel_skill_scaffolds.py` — 12 tests green
- [x] Full suite: `388 passed, 18 deselected`
- [x] `ruff check` + `ruff format --check` + `generate_channels_table.py --check` all green

## Interaction with pending PRs

Based on `origin/main` which does not yet contain #162 (HF Hub + OpenAlex) or #163 (SEC EDGAR). After those merge, rebase will auto-adjust scaffolds count + README.

## Channel inventory after full merge queue

T0 (20) + T1 (1) + T2 (8) = **29 channels**