### PR TITLE
feat(obs): diagnose channel silent failures via per-channel empty-result counter

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -171,6 +171,7 @@ def query(
                     "delivery_status": result.delivery_status,
                     "markdown": rendered_output,
                     "iterations": result.iterations,
+                    "channel_empty_calls": result.channel_empty_calls,
                     "quality_grade": (
                         result.quality.grade.value if result.quality is not None else None
                     ),

--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -33,6 +33,7 @@ class IterationController:
     def __init__(self, evidence_processor: EvidenceProcessor | None = None) -> None:
         self.evidence_processor = evidence_processor or EvidenceProcessor()
         self.logger = structlog.get_logger(__name__).bind(component="iteration_controller")
+        self._empty_counts: dict[str, int] = {}
 
     async def run(
         self,
@@ -42,6 +43,7 @@ class IterationController:
         budget: IterationBudget,
         client: LLMClient,
     ) -> list[Evidence]:
+        self._empty_counts = {}
         if budget.max_iterations <= 0 or not initial_queries or not channels:
             return []
 
@@ -155,6 +157,9 @@ class IterationController:
 
         return accumulated_evidence
 
+    def empty_counts_by_channel(self) -> dict[str, int]:
+        return dict(self._empty_counts)
+
     async def _search(
         self,
         subqueries: list[SubQuery],
@@ -169,18 +174,42 @@ class IterationController:
 
         evidences: list[Evidence] = []
         for (channel_name, query_text), result in zip(task_metadata, results, strict=True):
-            if isinstance(result, Exception):
-                self.logger.warning(
-                    "channel_search_failed",
+            evidences.extend(
+                await self._handle_search_result(
+                    channel_name=channel_name,
+                    query_text=query_text,
+                    result=result,
                     iteration=iteration,
-                    channel=channel_name,
-                    subquery=query_text,
-                    error=str(result),
                 )
-                continue
-            evidences.extend(result)
+            )
 
         return evidences
+
+    async def _handle_search_result(
+        self,
+        *,
+        channel_name: str,
+        query_text: str,
+        result: list[Evidence] | Exception,
+        iteration: int,
+    ) -> list[Evidence]:
+        if isinstance(result, Exception):
+            self.logger.warning(
+                "channel_search_failed",
+                iteration=iteration,
+                channel=channel_name,
+                subquery=query_text,
+                error=str(result),
+            )
+            return []
+        if result == []:
+            self._empty_counts[channel_name] = self._empty_counts.get(channel_name, 0) + 1
+            self.logger.warning(
+                "channel_empty_result",
+                channel=channel_name,
+                subquery=query_text[:80],
+            )
+        return result
 
     def _summarize(self, evidences: list[Evidence], query: str) -> list[Evidence]:
         deduped = self.evidence_processor.dedup_urls(evidences)

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -96,6 +96,7 @@ class PipelineResult:
     clarification: ClarifyResult
     markdown: str | None = None
     evidences: list[Evidence] = field(default_factory=list)
+    channel_empty_calls: dict[str, int] = field(default_factory=dict)
     reasoning_events: list[dict[str, object]] = field(default_factory=list)
     quality: EvaluationResult | None = None
     iterations: int = 0

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -340,6 +340,7 @@ class Pipeline:
                 clarification=clarification,
                 markdown=markdown,
                 evidences=processed_evidences,
+                channel_empty_calls=iteration_controller.empty_counts_by_channel(),
                 reasoning_events=list(self._captured_reasoning_events or []),
                 quality=quality,
                 iterations=iteration_controller.iterations_executed,
@@ -501,46 +502,43 @@ class _TrackingIterationController(IterationController):
         channels: list[Channel],
         iteration: int,
     ) -> list[Evidence]:
-        tasks = [channel.search(subquery) for subquery in subqueries for channel in channels]
-        task_metadata = [
-            (channel.name, subquery.text) for subquery in subqueries for channel in channels
-        ]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        evidences: list[Evidence] = []
-        for (channel_name, query_text), result in zip(task_metadata, results, strict=True):
-            result_count = 0
-            if isinstance(result, Exception):
-                self.logger.warning(
-                    "channel_search_failed",
-                    iteration=iteration,
-                    channel=channel_name,
-                    subquery=query_text,
-                    error=str(result),
-                )
-                if self.on_event is not None:
-                    await self.on_event(
-                        {
-                            "type": "error",
-                            "channel": channel_name,
-                            "phase": "search",
-                            "subquery": query_text,
-                            "message": str(result),
-                        }
-                    )
-            else:
-                result_count = len(result)
-                evidences.extend(result)
-
-            if self.session_store is not None and self.session_id is not None:
-                await self.session_store.add_query_log(
-                    self.session_id,
-                    query_text,
-                    channel_name,
-                    result_count,
-                )
-
+        evidences = await super()._search(subqueries, channels, iteration)
         self._latest_new_evidence_count = len(evidences)
+        return evidences
+
+    async def _handle_search_result(
+        self,
+        *,
+        channel_name: str,
+        query_text: str,
+        result: list[Evidence] | Exception,
+        iteration: int,
+    ) -> list[Evidence]:
+        evidences = await super()._handle_search_result(
+            channel_name=channel_name,
+            query_text=query_text,
+            result=result,
+            iteration=iteration,
+        )
+        result_count = len(evidences)
+        if isinstance(result, Exception) and self.on_event is not None:
+            await self.on_event(
+                {
+                    "type": "error",
+                    "channel": channel_name,
+                    "phase": "search",
+                    "subquery": query_text,
+                    "message": str(result),
+                }
+            )
+
+        if self.session_store is not None and self.session_id is not None:
+            await self.session_store.add_query_log(
+                self.session_id,
+                query_text,
+                channel_name,
+                result_count,
+            )
         return evidences
 
     async def _reflect(

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -85,6 +85,7 @@ def _terminal_payload(result: PipelineResult) -> dict[str, Any]:
         "type": "finished",
         "iterations": result.iterations,
         "delivery_status": result.delivery_status,
+        "channel_empty_calls": result.channel_empty_calls,
     }
     if result.delivery_status == "needs_clarification":
         payload["question"] = result.clarification.question or "More detail is required."

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -16,7 +16,7 @@ from autosearch.core.pipeline import PipelineResult
 runner = CliRunner()
 
 
-def _ok_result() -> PipelineResult:
+def _ok_result(channel_empty_calls: dict[str, int] | None = None) -> PipelineResult:
     return PipelineResult(
         delivery_status="ok",
         clarification=ClarifyResult(
@@ -32,6 +32,7 @@ def _ok_result() -> PipelineResult:
             follow_up_gaps=[],
         ),
         iterations=2,
+        channel_empty_calls=channel_empty_calls or {},
     )
 
 
@@ -134,6 +135,7 @@ def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
         "delivery_status": "ok",
         "markdown": "# Test\n\nBody",
         "iterations": 2,
+        "channel_empty_calls": {},
         "quality_grade": "pass",
         "sources": [],
         "scope": {
@@ -142,6 +144,15 @@ def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
             "output_format": "md",
         },
     }
+
+
+def test_cli_json_output_includes_channel_empty_calls(monkeypatch) -> None:
+    _install_cli_stubs(monkeypatch, _ok_result(channel_empty_calls={"arxiv": 3}))
+
+    result = runner.invoke(app, ["query", "test", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["channel_empty_calls"] == {"arxiv": 3}
 
 
 def test_cli_query_exits_two_for_needs_clarification(monkeypatch) -> None:

--- a/tests/unit/test_iteration_empty_counts.py
+++ b/tests/unit/test_iteration_empty_counts.py
@@ -1,0 +1,118 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import UTC, datetime
+
+from autosearch.core.iteration import IterationController
+from autosearch.core.models import Evidence, SubQuery
+
+NOW = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+
+
+class EmptyChannel:
+    name = "empty"
+    languages = ["en", "mixed"]
+
+    def __init__(self, responses: list[list[Evidence]]) -> None:
+        self.responses = list(responses)
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        _ = query
+        return self.responses.pop(0)
+
+
+class FilledChannel:
+    name = "filled"
+    languages = ["en", "mixed"]
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        _ = query
+        return [
+            Evidence(
+                url="https://example.com/evidence",
+                title="Evidence",
+                snippet="Evidence snippet",
+                source_channel=self.name,
+                fetched_at=NOW,
+            )
+        ]
+
+
+class FailingChannel:
+    name = "failing"
+    languages = ["en", "mixed"]
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        _ = query
+        raise RuntimeError("boom")
+
+
+class RecordingLogger:
+    def __init__(self) -> None:
+        self.warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warning_calls.append((event, kwargs))
+
+
+async def test_channel_empty_result_incremented() -> None:
+    controller = IterationController()
+    subqueries = [
+        SubQuery(text="first query", rationale="seed"),
+        SubQuery(text="second query", rationale="follow-up"),
+    ]
+
+    await controller._search(
+        subqueries=subqueries,
+        channels=[EmptyChannel(responses=[[], []])],
+        iteration=1,
+    )
+
+    assert controller.empty_counts_by_channel() == {"empty": 2}
+
+
+async def test_channel_empty_result_logged(monkeypatch) -> None:
+    controller = IterationController()
+    logger = RecordingLogger()
+    monkeypatch.setattr(controller, "logger", logger)
+    subquery_text = "x" * 120
+
+    await controller._search(
+        subqueries=[SubQuery(text=subquery_text, rationale="seed")],
+        channels=[EmptyChannel(responses=[[]])],
+        iteration=1,
+    )
+
+    assert logger.warning_calls == [
+        (
+            "channel_empty_result",
+            {
+                "channel": "empty",
+                "subquery": subquery_text[:80],
+            },
+        )
+    ]
+
+
+async def test_channel_with_evidence_not_counted() -> None:
+    controller = IterationController()
+
+    result = await controller._search(
+        subqueries=[SubQuery(text="query", rationale="seed")],
+        channels=[FilledChannel()],
+        iteration=1,
+    )
+
+    assert len(result) == 1
+    assert controller.empty_counts_by_channel().get("filled", 0) == 0
+
+
+async def test_channel_exception_not_counted_as_empty() -> None:
+    controller = IterationController()
+
+    result = await controller._search(
+        subqueries=[SubQuery(text="query", rationale="seed")],
+        channels=[FailingChannel()],
+        iteration=1,
+    )
+
+    assert result == []
+    assert controller.empty_counts_by_channel().get("failing", 0) == 0

--- a/tests/unit/test_pipeline_channel_error.py
+++ b/tests/unit/test_pipeline_channel_error.py
@@ -106,6 +106,7 @@ async def test_pipeline_continues_after_channel_error_and_emits_error_event() ->
 
     assert result.delivery_status == "ok"
     assert [evidence.url for evidence in result.evidences] == ["https://example.com/working"]
+    assert result.channel_empty_calls == {}
     assert "Working evidence supports the answer" in (result.markdown or "")
     assert failing_channel.calls == 1
     assert working_channel.calls == 1

--- a/tests/unit/test_pipeline_events.py
+++ b/tests/unit/test_pipeline_events.py
@@ -143,3 +143,40 @@ async def test_pipeline_awaits_async_event_callbacks() -> None:
 
     assert any(event["type"] == "phase" for event in recorded)
     assert recorded[-1] == {"type": "quality", "grade": "pass", "follow_up_count": 0}
+
+
+async def test_pipeline_result_includes_channel_empty_calls() -> None:
+    client = DummyClient(
+        [
+            {
+                "known_facts": ["Typer is a Python CLI framework."],
+                "gaps": [{"topic": "Current feature coverage", "reason": "Needs fresh evidence"}],
+            },
+            {
+                "need_clarification": False,
+                "question": "",
+                "verification": "Research empty channel result handling.",
+                "rubrics": ["Explain observed behavior"],
+                "mode": "fast",
+            },
+            {
+                "subqueries": [
+                    {"text": "empty channel result behavior", "rationale": "exercise the channel"}
+                ]
+            },
+            {"gaps": []},
+            {"headings": ["Overview"]},
+            {"content": "The channel produced no evidence in this run.", "ref_ids": []},
+            {"grade": "pass", "follow_up_gaps": []},
+        ]
+    )
+    channel = FakeChannel([[]])
+
+    result = await Pipeline(llm=client, channels=[channel]).run(
+        "How are empty channel results exposed?",
+        mode_hint=SearchMode.FAST,
+    )
+
+    assert result.delivery_status == "ok"
+    assert result.evidences == []
+    assert result.channel_empty_calls == {"fake": 1}

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -9,7 +9,7 @@ from autosearch.core.models import ClarifyResult, SearchMode
 from autosearch.core.pipeline import PipelineResult
 
 
-def _ok_result() -> PipelineResult:
+def _ok_result(channel_empty_calls: dict[str, int] | None = None) -> PipelineResult:
     return PipelineResult(
         delivery_status="ok",
         clarification=ClarifyResult(
@@ -21,6 +21,7 @@ def _ok_result() -> PipelineResult:
         ),
         markdown="# Test\n\nBody",
         iterations=2,
+        channel_empty_calls=channel_empty_calls or {},
     )
 
 
@@ -132,6 +133,7 @@ def test_search_streams_started_and_finished_events(monkeypatch) -> None:
         "markdown": "# Test\n\nBody",
         "iterations": 2,
         "delivery_status": "ok",
+        "channel_empty_calls": {},
     } in events
     assert pipeline.calls == [("test query", SearchMode.FAST)]
 
@@ -161,6 +163,31 @@ def test_search_streams_needs_clarification_event(monkeypatch) -> None:
         "type": "finished",
         "delivery_status": "needs_clarification",
         "iterations": 0,
+        "channel_empty_calls": {},
         "question": "Which deployment target do you care about?",
     } in events
     assert pipeline.calls == [("test query", SearchMode.DEEP)]
+
+
+def test_search_endpoint_returns_channel_empty_calls_in_json(monkeypatch) -> None:
+    pipeline = _StubPipeline(result=_ok_result(channel_empty_calls={"arxiv": 3}))
+    _install_pipeline_factory(monkeypatch, pipeline)
+    client = TestClient(server_main.app)
+
+    response = client.post(
+        "/search",
+        json={
+            "query": "test query",
+            "scope": {
+                "channel_scope": "all",
+                "depth": "fast",
+                "output_format": "md",
+            },
+        },
+    )
+
+    events = _parse_sse_events(response.text)
+    finished = next(event for event in events if event["type"] == "finished")
+
+    assert response.status_code == 200
+    assert finished["channel_empty_calls"] == {"arxiv": 3}


### PR DESCRIPTION
## Summary

Plan-0420 W4 F401: when a channel succeeds (no exception) but returns `[]` evidence for a subquery, currently the pipeline silently swallows it. This is how arxiv + devto were broken for weeks before PR #156's perf baseline test caught them.

### Changes

- **`IterationController`** (`autosearch/core/iteration.py`): per-channel empty counter `_empty_counts`, incremented + warn-logged `channel_empty_result` on every `(channel, subquery) → []` pair. Exposed via `empty_counts_by_channel()`.
- **`PipelineResult`** (`autosearch/core/models.py`): new field `channel_empty_calls: dict[str, int]`.
- **Pipeline** (`autosearch/core/pipeline.py`): threads counter into the `PipelineResult` construction.
- **Server** (`autosearch/server/main.py`): `/search` SSE terminal payload includes `channel_empty_calls`.
- **CLI** (`autosearch/cli/main.py`): `--json` output includes `channel_empty_calls`.

### Boundary

- Channel **exceptions** still flow through the existing error path — not counted as "empty". Silent success with 0 evidence is a distinct signal.
- `needs_clarification` early-return path is untouched (no channel calls happen).

## Test plan

- [x] `pytest tests/unit/test_pipeline_channel_error.py tests/unit/test_iteration_empty_counts.py tests/unit/test_pipeline_events.py tests/unit/test_server.py tests/unit/test_cli_query.py` — 18 tests green
- [x] Full suite: `389 passed, 18 deselected`
- [x] `ruff check` + `ruff format --check` green
- [x] Test coverage: empty-counter increment, warn-log payload, non-empty channels at 0, channel exceptions not mis-counted, PipelineResult carries the dict, both JSON surfaces expose it

## Future use

- Channel routing smart selection (plan-0420 W5) can feed this back into per-channel health / cooldown decisions: a channel that's returning 0 evidence 3 consecutive calls should probably be skipped on the 4th.