### PR TITLE
fix(tests): include domain_followups in server test body (unbreak main)

### DIFF
--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -181,6 +181,7 @@ def test_search_endpoint_returns_channel_empty_calls_in_json(monkeypatch) -> Non
         json={
             "query": "test query",
             "scope": {
+                "domain_followups": [],
                 "channel_scope": "all",
                 "depth": "fast",
                 "output_format": "md",


### PR DESCRIPTION
## Summary

`main` was left red after #165 + #166 merge: PR #165 made `domain_followups` the first scope clarifier question, but #166's new `test_search_endpoint_returns_channel_empty_calls_in_json` body doesn't include it. The server's `/search` endpoint now emits a `scope_needed` event for `domain_followups` before reaching `finished`, so `next(event... == 'finished')` raises StopIteration.

Every pending PR that rebases onto main inherits the failure — #164 and #167 already caught by CI.

Trivial fix: add `"domain_followups": []` to the scope body in that one test (other two server tests already had it).

## Test plan
- [x] Before: `pytest tests/unit/test_server.py::test_search_endpoint_returns_channel_empty_calls_in_json` fails on main with StopIteration
- [x] After: passes in 0.2s
- [x] Full server suite: 4/4 pass