### PR TITLE
feat(routing): intelligent channel routing via M1 clarify prefs (zero-extra-LLM-cost)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -194,6 +194,7 @@ def query(
                     "markdown": rendered_output,
                     "iterations": result.iterations,
                     "channel_empty_calls": result.channel_empty_calls,
+                    "routing_trace": result.routing_trace,
                     "quality_grade": (
                         result.quality.grade.value if result.quality is not None else None
                     ),

--- a/autosearch/core/clarify.py
+++ b/autosearch/core/clarify.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 import structlog
 from pydantic import BaseModel, Field
 
+from autosearch.channels.base import Channel
 from autosearch.core.models import ClarifyRequest, ClarifyResult, Rubric, SearchMode
 from autosearch.llm.client import LLMClient
 
@@ -18,6 +19,8 @@ CLARIFY_PROMPT = dedent(
     Today's date is {date}.
 
     {mode_preference}
+
+    {channel_routing_guidance}
 
     Assess whether you need to ask a clarifying question, or if the user has already provided
     enough information for you to start research. IMPORTANT: If you can see in the messages
@@ -41,6 +44,9 @@ CLARIFY_PROMPT = dedent(
     - "verification": "<verification message that we will start research>"
     - "rubrics": ["<short binary evaluation criterion>", "..."]
     - "mode": "fast" or "deep"
+    - "query_type": "<single category for this query>"
+    - "channel_priority": ["<channel name>", "..."]
+    - "channel_skip": ["<channel name>", "..."]
 
     If you need to ask a clarifying question, return:
     - "need_clarification": true
@@ -64,6 +70,14 @@ CLARIFY_PROMPT = dedent(
     - Each rubric must be binary and easy to check in the final report
     - Recommend "fast" for focused or lightweight research and "deep" for broad, comparative,
       time-sensitive, or higher-stakes research
+    - Return one short `query_type` label such as "code", "academic", "news", or
+      "product-review"
+    - `channel_priority` should usually contain 3 to 5 channel names from the available list
+      below; return [] only if there is no strong priority preference
+    - `channel_skip` should only include channel names from the available list that are clearly
+      a poor fit for this query
+    - Never invent channel names; only use names from the provided channel list
+    - If clarification is needed, still return your best routing guess based on the current query
     """
 ).strip()
 
@@ -74,36 +88,61 @@ class _ClarifyCompletion(BaseModel):
     verification: str = ""
     rubrics: list[str] = Field(default_factory=list)
     mode: SearchMode
+    query_type: str | None = None
+    channel_priority: list[str] = Field(default_factory=list)
+    channel_skip: list[str] = Field(default_factory=list)
 
 
 class Clarifier:
     def __init__(self) -> None:
         self.logger = structlog.get_logger(__name__).bind(component="clarifier")
 
-    async def clarify(self, req: ClarifyRequest, client: LLMClient) -> ClarifyResult:
+    async def clarify(
+        self,
+        req: ClarifyRequest,
+        client: LLMClient,
+        *,
+        channels: list[Channel] | None = None,
+    ) -> ClarifyResult:
         self.logger.info(
             "clarify_started",
             query=req.query,
             mode_hint=req.mode_hint.value if req.mode_hint is not None else None,
         )
+        allowed_channels = _allowed_channel_names(channels or [])
         prompt = CLARIFY_PROMPT.format(
             messages=req.query,
             date=date.today().isoformat(),
             mode_preference=_mode_preference_text(req.mode_hint),
+            channel_routing_guidance=_channel_routing_guidance(channels or []),
         )
         completion = await client.complete(prompt, _ClarifyCompletion)
+        channel_priority = _normalize_channel_names(
+            completion.channel_priority,
+            allowed_channels=allowed_channels,
+        )
         result = ClarifyResult(
             need_clarification=completion.need_clarification,
             question=_normalize_optional_text(completion.question),
             verification=_normalize_optional_text(completion.verification),
             rubrics=[Rubric(text=text.strip()) for text in completion.rubrics if text.strip()],
             mode=completion.mode,
+            query_type=_normalize_optional_text(completion.query_type),
+            channel_priority=channel_priority,
+            channel_skip=_normalize_channel_names(
+                completion.channel_skip,
+                allowed_channels=allowed_channels,
+                exclude=set(channel_priority),
+            ),
         )
         self.logger.info(
             "clarify_completed",
             need_clarification=result.need_clarification,
             rubrics=len(result.rubrics),
             mode=result.mode.value,
+            query_type=result.query_type,
+            channel_priority=len(result.channel_priority),
+            channel_skip=len(result.channel_skip),
         )
         return result
 
@@ -117,6 +156,87 @@ def _mode_preference_text(mode_hint: SearchMode | None) -> str:
     )
 
 
-def _normalize_optional_text(value: str) -> str | None:
+def _channel_routing_guidance(channels: list[Channel]) -> str:
+    if not channels:
+        return dedent(
+            """\
+            No channel catalog is available for routing in this run.
+            Return `query_type` if you can infer one, and return empty lists for
+            `channel_priority` and `channel_skip`.
+            """
+        ).strip()
+
+    lines = [
+        (
+            f"- {channel_name}: {', '.join(query_types)}"
+            if query_types
+            else f"- {channel_name}: general"
+        )
+        for channel_name, query_types in _channel_routing_rows(channels)
+    ]
+    return "\n".join(
+        [
+            f"Available research channels ({len(lines)} total):",
+            *lines,
+        ]
+    )
+
+
+def _channel_routing_rows(channels: list[Channel]) -> list[tuple[str, list[str]]]:
+    rows: list[tuple[str, list[str]]] = []
+    for channel in channels:
+        channel_name = getattr(channel, "name", "").strip()
+        if not channel_name:
+            continue
+
+        metadata = getattr(channel, "_metadata", None)
+        when_to_use = getattr(metadata, "when_to_use", None)
+        raw_query_types = getattr(when_to_use, "query_types", [])
+        query_types = [
+            query_type.strip()
+            for query_type in raw_query_types
+            if isinstance(query_type, str) and query_type.strip()
+        ]
+        rows.append((channel_name, query_types))
+    return rows
+
+
+def _allowed_channel_names(channels: list[Channel]) -> list[str]:
+    return [channel_name for channel_name, _ in _channel_routing_rows(channels)]
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
     stripped = value.strip()
     return stripped or None
+
+
+def _normalize_channel_names(
+    values: list[str],
+    *,
+    allowed_channels: list[str],
+    exclude: set[str] | None = None,
+) -> list[str]:
+    exclude = exclude or set()
+    allowed_lookup = {name.casefold(): name for name in allowed_channels}
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        candidate = value.strip()
+        if not candidate:
+            continue
+
+        if allowed_lookup:
+            canonical = allowed_lookup.get(candidate.casefold())
+            if canonical is None:
+                continue
+            candidate = canonical
+
+        folded = candidate.casefold()
+        if candidate in exclude or folded in seen:
+            continue
+        seen.add(folded)
+        normalized.append(candidate)
+
+    return normalized

--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -212,9 +212,9 @@ class IterationController:
         priority_names = [channel.name for channel in priority_batch]
         _extend_unique_names(self.routing_trace, "priority_ran", priority_names)
         priority_evidence = await self._run_channel_batch(subqueries, priority_batch, iteration)
-        self.routing_trace["priority_evidence_count"] = (
-            int(self.routing_trace.get("priority_evidence_count", 0)) + len(priority_evidence)
-        )
+        self.routing_trace["priority_evidence_count"] = int(
+            self.routing_trace.get("priority_evidence_count", 0)
+        ) + len(priority_evidence)
 
         if len(priority_evidence) >= FALLBACK_THRESHOLD or not rest_batch:
             return priority_evidence

--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -13,6 +13,7 @@ from autosearch.skills.prompts import load_prompt
 
 GAP_REFLECTION_PROMPT = load_prompt("m3_gap_reflection")
 FOLLOW_UP_QUERY_PROMPT = load_prompt("m3_follow_up_query")
+FALLBACK_THRESHOLD = 5
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,7 @@ class _FollowUpQueryResponse(BaseModel):
 class IterationController:
     def __init__(self, evidence_processor: EvidenceProcessor | None = None) -> None:
         self.evidence_processor = evidence_processor or EvidenceProcessor()
+        self.routing_trace: dict[str, object] = {}
         self.logger = structlog.get_logger(__name__).bind(component="iteration_controller")
         self._empty_counts: dict[str, int] = {}
 
@@ -42,8 +44,17 @@ class IterationController:
         channels: list[Channel],
         budget: IterationBudget,
         client: LLMClient,
+        priority_channels: set[str] | None = None,
+        skip_channels: set[str] | None = None,
     ) -> list[Evidence]:
         self._empty_counts = {}
+        effective_priority = set(priority_channels or [])
+        effective_skip = set(skip_channels or [])
+        self.routing_trace = _initial_routing_trace(
+            channels,
+            priority_channels=effective_priority,
+            skip_channels=effective_skip,
+        )
         if budget.max_iterations <= 0 or not initial_queries or not channels:
             return []
 
@@ -68,7 +79,13 @@ class IterationController:
                 channels=len(channels),
                 subqueries=len(active_queries),
             )
-            round_evidence = await self._search(active_queries, channels, iteration)
+            round_evidence = await self._search(
+                active_queries,
+                channels,
+                iteration,
+                priority_channels=effective_priority,
+                skip_channels=effective_skip,
+            )
             self.logger.info(
                 "iteration_phase_completed",
                 phase="search",
@@ -165,7 +182,58 @@ class IterationController:
         subqueries: list[SubQuery],
         channels: list[Channel],
         iteration: int,
+        priority_channels: set[str] | None = None,
+        skip_channels: set[str] | None = None,
     ) -> list[Evidence]:
+        effective_priority = set(priority_channels or [])
+        effective_skip = set(skip_channels or [])
+        self._ensure_routing_trace(
+            channels,
+            priority_channels=effective_priority,
+            skip_channels=effective_skip,
+        )
+
+        runnable_channels = [channel for channel in channels if channel.name not in effective_skip]
+        skipped_names = [channel.name for channel in channels if channel.name in effective_skip]
+        _extend_unique_names(self.routing_trace, "skipped_channels", skipped_names)
+
+        if not effective_priority:
+            rest_names = [channel.name for channel in runnable_channels]
+            _extend_unique_names(self.routing_trace, "rest_ran", rest_names)
+            return await self._run_channel_batch(subqueries, runnable_channels, iteration)
+
+        priority_batch = [
+            channel for channel in runnable_channels if channel.name in effective_priority
+        ]
+        rest_batch = [
+            channel for channel in runnable_channels if channel.name not in effective_priority
+        ]
+
+        priority_names = [channel.name for channel in priority_batch]
+        _extend_unique_names(self.routing_trace, "priority_ran", priority_names)
+        priority_evidence = await self._run_channel_batch(subqueries, priority_batch, iteration)
+        self.routing_trace["priority_evidence_count"] = (
+            int(self.routing_trace.get("priority_evidence_count", 0)) + len(priority_evidence)
+        )
+
+        if len(priority_evidence) >= FALLBACK_THRESHOLD or not rest_batch:
+            return priority_evidence
+
+        self.routing_trace["fallback_triggered"] = True
+        rest_names = [channel.name for channel in rest_batch]
+        _extend_unique_names(self.routing_trace, "rest_ran", rest_names)
+        rest_evidence = await self._run_channel_batch(subqueries, rest_batch, iteration)
+        return priority_evidence + rest_evidence
+
+    async def _run_channel_batch(
+        self,
+        subqueries: list[SubQuery],
+        channels: list[Channel],
+        iteration: int,
+    ) -> list[Evidence]:
+        if not subqueries or not channels:
+            return []
+
         tasks = [channel.search(subquery) for subquery in subqueries for channel in channels]
         task_metadata = [
             (channel.name, subquery.text) for subquery in subqueries for channel in channels
@@ -210,6 +278,32 @@ class IterationController:
                 subquery=query_text[:80],
             )
         return result
+
+    def _ensure_routing_trace(
+        self,
+        channels: list[Channel],
+        *,
+        priority_channels: set[str],
+        skip_channels: set[str],
+    ) -> None:
+        expected_priority = _ordered_channel_names(
+            channels,
+            include=priority_channels,
+            exclude=skip_channels,
+        )
+        expected_skip = _ordered_channel_names(channels, include=skip_channels)
+
+        if (
+            self.routing_trace.get("priority") == expected_priority
+            and self.routing_trace.get("skip") == expected_skip
+        ):
+            return
+
+        self.routing_trace = _initial_routing_trace(
+            channels,
+            priority_channels=priority_channels,
+            skip_channels=skip_channels,
+        )
 
     def _summarize(self, evidences: list[Evidence], query: str) -> list[Evidence]:
         deduped = self.evidence_processor.dedup_urls(evidences)
@@ -310,3 +404,54 @@ def _format_evidence(evidences: list[Evidence], max_items: int) -> str:
         formatted.append(f"... {len(evidences) - max_items} additional evidence items omitted")
 
     return "\n\n".join(formatted)
+
+
+def _initial_routing_trace(
+    channels: list[Channel],
+    *,
+    priority_channels: set[str],
+    skip_channels: set[str],
+) -> dict[str, object]:
+    skipped = _ordered_channel_names(channels, include=skip_channels)
+    priority = _ordered_channel_names(
+        channels,
+        include=priority_channels,
+        exclude=skip_channels,
+    )
+    return {
+        "priority": priority,
+        "skip": skipped,
+        "priority_ran": [],
+        "rest_ran": [],
+        "priority_evidence_count": 0,
+        "fallback_triggered": False,
+        "skipped_channels": list(skipped),
+    }
+
+
+def _ordered_channel_names(
+    channels: list[Channel],
+    *,
+    include: set[str],
+    exclude: set[str] | None = None,
+) -> list[str]:
+    excluded = exclude or set()
+    return [
+        channel.name
+        for channel in channels
+        if channel.name in include and channel.name not in excluded
+    ]
+
+
+def _extend_unique_names(trace: dict[str, object], key: str, names: list[str]) -> None:
+    existing = trace.get(key)
+    if not isinstance(existing, list):
+        existing = []
+        trace[key] = existing
+
+    seen = {name for name in existing if isinstance(name, str)}
+    for name in names:
+        if name in seen:
+            continue
+        existing.append(name)
+        seen.add(name)

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -69,6 +69,9 @@ class ClarifyResult(BaseModel):
     verification: str | None = None
     rubrics: list[Rubric] = Field(default_factory=list)
     mode: SearchMode
+    query_type: str | None = None
+    channel_priority: list[str] = Field(default_factory=list)
+    channel_skip: list[str] = Field(default_factory=list)
 
 
 class KnowledgeRecall(BaseModel):
@@ -98,6 +101,7 @@ class PipelineResult:
     evidences: list[Evidence] = field(default_factory=list)
     channel_empty_calls: dict[str, int] = field(default_factory=dict)
     reasoning_events: list[dict[str, object]] = field(default_factory=list)
+    routing_trace: dict[str, object] = field(default_factory=dict)
     quality: EvaluationResult | None = None
     iterations: int = 0
     session_id: str | None = None

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -14,6 +14,7 @@ from autosearch.core.iteration import IterationBudget, IterationController
 from autosearch.core.knowledge import KnowledgeRecaller
 from autosearch.core.models import (
     ClarifyRequest,
+    ClarifyResult,
     Evidence,
     Gap,
     GradeOutcome,
@@ -87,6 +88,18 @@ class Pipeline:
         current_phase = "M0"
 
         try:
+            active_channels = self.channels
+            if scope is not None:
+                scoped_channels = filter_channels_by_scope(self.channels, scope.channel_scope)
+                if not scoped_channels:
+                    self.logger.warning(
+                        "channel_scope_filter_empty",
+                        channel_scope=scope.channel_scope,
+                        original_count=len(self.channels),
+                    )
+                else:
+                    active_channels = scoped_channels
+
             await self._emit_phase_event(current_phase, "start")
             self.logger.info("pipeline_phase_started", phase="m0_recall", query=query)
             recall = await self.knowledge_recaller.recall(query, self.llm)
@@ -108,6 +121,7 @@ class Pipeline:
             clarification = await self.clarifier.clarify(
                 ClarifyRequest(query=query, mode_hint=mode_hint),
                 self.llm,
+                channels=active_channels,
             )
             self.logger.info(
                 "pipeline_phase_completed",
@@ -133,6 +147,7 @@ class Pipeline:
                 session_created=session_created,
             )
             session_created = True
+            routing_trace = _build_routing_trace(clarification)
 
             if clarification.need_clarification:
                 final_status = "needs_clarification"
@@ -143,6 +158,7 @@ class Pipeline:
                     clarification=clarification,
                     iterations=0,
                     reasoning_events=list(self._captured_reasoning_events or []),
+                    routing_trace=routing_trace,
                     session_id=session_id,
                     cost=self._current_cost(),
                     prompt_tokens=prompt_tokens,
@@ -176,16 +192,7 @@ class Pipeline:
                 }
             )
 
-            active_channels = self.channels
             if scope is not None:
-                active_channels = filter_channels_by_scope(self.channels, scope.channel_scope)
-                if not active_channels:
-                    self.logger.warning(
-                        "channel_scope_filter_empty",
-                        channel_scope=scope.channel_scope,
-                        original_count=len(self.channels),
-                    )
-                    active_channels = self.channels
                 await self._emit_event(
                     {
                         "type": "channels_filtered",
@@ -210,7 +217,10 @@ class Pipeline:
                 channels=active_channels,
                 budget=self.budget,
                 client=self.llm,
+                priority_channels=set(clarification.channel_priority),
+                skip_channels=set(clarification.channel_skip),
             )
+            routing_trace = _build_routing_trace(clarification, iteration_controller.routing_trace)
             self.logger.info(
                 "pipeline_phase_completed",
                 phase="m3_iteration",
@@ -303,6 +313,8 @@ class Pipeline:
                         channels=active_channels,
                         budget=retry_budget,
                         client=self.llm,
+                        priority_channels=set(clarification.channel_priority),
+                        skip_channels=set(clarification.channel_skip),
                     )
                     await self._emit_phase_event(current_phase, "complete")
                     processed_evidences = self._finalize_evidences(
@@ -342,6 +354,7 @@ class Pipeline:
                 evidences=processed_evidences,
                 channel_empty_calls=iteration_controller.empty_counts_by_channel(),
                 reasoning_events=list(self._captured_reasoning_events or []),
+                routing_trace=routing_trace,
                 quality=quality,
                 iterations=iteration_controller.iterations_executed,
                 session_id=session_id,
@@ -501,8 +514,16 @@ class _TrackingIterationController(IterationController):
         subqueries: list[SubQuery],
         channels: list[Channel],
         iteration: int,
+        priority_channels: set[str] | None = None,
+        skip_channels: set[str] | None = None,
     ) -> list[Evidence]:
-        evidences = await super()._search(subqueries, channels, iteration)
+        evidences = await super()._search(
+            subqueries,
+            channels,
+            iteration,
+            priority_channels=priority_channels,
+            skip_channels=skip_channels,
+        )
         self._latest_new_evidence_count = len(evidences)
         return evidences
 
@@ -659,3 +680,14 @@ def _extract_ref_ids(content: str) -> list[int]:
         seen.add(ref_id)
         ref_ids.append(ref_id)
     return ref_ids
+
+
+def _build_routing_trace(
+    clarification: ClarifyResult,
+    runtime_trace: dict[str, object] | None = None,
+) -> dict[str, object]:
+    trace = dict(runtime_trace or {})
+    trace["query_type"] = clarification.query_type
+    trace["priority"] = list(clarification.channel_priority)
+    trace["skip"] = list(clarification.channel_skip)
+    return trace

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -10,6 +10,24 @@ from autosearch.core.search_scope import SearchScope, depth_to_mode
 from autosearch.llm.client import LLMClient
 
 
+class ResearchResponse(str):
+    def __new__(
+        cls,
+        content: str,
+        *,
+        channel_empty_calls: dict[str, int],
+        routing_trace: dict[str, object],
+        delivery_status: str,
+        scope: SearchScope,
+    ) -> "ResearchResponse":
+        instance = str.__new__(cls, content)
+        instance.channel_empty_calls = dict(channel_empty_calls)
+        instance.routing_trace = dict(routing_trace)
+        instance.delivery_status = delivery_status
+        instance.scope = scope.model_dump()
+        return instance
+
+
 def _default_pipeline_factory() -> Pipeline:
     return Pipeline(llm=LLMClient(), channels=_build_channels())
 
@@ -44,21 +62,39 @@ def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> Fas
         try:
             result = await factory().run(query, mode_hint=mode_hint, scope=scope)
         except Exception as exc:
-            return f"[error] {exc}"
+            return ResearchResponse(
+                f"[error] {exc}",
+                channel_empty_calls={},
+                routing_trace={},
+                delivery_status="error",
+                scope=scope,
+            )
 
         if result.delivery_status == "needs_clarification":
             question = result.clarification.question or "More detail is required."
-            return f"[clarification needed] {question}"
+            return ResearchResponse(
+                f"[clarification needed] {question}",
+                channel_empty_calls=result.channel_empty_calls,
+                routing_trace=result.routing_trace,
+                delivery_status=result.delivery_status,
+                scope=scope,
+            )
 
         banner = _scope_banner(scope)
         markdown_text = result.markdown or ""
         if banner is not None:
             markdown_text = f"{banner}\n\n{markdown_text}" if markdown_text else banner
 
-        return _render_output(
-            markdown_text=markdown_text,
-            title=query,
-            output_format=scope.output_format,
+        return ResearchResponse(
+            _render_output(
+                markdown_text=markdown_text,
+                title=query,
+                output_format=scope.output_format,
+            ),
+            channel_empty_calls=result.channel_empty_calls,
+            routing_trace=result.routing_trace,
+            delivery_status=result.delivery_status,
+            scope=scope,
         )
 
     @server.tool()

--- a/autosearch/server/main.py
+++ b/autosearch/server/main.py
@@ -86,6 +86,7 @@ def _terminal_payload(result: PipelineResult) -> dict[str, Any]:
         "iterations": result.iterations,
         "delivery_status": result.delivery_status,
         "channel_empty_calls": result.channel_empty_calls,
+        "routing_trace": result.routing_trace,
     }
     if result.delivery_status == "needs_clarification":
         payload["question"] = result.clarification.question or "More detail is required."

--- a/tests/unit/test_clarify.py
+++ b/tests/unit/test_clarify.py
@@ -19,6 +19,28 @@ class DummyClient:
         return response_model.model_validate(self.payload)
 
 
+class _FakeWhenToUse:
+    def __init__(self, query_types: list[str]) -> None:
+        self.query_types = query_types
+
+
+class _FakeMetadata:
+    def __init__(self, query_types: list[str]) -> None:
+        self.when_to_use = _FakeWhenToUse(query_types)
+
+
+class FakeChannel:
+    languages = ["en"]
+
+    def __init__(self, name: str, query_types: list[str]) -> None:
+        self.name = name
+        self._metadata = _FakeMetadata(query_types)
+
+    async def search(self, query):  # pragma: no cover - unused in clarify tests
+        _ = query
+        raise AssertionError("search should not be called in clarify tests")
+
+
 async def test_clarifier_returns_question_for_ambiguous_query() -> None:
     client = DummyClient(
         {
@@ -101,3 +123,40 @@ async def test_clarifier_includes_mode_hint_when_provided() -> None:
     assert result.mode is SearchMode.DEEP
     assert "The user prefers deep mode." in client.prompts[0]
     assert client.calls == 1
+
+
+async def test_clarifier_outputs_query_type_and_channel_prefs() -> None:
+    client = DummyClient(
+        {
+            "need_clarification": False,
+            "question": "",
+            "verification": "I have enough information to proceed.",
+            "rubrics": [
+                "Uses live implementation details",
+                "Includes current API behavior",
+                "Explains concrete tradeoffs",
+            ],
+            "mode": "fast",
+            "query_type": "code",
+            "channel_priority": ["stackoverflow", "github", "not-a-channel"],
+            "channel_skip": ["xiaohongshu", "another-miss"],
+        }
+    )
+    channels = [
+        FakeChannel("stackoverflow", ["programming-error", "how-to"]),
+        FakeChannel("github", ["code", "library"]),
+        FakeChannel("xiaohongshu", ["product-review", "experience-report"]),
+    ]
+
+    result = await Clarifier().clarify(
+        ClarifyRequest(query="How do I fix a FastAPI dependency override issue?"),
+        client,
+        channels=channels,
+    )
+
+    assert result.query_type == "code"
+    assert result.channel_priority == ["stackoverflow", "github"]
+    assert result.channel_skip == ["xiaohongshu"]
+    assert "Available research channels (3 total):" in client.prompts[0]
+    assert "- stackoverflow: programming-error, how-to" in client.prompts[0]
+    assert "- github: code, library" in client.prompts[0]

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -33,6 +33,13 @@ def _ok_result(channel_empty_calls: dict[str, int] | None = None) -> PipelineRes
         ),
         iterations=2,
         channel_empty_calls=channel_empty_calls or {},
+        routing_trace={
+            "query_type": "code",
+            "priority": ["github"],
+            "skip": ["xiaohongshu"],
+            "fallback_triggered": False,
+            "priority_evidence_count": 6,
+        },
     )
 
 
@@ -47,6 +54,11 @@ def _clarification_result() -> PipelineResult:
             mode=SearchMode.DEEP,
         ),
         iterations=0,
+        routing_trace={
+            "query_type": "deployment",
+            "priority": ["github"],
+            "skip": [],
+        },
     )
 
 
@@ -136,6 +148,13 @@ def test_cli_query_json_outputs_machine_readable_envelope(monkeypatch) -> None:
         "markdown": "# Test\n\nBody",
         "iterations": 2,
         "channel_empty_calls": {},
+        "routing_trace": {
+            "query_type": "code",
+            "priority": ["github"],
+            "skip": ["xiaohongshu"],
+            "fallback_triggered": False,
+            "priority_evidence_count": 6,
+        },
         "quality_grade": "pass",
         "sources": [],
         "scope": {
@@ -164,3 +183,14 @@ def test_cli_query_exits_two_for_needs_clarification(monkeypatch) -> None:
     assert result.exit_code == 2
     assert result.stdout == ""
     assert result.stderr == "Which deployment target do you care about?\n"
+
+
+def test_cli_json_includes_routing_trace(monkeypatch) -> None:
+    _install_cli_stubs(monkeypatch, _ok_result())
+
+    result = runner.invoke(app, ["query", "test", "--json"])
+
+    payload = json.loads(result.stdout)
+
+    assert payload["routing_trace"]["query_type"] == "code"
+    assert payload["routing_trace"]["priority"] == ["github"]

--- a/tests/unit/test_iteration_routing.py
+++ b/tests/unit/test_iteration_routing.py
@@ -141,10 +141,12 @@ async def test_iteration_fallback_not_triggered_when_priority_sufficient() -> No
     channels = [
         FakeChannel(
             "A",
-            [[
-                make_evidence(f"https://example.com/a-{index}", source_channel="A")
-                for index in range(FALLBACK_THRESHOLD)
-            ]],
+            [
+                [
+                    make_evidence(f"https://example.com/a-{index}", source_channel="A")
+                    for index in range(FALLBACK_THRESHOLD)
+                ]
+            ],
             call_order=call_order,
         ),
         FakeChannel(

--- a/tests/unit/test_iteration_routing.py
+++ b/tests/unit/test_iteration_routing.py
@@ -1,0 +1,172 @@
+# Self-written, plan 0420 W5 F501 routing
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from autosearch.core.iteration import FALLBACK_THRESHOLD, IterationBudget, IterationController
+from autosearch.core.models import Evidence, SubQuery
+
+NOW = datetime(2026, 4, 20, 12, 0, 0)
+
+
+class DummyClient:
+    def __init__(self, payloads: list[dict[str, object]]) -> None:
+        self.payloads = payloads
+        self.calls = 0
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        _ = prompt
+        payload = self.payloads[self.calls]
+        self.calls += 1
+        return response_model.model_validate(payload)
+
+
+class FakeChannel:
+    languages = ["en"]
+
+    def __init__(
+        self,
+        name: str,
+        responses: list[list[Evidence]],
+        *,
+        call_order: list[str],
+    ) -> None:
+        self.name = name
+        self.responses = list(responses)
+        self.queries: list[str] = []
+        self.call_order = call_order
+
+    async def search(self, query: SubQuery) -> list[Evidence]:
+        self.queries.append(query.text)
+        self.call_order.append(self.name)
+        return self.responses.pop(0)
+
+
+def make_evidence(url: str, *, source_channel: str) -> Evidence:
+    return Evidence(
+        url=url,
+        title=url.rsplit("/", maxsplit=1)[-1],
+        content="evidence",
+        source_channel=source_channel,
+        fetched_at=NOW,
+    )
+
+
+async def test_iteration_runs_priority_channels_first() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    subqueries = [SubQuery(text="fastapi dependency override", rationale="seed")]
+    channels = [
+        FakeChannel(
+            "A",
+            [[make_evidence("https://example.com/a", source_channel="A")]],
+            call_order=call_order,
+        ),
+        FakeChannel(
+            "B",
+            [[make_evidence("https://example.com/b", source_channel="B")]],
+            call_order=call_order,
+        ),
+        FakeChannel(
+            "C",
+            [[make_evidence("https://example.com/c", source_channel="C")]],
+            call_order=call_order,
+        ),
+    ]
+
+    await controller._search(subqueries, channels, 1, priority_channels={"A"})
+
+    assert call_order[0] == "A"
+    assert set(call_order[1:]) == {"B", "C"}
+    assert controller.routing_trace["priority_ran"] == ["A"]
+    assert controller.routing_trace["rest_ran"] == ["B", "C"]
+
+
+async def test_iteration_skips_channels_in_skip_list() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    subqueries = [SubQuery(text="search ranking", rationale="seed")]
+    channels = [
+        FakeChannel(
+            "A",
+            [[make_evidence("https://example.com/a", source_channel="A")]],
+            call_order=call_order,
+        ),
+        FakeChannel(
+            "B",
+            [[make_evidence("https://example.com/b", source_channel="B")]],
+            call_order=call_order,
+        ),
+    ]
+
+    await controller._search(subqueries, channels, 1, skip_channels={"B"})
+
+    assert call_order == ["A"]
+    assert channels[1].queries == []
+    assert controller.routing_trace["skipped_channels"] == ["B"]
+
+
+async def test_iteration_fallback_triggered_when_priority_empty() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    channels = [
+        FakeChannel("A", [[]], call_order=call_order),
+        FakeChannel(
+            "B",
+            [[make_evidence("https://example.com/b", source_channel="B")]],
+            call_order=call_order,
+        ),
+    ]
+    client = DummyClient([{"gaps": []}])
+
+    evidences = await controller.run(
+        query="empty priority evidence",
+        initial_queries=[SubQuery(text="empty priority evidence", rationale="seed")],
+        channels=channels,
+        budget=IterationBudget(max_iterations=1, per_channel_rate_limit=0.0),
+        client=client,
+        priority_channels={"A"},
+    )
+
+    assert [evidence.source_channel for evidence in evidences] == ["B"]
+    assert call_order == ["A", "B"]
+    assert controller.routing_trace["priority_evidence_count"] == 0
+    assert controller.routing_trace["fallback_triggered"] is True
+    assert controller.routing_trace["rest_ran"] == ["B"]
+
+
+async def test_iteration_fallback_not_triggered_when_priority_sufficient() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    channels = [
+        FakeChannel(
+            "A",
+            [[
+                make_evidence(f"https://example.com/a-{index}", source_channel="A")
+                for index in range(FALLBACK_THRESHOLD)
+            ]],
+            call_order=call_order,
+        ),
+        FakeChannel(
+            "B",
+            [[make_evidence("https://example.com/b", source_channel="B")]],
+            call_order=call_order,
+        ),
+    ]
+    client = DummyClient([{"gaps": []}])
+
+    evidences = await controller.run(
+        query="sufficient priority evidence",
+        initial_queries=[SubQuery(text="sufficient priority evidence", rationale="seed")],
+        channels=channels,
+        budget=IterationBudget(max_iterations=1, per_channel_rate_limit=0.0),
+        client=client,
+        priority_channels={"A"},
+    )
+
+    assert len(evidences) == FALLBACK_THRESHOLD
+    assert call_order == ["A"]
+    assert channels[1].queries == []
+    assert controller.routing_trace["priority_evidence_count"] == FALLBACK_THRESHOLD
+    assert controller.routing_trace["fallback_triggered"] is False
+    assert controller.routing_trace["rest_ran"] == []

--- a/tests/unit/test_mcp_research_scope.py
+++ b/tests/unit/test_mcp_research_scope.py
@@ -19,6 +19,14 @@ def _ok_result() -> PipelineResult:
         ),
         markdown="# Test\n\nBody",
         iterations=1,
+        channel_empty_calls={"arxiv": 2},
+        routing_trace={
+            "query_type": "code",
+            "priority": ["github"],
+            "skip": ["xiaohongshu"],
+            "fallback_triggered": False,
+            "priority_evidence_count": 6,
+        },
     )
 
 
@@ -138,3 +146,34 @@ async def test_research_html_format_wraps_markdown(
     assert research_tool is not None
     result = await research_tool.run({"query": "test query", "output_format": "html"})
     assert result.startswith("<!doctype html>")
+
+
+@pytest.mark.asyncio
+async def test_research_response_includes_routing_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _StubPipeline(result=_ok_result())
+    _install_default_factory(monkeypatch, pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+    result = await research_tool.run({"query": "test query"})
+    assert result.routing_trace["query_type"] == "code"
+    assert result.routing_trace["priority"] == ["github"]
+
+
+@pytest.mark.asyncio
+async def test_research_response_includes_channel_empty_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _StubPipeline(result=_ok_result())
+    _install_default_factory(monkeypatch, pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+    result = await research_tool.run({"query": "test query"})
+    assert result.channel_empty_calls == {"arxiv": 2}

--- a/tests/unit/test_pipeline_events.py
+++ b/tests/unit/test_pipeline_events.py
@@ -62,6 +62,9 @@ def make_pipeline(on_event=None) -> Pipeline:
                     "Explain tradeoffs",
                 ],
                 "mode": "fast",
+                "query_type": "technical",
+                "channel_priority": ["fake"],
+                "channel_skip": [],
             },
             {
                 "subqueries": [
@@ -180,3 +183,16 @@ async def test_pipeline_result_includes_channel_empty_calls() -> None:
     assert result.delivery_status == "ok"
     assert result.evidences == []
     assert result.channel_empty_calls == {"fake": 1}
+
+
+async def test_routing_trace_recorded_on_pipeline_result() -> None:
+    pipeline = make_pipeline()
+
+    result = await pipeline.run("How does streaming progress work?", mode_hint=SearchMode.FAST)
+
+    assert result.routing_trace["query_type"] == "technical"
+    assert result.routing_trace["priority"] == ["fake"]
+    assert result.routing_trace["skip"] == []
+    assert result.routing_trace["priority_ran"] == ["fake"]
+    assert result.routing_trace["fallback_triggered"] is False
+    assert result.routing_trace["priority_evidence_count"] == 4

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -194,6 +194,7 @@ def test_search_streams_needs_clarification_event(monkeypatch) -> None:
     } in events
     assert pipeline.calls == [("test query", SearchMode.DEEP)]
 
+
 def test_search_endpoint_returns_channel_empty_calls_in_json(monkeypatch) -> None:
     pipeline = _StubPipeline(result=_ok_result(channel_empty_calls={"arxiv": 3}))
     _install_pipeline_factory(monkeypatch, pipeline)
@@ -204,6 +205,7 @@ def test_search_endpoint_returns_channel_empty_calls_in_json(monkeypatch) -> Non
         json={
             "query": "test query",
             "scope": {
+                "domain_followups": [],
                 "channel_scope": "all",
                 "depth": "fast",
                 "output_format": "md",
@@ -228,6 +230,7 @@ def test_search_endpoint_includes_routing_trace(monkeypatch) -> None:
         json={
             "query": "test query",
             "scope": {
+                "domain_followups": [],
                 "channel_scope": "all",
                 "depth": "fast",
                 "output_format": "md",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -22,6 +22,13 @@ def _ok_result(channel_empty_calls: dict[str, int] | None = None) -> PipelineRes
         markdown="# Test\n\nBody",
         iterations=2,
         channel_empty_calls=channel_empty_calls or {},
+        routing_trace={
+            "query_type": "code",
+            "priority": ["github"],
+            "skip": ["xiaohongshu"],
+            "fallback_triggered": False,
+            "priority_evidence_count": 6,
+        },
     )
 
 
@@ -36,6 +43,11 @@ def _clarification_result() -> PipelineResult:
             mode=SearchMode.DEEP,
         ),
         iterations=0,
+        routing_trace={
+            "query_type": "deployment",
+            "priority": ["github"],
+            "skip": [],
+        },
     )
 
 
@@ -135,6 +147,13 @@ def test_search_streams_started_and_finished_events(monkeypatch) -> None:
         "iterations": 2,
         "delivery_status": "ok",
         "channel_empty_calls": {},
+        "routing_trace": {
+            "query_type": "code",
+            "priority": ["github"],
+            "skip": ["xiaohongshu"],
+            "fallback_triggered": False,
+            "priority_evidence_count": 6,
+        },
     } in events
     assert pipeline.calls == [("test query", SearchMode.FAST)]
 
@@ -167,9 +186,13 @@ def test_search_streams_needs_clarification_event(monkeypatch) -> None:
         "iterations": 0,
         "channel_empty_calls": {},
         "question": "Which deployment target do you care about?",
+        "routing_trace": {
+            "query_type": "deployment",
+            "priority": ["github"],
+            "skip": [],
+        },
     } in events
     assert pipeline.calls == [("test query", SearchMode.DEEP)]
-
 
 def test_search_endpoint_returns_channel_empty_calls_in_json(monkeypatch) -> None:
     pipeline = _StubPipeline(result=_ok_result(channel_empty_calls={"arxiv": 3}))
@@ -193,3 +216,27 @@ def test_search_endpoint_returns_channel_empty_calls_in_json(monkeypatch) -> Non
 
     assert response.status_code == 200
     assert finished["channel_empty_calls"] == {"arxiv": 3}
+
+
+def test_search_endpoint_includes_routing_trace(monkeypatch) -> None:
+    pipeline = _StubPipeline(result=_ok_result())
+    _install_pipeline_factory(monkeypatch, pipeline)
+    client = TestClient(server_main.app)
+
+    response = client.post(
+        "/search",
+        json={
+            "query": "test query",
+            "scope": {
+                "channel_scope": "all",
+                "depth": "fast",
+                "output_format": "md",
+            },
+        },
+    )
+
+    events = _parse_sse_events(response.text)
+    finished = next(event for event in events if event["type"] == "finished")
+
+    assert finished["routing_trace"]["query_type"] == "code"
+    assert finished["routing_trace"]["priority"] == ["github"]


### PR DESCRIPTION
## Summary

Plan-0420 W5 F501 — intelligent channel routing. Key design decision (from user 2026-04-20): **zero extra LLM cost** — extended the existing M1 clarify call's output schema rather than adding a new classification call.

### What changes

- **M1 clarifier** (`clarify.py` + prompt): output schema extended with `query_type: str` + `channel_priority: list[str]` + `channel_skip: list[str]`. Prompt is injected with the live channel catalog (name + `when_to_use.query_types` for each channel) so the LLM picks informed preferences for that specific query. `ClarifyResult` carries the 3 new fields.

- **Iteration controller**: accepts `priority_channels` + `skip_channels` sets. Runs priority first, records evidence count; falls back to the remaining channel set only if priority evidence < `FALLBACK_THRESHOLD` (= 5). Explicit skips are never run. Records routing decisions (priority_ran / rest_ran / evidence_count / fallback_triggered / skipped_channels).

- **PipelineResult**: new field `routing_trace: dict[str, object]` aggregated across the run.

- **Surfaces**: `/search` SSE, CLI `--json`, and MCP research tool all expose `routing_trace` in their JSON envelopes.

### Why this design

Single LLM call now outputs: need_clarification / question / rubrics / query_type / channel_priority / channel_skip. No pipeline performance penalty, full intelligent routing.

### Backward compatibility

- `priority_channels=None` or empty list → run all channels as before (preserves existing test behavior)
- Old callers of `_search` unaffected — new params have defaults

## Test plan

- [x] `pytest tests/unit/test_clarify.py tests/unit/test_iteration_routing.py tests/unit/test_pipeline_events.py tests/unit/test_server.py tests/unit/test_cli_query.py tests/unit/test_mcp_research_scope.py` — 28 tests green
- [x] Full suite: `391 passed, 18 deselected`
- [x] `ruff check` + `ruff format --check` green

## Limitations (noted by implementer)

- `routing_trace` is aggregated across the run; per-iteration history not preserved (can extend later if needed)
- MCP research tool keeps backward-compatible text response by attaching `routing_trace` as metadata on a `str` subclass

## Interaction with pending PRs

Based on `origin/main`. After the 8-PR queue merges (#159, #161-167), rebase will auto-adjust.