### PR TITLE
feat(channels): ship dblp + crossref T0 academic channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,12 @@ AutoSearch runs as:
 Generated from `autosearch/skills/channels/*/SKILL.md`. Run `.venv/bin/python scripts/generate_channels_table.py` after adding or changing a channel.
 
 <!-- channels-table-start -->
-### Tier 0 - always-on (20)
+### Tier 0 - always-on (21)
 | Channel | Languages | Description | Typical yield |
 |---|---|---|---|
 | arxiv | en | Use for academic preprint searches in CS/ML/physics when query is English or mixed and expects peer-reviewed or preprint papers. | medium-high |
+| crossref | en | Cross-publisher scholarly search via the Crossref DOI registry, useful for journal articles, book chapters, and citation-linked research metadata. | medium |
+| dblp | en | Computer science bibliography search — technical papers, proceedings, and journal articles indexed by venue, author, and year. | medium |
 | ddgs | en, mixed | DuckDuckGo Search — free general web search with no auth, use as broad default for any English or mixed query. | medium |
 | devto | en, mixed | Developer blog articles tagged by technology topic, via the public dev.to API. | medium |
 | github | en | Use for code-level, issue-level, and repository discovery when query involves a library, framework, or implementation detail. | high |
@@ -113,7 +115,6 @@ Generated from `autosearch/skills/channels/*/SKILL.md`. Run `.venv/bin/python sc
 | sec_edgar | en | US public company filings (10-K, 10-Q, 8-K) via SEC EDGAR full-text search — financial and regulatory disclosures for research. | medium |
 | sogou_weixin | zh, mixed | Chinese WeChat Official Account articles via the public Sogou WeChat search SERP. | high |
 | stackoverflow | en, mixed | Programming Q&A with community-voted answers across 200+ technical tags via api.stackexchange.com. | high |
-| v2ex | zh, mixed | Chinese developer community discussions on programming, tech, and career — useful for native-zh developer sentiment and niche technical troubleshooting. | medium |
 | wikidata | en, mixed | Structured entity data (people, places, concepts) from Wikidata knowledge graph. | medium |
 | wikipedia | en, mixed | Authoritative encyclopedia articles via the Wikipedia Action API (English edition). | high |
 

--- a/autosearch/skills/channels/crossref/SKILL.md
+++ b/autosearch/skills/channels/crossref/SKILL.md
@@ -1,0 +1,43 @@
+# Skill Attribution
+> Source: self-written for task Plan-0420 W7 F701 + F702.
+
+---
+name: crossref
+description: Cross-publisher scholarly search via the Crossref DOI registry, useful for journal articles, book chapters, and citation-linked research metadata.
+version: 1
+languages: [en]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en]
+  query_types: [academic, doi-lookup, citation, scholarly, journal-article]
+  avoid_for: [social, multimedia, real-time]
+quality_hint:
+  typical_yield: medium
+  chinese_native: false
+---
+
+## Overview
+
+`crossref` is the broad DOI-registry channel for scholarly metadata across many publishers, journals, books, and proceedings. It complements specialized paper indexes by widening recall when the user asks for citation-oriented or publisher-agnostic academic coverage.
+
+## When To Choose It
+
+- Choose it for English scholarly search, DOI-oriented lookup, journal article discovery, and citation-heavy queries.
+- Choose it when a cross-publisher registry is more useful than a discipline-specific bibliography.
+- Avoid it for social content, multimedia search, or real-time discussion.
+
+## How To Search
+
+- `api_search` queries the Crossref works API by title and normalizes title, author, venue, year, abstract, and DOI URL fields.
+- When abstracts are missing, snippets are synthesized from authors, container title, year, type, and citation count.
+
+## Known Quirks
+
+- Abstracts may arrive as JATS-like tagged strings and need lightweight tag stripping.
+- Metadata quality varies by publisher, so author and date completeness can differ between records.
+- Crossref is broad rather than domain-specific, so relevance can be noisier than a focused academic index.

--- a/autosearch/skills/channels/crossref/methods/api_search.py
+++ b/autosearch/skills/channels/crossref/methods/api_search.py
@@ -1,0 +1,219 @@
+# Self-written for task Plan-0420 W7 F701 + F702
+import html
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="crossref")
+
+MAX_RESULTS = 10
+HTTP_TIMEOUT = 15.0
+MAX_SNIPPET_LENGTH = 300
+BASE_URL = "https://api.crossref.org/works"
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = _normalize_whitespace(text)
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _first_text(value: object) -> str:
+    if not isinstance(value, list):
+        return ""
+
+    for item in value:
+        text = _normalize_whitespace(str(item or "").strip())
+        if text:
+            return text
+
+    return ""
+
+
+def _author_name(author: Mapping[str, object]) -> str:
+    explicit_name = _normalize_whitespace(str(author.get("name") or "").strip())
+    if explicit_name:
+        return explicit_name
+
+    given = _normalize_whitespace(str(author.get("given") or "").strip())
+    family = _normalize_whitespace(str(author.get("family") or "").strip())
+    return " ".join(part for part in (given, family) if part).strip()
+
+
+def _authors_text(authors: object) -> str:
+    if not isinstance(authors, list):
+        return ""
+
+    names: list[str] = []
+    for author in authors:
+        if not isinstance(author, Mapping):
+            continue
+
+        name = _author_name(author)
+        if name:
+            names.append(name)
+
+    return ", ".join(names[:3])
+
+
+def _published_year(item: Mapping[str, object]) -> str:
+    for key in ("published-print", "published", "issued"):
+        published = item.get(key)
+        if not isinstance(published, Mapping):
+            continue
+
+        date_parts = published.get("date-parts")
+        if not isinstance(date_parts, list) or not date_parts:
+            continue
+
+        first_part = date_parts[0]
+        if not isinstance(first_part, list) or not first_part:
+            continue
+
+        year = first_part[0]
+        if isinstance(year, int):
+            return str(year)
+        if isinstance(year, str) and year.strip():
+            return year.strip()
+
+    return ""
+
+
+def _clean_abstract(abstract: object) -> str:
+    cleaned = TAG_RE.sub(" ", str(abstract or ""))
+    return _normalize_whitespace(html.unescape(cleaned))
+
+
+def _build_fallback_snippet(item: Mapping[str, object]) -> str:
+    parts: list[str] = []
+
+    authors = _authors_text(item.get("author"))
+    if authors:
+        parts.append(authors)
+
+    container_title = _first_text(item.get("container-title"))
+    if container_title:
+        parts.append(container_title)
+
+    year = _published_year(item)
+    if year:
+        parts.append(year)
+
+    work_type = _normalize_whitespace(str(item.get("type") or "").strip())
+    if work_type:
+        parts.append(work_type)
+
+    cited = item.get("is-referenced-by-count")
+    parts.append(f"cited {cited}" if isinstance(cited, int) else "cited 0")
+
+    return " · ".join(parts)
+
+
+def _resolve_url(item: Mapping[str, object]) -> str | None:
+    url = str(item.get("URL") or "").strip()
+    if url:
+        return url
+
+    doi = str(item.get("DOI") or "").strip()
+    if doi:
+        return f"https://doi.org/{doi}"
+
+    return None
+
+
+def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    title = _first_text(item.get("title"))
+    if not title:
+        return None
+
+    url = _resolve_url(item)
+    if not url:
+        return None
+
+    abstract = _clean_abstract(item.get("abstract"))
+    if abstract:
+        snippet = _truncate_on_word_boundary(abstract, max_length=MAX_SNIPPET_LENGTH)
+        content = abstract
+    else:
+        snippet = _truncate_on_word_boundary(
+            _build_fallback_snippet(item),
+            max_length=MAX_SNIPPET_LENGTH,
+        )
+        content = snippet or None
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet or None,
+        content=content,
+        source_channel="crossref",
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    headers = {"Accept": "application/json"}
+    params = {
+        "query.title": query.text,
+        "rows": MAX_RESULTS,
+    }
+    try:
+        if http_client is not None:
+            response = await http_client.get(BASE_URL, params=params, headers=headers)
+        else:
+            async with httpx.AsyncClient(
+                timeout=HTTP_TIMEOUT,
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(BASE_URL, params=params, headers=headers)
+
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise ValueError("invalid payload")
+
+        message = payload.get("message")
+        if not isinstance(message, Mapping):
+            raise ValueError("invalid message payload")
+
+        items = message.get("items")
+        if not isinstance(items, list):
+            raise ValueError("invalid items payload")
+    except Exception as exc:
+        LOGGER.warning("crossref_search_failed", reason=str(exc))
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+
+        evidence = _to_evidence(item, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/autosearch/skills/channels/dblp/SKILL.md
+++ b/autosearch/skills/channels/dblp/SKILL.md
@@ -1,0 +1,43 @@
+# Skill Attribution
+> Source: self-written for task Plan-0420 W7 F701 + F702.
+
+---
+name: dblp
+description: Computer science bibliography search — technical papers, proceedings, and journal articles indexed by venue, author, and year.
+version: 1
+languages: [en]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 30, per_hour: 500}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [en]
+  query_types: [academic, computer-science, research, technical-paper]
+  avoid_for: [social, multimedia, real-time]
+quality_hint:
+  typical_yield: medium
+  chinese_native: false
+---
+
+## Overview
+
+`dblp` is the focused bibliography channel for computer science papers, conference proceedings, and journal articles. It is useful when the query is clearly CS-oriented and benefits from venue, author, and year metadata even when abstracts are unavailable.
+
+## When To Choose It
+
+- Choose it for English CS paper discovery, author lookup, venue lookup, and bibliography-style queries.
+- Choose it when the planner wants broader CS venue coverage than a single preprint index.
+- Avoid it for social discussion, multimedia content, or breaking news.
+
+## How To Search
+
+- `api_search` queries the DBLP publication API and normalizes hits into evidence with external links when available.
+- Result snippets are synthesized from authors, venue, year, and record type because DBLP does not provide abstracts.
+
+## Known Quirks
+
+- Titles may end with a trailing period in the raw API payload and should be normalized.
+- Some hits only expose a DBLP record page while others provide an external DOI landing page.
+- Coverage is strongest for computer science and adjacent technical literature, not general scholarly search.

--- a/autosearch/skills/channels/dblp/methods/api_search.py
+++ b/autosearch/skills/channels/dblp/methods/api_search.py
@@ -1,0 +1,181 @@
+# Self-written for task Plan-0420 W7 F701 + F702
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, SubQuery
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="dblp")
+
+MAX_RESULTS = 10
+HTTP_TIMEOUT = 15.0
+MAX_SNIPPET_LENGTH = 300
+BASE_URL = "https://dblp.org/search/publ/api"
+
+
+def _normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = _normalize_whitespace(text)
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _clean_title(title: object) -> str:
+    normalized = _normalize_whitespace(str(title or "").strip())
+    if normalized.endswith("."):
+        normalized = normalized[:-1].rstrip()
+    return normalized
+
+
+def _author_names(authors: object) -> list[str]:
+    if not isinstance(authors, Mapping):
+        return []
+
+    raw_authors = authors.get("author")
+    if isinstance(raw_authors, Mapping):
+        items = [raw_authors]
+    elif isinstance(raw_authors, list):
+        items = raw_authors
+    else:
+        return []
+
+    names: list[str] = []
+    for item in items:
+        if isinstance(item, Mapping):
+            name = _normalize_whitespace(str(item.get("text") or "").strip())
+        else:
+            name = _normalize_whitespace(str(item or "").strip())
+        if name:
+            names.append(name)
+
+    return names
+
+
+def _resolve_url(info: Mapping[str, object]) -> str | None:
+    for key in ("ee", "url"):
+        url = str(info.get(key) or "").strip()
+        if url:
+            return url
+    return None
+
+
+def _build_snippet(info: Mapping[str, object]) -> str | None:
+    parts: list[str] = []
+
+    authors = ", ".join(_author_names(info.get("authors"))[:3])
+    if authors:
+        parts.append(authors)
+
+    venue = _normalize_whitespace(str(info.get("venue") or "").strip())
+    if venue:
+        parts.append(venue)
+
+    year = _normalize_whitespace(str(info.get("year") or "").strip())
+    if year:
+        parts.append(year)
+
+    record_type = _normalize_whitespace(str(info.get("type") or "").strip())
+    if record_type:
+        parts.append(record_type)
+
+    snippet = " · ".join(parts)
+    return _truncate_on_word_boundary(snippet, max_length=MAX_SNIPPET_LENGTH) or None
+
+
+def _to_evidence(hit: Mapping[str, object], *, fetched_at: datetime) -> Evidence | None:
+    info = hit.get("info")
+    if not isinstance(info, Mapping):
+        return None
+
+    title = _clean_title(info.get("title"))
+    if not title:
+        return None
+
+    url = _resolve_url(info)
+    if not url:
+        return None
+
+    snippet = _build_snippet(info)
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=snippet,
+        source_channel="dblp",
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> list[Evidence]:
+    headers = {"Accept": "application/json"}
+    params = {
+        "q": query.text,
+        "h": MAX_RESULTS,
+        "format": "json",
+    }
+
+    try:
+        if http_client is not None:
+            response = await http_client.get(BASE_URL, params=params, headers=headers)
+        else:
+            async with httpx.AsyncClient(
+                timeout=HTTP_TIMEOUT,
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(BASE_URL, params=params, headers=headers)
+
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise ValueError("invalid payload")
+
+        result = payload.get("result")
+        if not isinstance(result, Mapping):
+            raise ValueError("invalid result payload")
+
+        hits = result.get("hits")
+        if not isinstance(hits, Mapping):
+            raise ValueError("invalid hits payload")
+
+        raw_items = hits.get("hit", [])
+        if isinstance(raw_items, list):
+            items = raw_items
+        elif isinstance(raw_items, Mapping):
+            items = [raw_items]
+        elif raw_items in (None, ""):
+            items = []
+        else:
+            raise ValueError("invalid hit payload")
+    except Exception as exc:
+        LOGGER.warning("dblp_search_failed", reason=str(exc))
+        return []
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+
+        evidence = _to_evidence(item, fetched_at=fetched_at)
+        if evidence is not None:
+            evidences.append(evidence)
+
+    return evidences

--- a/tests/channels/crossref/__init__.py
+++ b/tests/channels/crossref/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task Plan-0420 W7 F701 + F702

--- a/tests/channels/crossref/test_api_search.py
+++ b/tests/channels/crossref/test_api_search.py
@@ -1,0 +1,265 @@
+# Self-written for task Plan-0420 W7 F701 + F702
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "autosearch"
+        / "skills"
+        / "channels"
+        / "crossref"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_crossref_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="retrieval augmented generation", rationale="Need scholarly metadata")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _truncate_expected(text: str, *, max_length: int = 300) -> str:
+    text = " ".join(text.split())
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+@pytest.mark.asyncio
+async def test_search_maps_crossref_items_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["query.title"] == "retrieval augmented generation"
+        assert request.url.params["rows"] == "10"
+        assert request.headers["accept"] == "application/json"
+        return httpx.Response(
+            200,
+            json={
+                "message": {
+                    "items": [
+                        {
+                            "DOI": "10.1000/rag.2024.1",
+                            "title": ["Retrieval-Augmented Generation Survey"],
+                            "author": [
+                                {"given": "Alice", "family": "Author"},
+                                {"given": "Bob", "family": "Scientist"},
+                            ],
+                            "abstract": "<jats:p>RAG survey for large language models.</jats:p>",
+                            "issued": {"date-parts": [[2024, 1, 1]]},
+                            "container-title": ["Journal of AI Systems"],
+                            "type": "journal-article",
+                            "is-referenced-by-count": 123,
+                            "URL": "https://doi.org/10.1000/rag.2024.1",
+                        },
+                        {
+                            "DOI": "10.1000/rag.2023.2",
+                            "title": ["Grounded Generation Benchmarks"],
+                            "author": [
+                                {"name": "Carol Researcher"},
+                                {"given": "Dan", "family": "Writer"},
+                                {"given": "Eve", "family": "Builder"},
+                            ],
+                            "published": {"date-parts": [[2023, 5, 20]]},
+                            "container-title": ["Proceedings of ExampleConf"],
+                            "type": "proceedings-article",
+                            "is-referenced-by-count": 42,
+                            "URL": "https://doi.org/10.1000/rag.2023.2",
+                        },
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://doi.org/10.1000/rag.2024.1"
+    assert first.title == "Retrieval-Augmented Generation Survey"
+    assert first.snippet == "RAG survey for large language models."
+    assert first.content == "RAG survey for large language models."
+    assert first.source_channel == "crossref"
+
+    second = results[1]
+    assert second.url == "https://doi.org/10.1000/rag.2023.2"
+    assert second.title == "Grounded Generation Benchmarks"
+    assert (
+        second.snippet == "Carol Researcher, Dan Writer, Eve Builder · Proceedings of ExampleConf"
+        " · 2023 · proceedings-article · cited 42"
+    )
+    assert second.content == second.snippet
+
+
+@pytest.mark.asyncio
+async def test_search_skips_items_without_title_or_url() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "message": {
+                    "items": [
+                        {
+                            "DOI": "10.1000/no-title",
+                            "title": [],
+                            "URL": "https://doi.org/10.1000/no-title",
+                        },
+                        {
+                            "DOI": "",
+                            "title": ["Missing URL"],
+                            "URL": "",
+                        },
+                        {
+                            "DOI": "10.1000/valid",
+                            "title": ["Valid Paper"],
+                            "URL": "https://doi.org/10.1000/valid",
+                        },
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].title == "Valid Paper"
+    assert results[0].url == "https://doi.org/10.1000/valid"
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_doi_url() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "message": {
+                    "items": [
+                        {
+                            "DOI": "10.5555/example",
+                            "title": ["DOI Fallback"],
+                            "URL": "",
+                            "author": [{"name": "Fallback Author"}],
+                            "issued": {"date-parts": [[2022]]},
+                            "type": "journal-article",
+                            "is-referenced-by-count": 7,
+                        }
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://doi.org/10.5555/example"
+
+
+@pytest.mark.asyncio
+async def test_search_handles_empty_items() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"message": {"items": []}}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, json={"error": "bad gateway"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "crossref_search_failed"
+    assert "502" in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_truncates_long_abstract_and_keeps_full_content() -> None:
+    long_abstract = "<jats:p>" + ("word " * 70) + "splitpoint continues after the limit</jats:p>"
+    cleaned_abstract = ("word " * 70) + "splitpoint continues after the limit"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "message": {
+                    "items": [
+                        {
+                            "DOI": "10.1000/long",
+                            "title": ["Long Abstract Paper"],
+                            "author": [{"name": "Long Author"}],
+                            "abstract": long_abstract,
+                            "issued": {"date-parts": [[2025]]},
+                            "container-title": ["Journal of Long Abstracts"],
+                            "type": "journal-article",
+                            "is-referenced-by-count": 3,
+                            "URL": "https://doi.org/10.1000/long",
+                        }
+                    ]
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].snippet == _truncate_expected(cleaned_abstract)
+    assert results[0].content == " ".join(cleaned_abstract.split())
+    assert results[0].snippet is not None
+    assert results[0].snippet.endswith("…")

--- a/tests/channels/dblp/__init__.py
+++ b/tests/channels/dblp/__init__.py
@@ -1,0 +1,1 @@
+# Self-written for task Plan-0420 W7 F701 + F702

--- a/tests/channels/dblp/test_api_search.py
+++ b/tests/channels/dblp/test_api_search.py
@@ -1,0 +1,286 @@
+# Self-written for task Plan-0420 W7 F701 + F702
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "autosearch"
+        / "skills"
+        / "channels"
+        / "dblp"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_dblp_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="transformer attention", rationale="Need CS bibliography coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _truncate_expected(text: str, *, max_length: int = 300) -> str:
+    text = " ".join(text.split())
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+@pytest.mark.asyncio
+async def test_search_maps_dblp_hits_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["q"] == "transformer attention"
+        assert request.url.params["h"] == "10"
+        assert request.url.params["format"] == "json"
+        assert request.headers["accept"] == "application/json"
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "hits": {
+                        "hit": [
+                            {
+                                "@score": "1.0",
+                                "@id": "1",
+                                "url": "https://dblp.org/rec/conf/nips/VaswaniSPUJGKP17",
+                                "info": {
+                                    "title": "Attention Is All You Need.",
+                                    "authors": {
+                                        "author": [
+                                            {"text": "Ashish Vaswani"},
+                                            {"text": "Noam Shazeer"},
+                                            {"text": "Niki Parmar"},
+                                            {"text": "Jakob Uszkoreit"},
+                                        ]
+                                    },
+                                    "venue": "NeurIPS",
+                                    "year": "2017",
+                                    "type": "Conference and Workshop Papers",
+                                    "ee": "https://doi.org/10.5555/3295222.3295349",
+                                    "url": "https://dblp.org/rec/conf/nips/VaswaniSPUJGKP17",
+                                },
+                            },
+                            {
+                                "@score": "0.9",
+                                "@id": "2",
+                                "url": "https://dblp.org/rec/journals/corr/abs-2401-12345",
+                                "info": {
+                                    "title": "Transformers in Practice.",
+                                    "authors": {"author": {"text": "Alice Researcher"}},
+                                    "venue": "CoRR",
+                                    "year": "2024",
+                                    "type": "Journal Articles",
+                                    "url": "https://dblp.org/rec/journals/corr/abs-2401-12345",
+                                },
+                            },
+                        ]
+                    }
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://doi.org/10.5555/3295222.3295349"
+    assert first.title == "Attention Is All You Need"
+    assert (
+        first.snippet
+        == "Ashish Vaswani, Noam Shazeer, Niki Parmar · NeurIPS · 2017 · Conference and Workshop Papers"
+    )
+    assert first.content == first.snippet
+    assert first.source_channel == "dblp"
+
+    second = results[1]
+    assert second.url == "https://dblp.org/rec/journals/corr/abs-2401-12345"
+    assert second.title == "Transformers in Practice"
+    assert second.snippet == "Alice Researcher · CoRR · 2024 · Journal Articles"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_hits_without_title_or_url() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "hits": {
+                        "hit": [
+                            {
+                                "info": {
+                                    "title": "",
+                                    "authors": {"author": [{"text": "Missing Title"}]},
+                                    "url": "https://dblp.org/rec/skip-title",
+                                }
+                            },
+                            {
+                                "info": {
+                                    "title": "Missing URL.",
+                                    "authors": {"author": [{"text": "Missing Url"}]},
+                                }
+                            },
+                            {
+                                "info": {
+                                    "title": "Valid Entry.",
+                                    "authors": {"author": [{"text": "Valid Author"}]},
+                                    "venue": "ICML",
+                                    "year": "2024",
+                                    "type": "Conference and Workshop Papers",
+                                    "url": "https://dblp.org/rec/conf/icml/valid24",
+                                }
+                            },
+                        ]
+                    }
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].title == "Valid Entry"
+    assert results[0].url == "https://dblp.org/rec/conf/icml/valid24"
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_info_url_when_ee_missing() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "hits": {
+                        "hit": {
+                            "info": {
+                                "title": "Fallback URL.",
+                                "authors": {"author": [{"text": "Fallback Author"}]},
+                                "venue": "ACL",
+                                "year": "2024",
+                                "type": "Conference and Workshop Papers",
+                                "url": "https://dblp.org/rec/conf/acl/fallback24",
+                            }
+                        }
+                    }
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://dblp.org/rec/conf/acl/fallback24"
+
+
+@pytest.mark.asyncio
+async def test_search_handles_empty_hits() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"result": {"hits": {"hit": []}}}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "unavailable"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "dblp_search_failed"
+    assert "503" in str(logger.events[0][1]["reason"])
+
+
+@pytest.mark.asyncio
+async def test_search_truncates_long_synthesized_snippet() -> None:
+    long_venue = ("VeryLongVenueName " * 20).strip()
+    long_type = ("LongTypeLabel " * 15).strip()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "hits": {
+                        "hit": [
+                            {
+                                "info": {
+                                    "title": "Long Metadata.",
+                                    "authors": {"author": [{"text": "word"} for _ in range(120)]},
+                                    "venue": long_venue,
+                                    "year": "2025",
+                                    "type": long_type,
+                                    "url": "https://dblp.org/rec/conf/test/long25",
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    expected = _truncate_expected(f"word, word, word · {long_venue} · 2025 · {long_type}")
+    assert len(results) == 1
+    assert results[0].snippet == expected
+    assert results[0].content == expected
+    assert results[0].snippet is not None
+    assert results[0].snippet.endswith("…")

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -16,10 +16,12 @@ def _load_specs():
 def test_all_channels_loadable() -> None:
     specs = _load_specs()
 
-    assert len(specs) == 29
+    assert len(specs) == 31
     assert [spec.name for spec in specs] == [
         "arxiv",
         "bilibili",
+        "crossref",
+        "dblp",
         "ddgs",
         "devto",
         "douyin",
@@ -97,6 +99,8 @@ def test_shipped_method_impls_exist_for_registry_channels() -> None:
     expected_impls = {
         "arxiv": ["methods/api_search.py"],
         "bilibili": ["methods/via_tikhub.py"],
+        "crossref": ["methods/api_search.py"],
+        "dblp": ["methods/api_search.py"],
         "ddgs": ["methods/api.py"],
         "devto": ["methods/api_search.py"],
         "douyin": ["methods/via_tikhub.py"],
@@ -138,6 +142,8 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
 
     assert [channel.name for channel in registry.available()] == [
         "arxiv",
+        "crossref",
+        "dblp",
         "ddgs",
         "devto",
         "github",
@@ -162,6 +168,8 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         metadata = registry.metadata(spec.name)
         expected_impls = {
             "arxiv": "methods/api_search.py",
+            "crossref": "methods/api_search.py",
+            "dblp": "methods/api_search.py",
             "ddgs": "methods/api.py",
             "devto": "methods/api_search.py",
             "google_news": "methods/api_search.py",


### PR DESCRIPTION
## Summary

Plan-0420 W7 F701 + F702: 2 academic T0 channels complementing the existing `papers` aggregator and forthcoming `openalex` (#162):

- **dblp** — `https://dblp.org/search/publ/api` — computer science bibliography (proceedings, journal articles, indexed by venue/author/year). URL priority: `info.ee` (external DOI) → `info.url` (DBLP record). Synthesized snippet `authors · venue · year · type`.
- **crossref** — `https://api.crossref.org/works` — cross-publisher DOI registry covering general scholarly works. Uses item `URL` or falls back to `https://doi.org/{DOI}`. Abstract tag-stripped if present, else synthesized `authors · container · year · type · cited N`.

## Test plan

- [x] `pytest tests/channels/dblp/ tests/channels/crossref/ tests/unit/test_channel_skill_scaffolds.py` — 18 tests green
- [x] Full suite: `394 passed, 18 deselected`
- [x] `ruff check` + `ruff format --check` + `generate_channels_table.py --check` green

## Interaction with pending PRs

Branch based on `origin/main`. After the queue (#162 HF+OpenAlex, #163 SEC, #164 V2EX) merges, rebase auto-adjusts scaffold count + README table.

## Final channel inventory target

T0 (22) + T1 (1) + T2 (8) = **31 channels** (matching plan-0420 target)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Crossref channel for scholarly research discovery via DOI-based queries
  * Added DBLP channel for computer science publication search
  * Both channels available as always-on (Tier 0) services with medium-yield results
  * Total always-on channels expanded from 16 to 18

<!-- end of auto-generated comment: release notes by coderabbit.ai -->