### PR TITLE
feat: W1 tool layer — fetch_page + PruningCleaner + BM25Cleaner (steal crawl4ai ideas)

### DIFF
--- a/autosearch/cleaners/bm25_cleaner.py
+++ b/autosearch/cleaners/bm25_cleaner.py
@@ -1,0 +1,132 @@
+# Self-written, plan v2.3 § 13.5 F104
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import ClassVar
+
+from bs4 import BeautifulSoup, Tag
+from rank_bm25 import BM25Okapi
+
+from autosearch.cleaners.base import Cleaner
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    index: int
+    html: str
+    tokens: tuple[str, ...]
+
+
+class BM25Cleaner(Cleaner):
+    """Query-aware HTML compression that keeps only BM25-relevant blocks."""
+
+    CANDIDATE_TAGS: ClassVar[tuple[str, ...]] = (
+        "p",
+        "li",
+        "pre",
+        "blockquote",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+    )
+    TOKEN_PATTERN: ClassVar[re.Pattern[str]] = re.compile(r"\w+")
+
+    def __init__(
+        self,
+        top_k: int = 15,
+        min_score: float = 0.0,
+        user_query_weight: float = 1.0,
+    ) -> None:
+        self.top_k = top_k
+        self.min_score = min_score
+        self.user_query_weight = user_query_weight
+
+    def clean(self, html: str, query: str | None = None) -> str:
+        if query is None:
+            return html
+
+        query_tokens = self._tokenize(query)
+        if not query_tokens:
+            return html
+
+        if not html:
+            return ""
+
+        soup = BeautifulSoup(html, "html.parser")
+        if soup.body is None:
+            soup = BeautifulSoup(f"<body>{html}</body>", "html.parser")
+
+        body = soup.body
+        if body is None:
+            return ""
+
+        candidates = self._extract_candidates(body)
+        if not candidates:
+            return ""
+
+        if len(candidates) == 1:
+            return candidates[0].html
+
+        scored_candidates = [candidate for candidate in candidates if candidate.tokens]
+        if not scored_candidates:
+            return ""
+
+        bm25 = BM25Okapi([list(candidate.tokens) for candidate in scored_candidates])
+        scores = bm25.get_scores(query_tokens)
+        selected_indexes = self._select_candidate_indexes(scored_candidates, scores)
+        if not selected_indexes:
+            return ""
+
+        return "\n".join(
+            candidate.html for candidate in candidates if candidate.index in selected_indexes
+        )
+
+    def _extract_candidates(self, body: Tag) -> list[_Candidate]:
+        candidates: list[_Candidate] = []
+        for index, tag in enumerate(body.find_all(self.CANDIDATE_TAGS)):
+            text = tag.get_text(" ", strip=True)
+            if not text:
+                continue
+            candidates.append(
+                _Candidate(
+                    index=index,
+                    html=str(tag),
+                    tokens=tuple(self._tokenize(text)),
+                )
+            )
+        return candidates
+
+    def _select_candidate_indexes(
+        self,
+        candidates: list[_Candidate],
+        scores: list[float],
+    ) -> set[int]:
+        scored_candidates = list(zip(candidates, scores, strict=True))
+        ranked_candidates = sorted(scored_candidates, key=lambda item: item[1], reverse=True)
+
+        selected_indexes: set[int] = set()
+        if self.top_k > 0:
+            selected_indexes.update(
+                candidate.index for candidate, score in ranked_candidates if score > self.min_score
+            )
+            if len(selected_indexes) > self.top_k:
+                top_indexes = {
+                    candidate.index
+                    for candidate, score in ranked_candidates[: self.top_k]
+                    if score > self.min_score
+                }
+                selected_indexes = top_indexes
+
+        if self.min_score > 0:
+            selected_indexes.update(
+                candidate.index for candidate, score in scored_candidates if score >= self.min_score
+            )
+
+        return selected_indexes
+
+    def _tokenize(self, text: str) -> list[str]:
+        return self.TOKEN_PATTERN.findall(text.lower())

--- a/autosearch/cleaners/bm25_cleaner.py
+++ b/autosearch/cleaners/bm25_cleaner.py
@@ -105,26 +105,19 @@ class BM25Cleaner(Cleaner):
         candidates: list[_Candidate],
         scores: list[float],
     ) -> set[int]:
-        scored_candidates = list(zip(candidates, scores, strict=True))
-        ranked_candidates = sorted(scored_candidates, key=lambda item: item[1], reverse=True)
-
+        ranked_candidates = sorted(
+            zip(candidates, scores, strict=True),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+        score_floor = max(self.min_score, 0.0)
         selected_indexes: set[int] = set()
-        if self.top_k > 0:
-            selected_indexes.update(
-                candidate.index for candidate, score in ranked_candidates if score > self.min_score
-            )
-            if len(selected_indexes) > self.top_k:
-                top_indexes = {
-                    candidate.index
-                    for candidate, score in ranked_candidates[: self.top_k]
-                    if score > self.min_score
-                }
-                selected_indexes = top_indexes
-
-        if self.min_score > 0:
-            selected_indexes.update(
-                candidate.index for candidate, score in scored_candidates if score >= self.min_score
-            )
+        for candidate, score in ranked_candidates:
+            if score <= score_floor:
+                break
+            selected_indexes.add(candidate.index)
+            if self.top_k > 0 and len(selected_indexes) >= self.top_k:
+                break
 
         return selected_indexes
 

--- a/autosearch/cleaners/pruning_cleaner.py
+++ b/autosearch/cleaners/pruning_cleaner.py
@@ -13,6 +13,7 @@ class PruningCleaner(Cleaner):
     LINK_DENSITY_WEIGHT = 0.30
     TAG_WEIGHT = 0.18
     CLASS_ID_HINT_WEIGHT = 0.20
+    CJK_CHAR_RE = re.compile(r"[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff]")
 
     POSITIVE_TAG_WEIGHTS = {
         "article": 1.5,
@@ -184,4 +185,7 @@ class PruningCleaner(Cleaner):
         return any(isinstance(child, Tag) for child in node.children)
 
     def _word_count(self, text: str) -> int:
-        return len(text.split())
+        cjk_chars = len(self.CJK_CHAR_RE.findall(text))
+        ascii_portion = self.CJK_CHAR_RE.sub(" ", text)
+        ascii_words = len(ascii_portion.split())
+        return cjk_chars + ascii_words

--- a/autosearch/cleaners/pruning_cleaner.py
+++ b/autosearch/cleaners/pruning_cleaner.py
@@ -1,0 +1,187 @@
+# Self-written, plan v2.3 § 13.5 F103
+from __future__ import annotations
+
+import re
+
+from bs4 import BeautifulSoup, Comment, Tag
+
+from autosearch.cleaners.base import Cleaner
+
+
+class PruningCleaner(Cleaner):
+    TEXT_DENSITY_WEIGHT = 0.55
+    LINK_DENSITY_WEIGHT = 0.30
+    TAG_WEIGHT = 0.18
+    CLASS_ID_HINT_WEIGHT = 0.20
+
+    POSITIVE_TAG_WEIGHTS = {
+        "article": 1.5,
+        "main": 1.3,
+        "section": 1.0,
+        "p": 0.8,
+        "li": 0.4,
+        "pre": 1.8,
+        "code": 1.8,
+        "blockquote": 1.0,
+    }
+    NEGATIVE_TAG_WEIGHTS = {
+        "nav": -1.6,
+        "footer": -1.4,
+        "aside": -1.2,
+        "script": -2.0,
+        "style": -2.0,
+        "header": -0.8,
+        "form": -1.0,
+        "button": -0.8,
+    }
+    ALWAYS_DROP_TAGS = {"script", "style", "noscript", "template"}
+    POSITIVE_HINT_KEYWORDS = {"content", "article", "post", "main", "body", "entry"}
+    NEGATIVE_HINT_KEYWORDS = {
+        "nav",
+        "menu",
+        "footer",
+        "sidebar",
+        "ad",
+        "advert",
+        "banner",
+        "social",
+        "share",
+        "comment",
+        "related",
+        "popup",
+        "modal",
+        "cookie",
+    }
+
+    def __init__(self, threshold: float = 0.48, min_word_count: int = 2):
+        self.threshold = threshold
+        self.min_word_count = min_word_count
+
+    def clean(self, html: str) -> str:
+        if not html:
+            return ""
+
+        soup = BeautifulSoup(html, "html.parser")
+        if soup.body is None:
+            soup = BeautifulSoup(f"<body>{html}</body>", "html.parser")
+
+        self._remove_comments(soup)
+        self._remove_always_drop_tags(soup)
+
+        body = soup.body
+        if body is None:
+            return ""
+
+        self._prune_node(body, is_root=True)
+        return body.decode_contents().strip()
+
+    def _remove_comments(self, soup: BeautifulSoup) -> None:
+        for node in soup(string=lambda value: isinstance(value, Comment)):
+            node.extract()
+
+    def _remove_always_drop_tags(self, soup: BeautifulSoup) -> None:
+        for tag_name in self.ALWAYS_DROP_TAGS:
+            for node in soup.find_all(tag_name):
+                node.decompose()
+
+    def _prune_node(self, node: Tag, *, is_root: bool = False) -> None:
+        children = [child for child in node.children if isinstance(child, Tag)]
+        for child in children:
+            self._prune_node(child)
+
+        if is_root or node.name in {"html", "body"}:
+            return
+
+        text = node.get_text(" ", strip=True)
+        if not text:
+            node.decompose()
+            return
+
+        if node.name not in {"pre", "code"} and self._word_count(text) < self.min_word_count:
+            node.decompose()
+            return
+
+        score, link_density, class_id_hints = self._score_node(node, text)
+        if score >= self.threshold:
+            return
+
+        if self._can_unwrap(node, link_density, class_id_hints):
+            node.unwrap()
+            return
+
+        node.decompose()
+
+    def _score_node(self, node: Tag, text: str) -> tuple[float, float, float]:
+        text_length = len(text)
+        html_length = max(1, len(str(node)))
+        link_text_length = sum(len(link.get_text(" ", strip=True)) for link in node.find_all("a"))
+
+        text_density = min(1.0, text_length / html_length)
+        link_density = min(1.0, link_text_length / max(1, text_length))
+        tag_weight = self.POSITIVE_TAG_WEIGHTS.get(node.name, 0.0) + self.NEGATIVE_TAG_WEIGHTS.get(
+            node.name,
+            0.0,
+        )
+        class_id_hints = self._class_id_hint_score(node)
+
+        score = (
+            text_density * self.TEXT_DENSITY_WEIGHT
+            - link_density * self.LINK_DENSITY_WEIGHT
+            + tag_weight * self.TAG_WEIGHT
+            + class_id_hints * self.CLASS_ID_HINT_WEIGHT
+        )
+        return score, link_density, class_id_hints
+
+    def _class_id_hint_score(self, node: Tag) -> float:
+        tokens = set(self._attribute_tokens(node))
+        if not tokens:
+            return 0.0
+
+        positive_hits = self._count_hint_hits(tokens, self.POSITIVE_HINT_KEYWORDS)
+        negative_hits = self._count_hint_hits(tokens, self.NEGATIVE_HINT_KEYWORDS)
+        raw_score = positive_hits - negative_hits
+        return max(-1.0, min(1.0, raw_score))
+
+    def _attribute_tokens(self, node: Tag) -> list[str]:
+        values: list[str] = []
+
+        class_values = node.get("class", [])
+        if isinstance(class_values, str):
+            values.append(class_values)
+        else:
+            values.extend(class_values)
+
+        element_id = node.get("id")
+        if isinstance(element_id, str):
+            values.append(element_id)
+
+        tokens: list[str] = []
+        for value in values:
+            tokens.extend(token for token in re.split(r"[^a-z0-9]+", value.lower()) if token)
+        return tokens
+
+    def _count_hint_hits(self, tokens: set[str], keywords: set[str]) -> int:
+        hits = 0
+        for token in tokens:
+            for keyword in keywords:
+                if keyword == "ad":
+                    if token == keyword:
+                        hits += 1
+                        break
+                    continue
+                if token == keyword or token.startswith(keyword):
+                    hits += 1
+                    break
+        return hits
+
+    def _can_unwrap(self, node: Tag, link_density: float, class_id_hints: float) -> bool:
+        if node.name in self.NEGATIVE_TAG_WEIGHTS:
+            return False
+        if class_id_hints < 0:
+            return False
+        if link_density > 0.6:
+            return False
+        return any(isinstance(child, Tag) for child in node.children)
+
+    def _word_count(self, text: str) -> int:
+        return len(text.split())

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -1,6 +1,6 @@
 # Self-written, plan v2.3 § 13.5
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Literal
 
@@ -20,6 +20,44 @@ class SubQuery(BaseModel):
     rationale: str
 
 
+class LinkRef(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    href: str
+    text: str
+    internal: bool = False
+
+
+class TableData(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    headers: list[str] = Field(default_factory=list)
+    rows: list[dict[str, str]] = Field(default_factory=list)
+
+
+class MediaRef(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    src: str
+    alt: str = ""
+    kind: Literal["image", "video"] = "image"
+
+
+class FetchedPage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    url: str
+    status_code: int
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    html: str = ""
+    cleaned_html: str = ""
+    markdown: str = ""
+    links: list[LinkRef] = Field(default_factory=list)
+    metadata: dict[str, str] = Field(default_factory=dict)
+    tables: list[TableData] = Field(default_factory=list)
+    media: list[MediaRef] = Field(default_factory=list)
+
+
 class Evidence(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -30,6 +68,7 @@ class Evidence(BaseModel):
     source_channel: str
     fetched_at: datetime
     score: float | None = None
+    source_page: FetchedPage | None = None
 
 
 class Gap(BaseModel):

--- a/autosearch/lib/html_scraper.py
+++ b/autosearch/lib/html_scraper.py
@@ -1,8 +1,15 @@
 # Self-written for task F204
 from __future__ import annotations
 
+from urllib.parse import urljoin, urlparse
+
 import httpx
 import structlog
+from bs4 import BeautifulSoup
+from markdownify import markdownify
+
+from autosearch.cleaners.pruning_cleaner import PruningCleaner
+from autosearch.core.models import FetchedPage, LinkRef, MediaRef, TableData
 
 LOGGER = structlog.get_logger(__name__).bind(component="html_scraper")
 
@@ -54,3 +61,189 @@ async def fetch_html(
 
     async with httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True) as client:
         return await _fetch(client)
+
+
+async def fetch_page(
+    url: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    run_prune: bool = True,
+) -> FetchedPage:
+    raw_html = await fetch_html(url, http_client=client, timeout_seconds=timeout)
+    # TODO: fetch_html only returns the response body today; return response metadata to preserve
+    # the real status code here instead of assuming 200 on success.
+    status_code = 200
+    soup = BeautifulSoup(raw_html, "html.parser")
+    cleaned_html = PruningCleaner().clean(raw_html) if run_prune else raw_html
+    markdown = markdownify(
+        cleaned_html,
+        heading_style="ATX",
+        strip=["script", "style"],
+    ).strip()
+
+    return FetchedPage(
+        url=url,
+        status_code=status_code,
+        html=raw_html,
+        cleaned_html=cleaned_html,
+        markdown=markdown,
+        links=_extract_links(soup, base_url=url),
+        metadata=_extract_metadata(soup),
+        tables=_extract_tables(soup),
+        media=_extract_media(soup, base_url=url),
+    )
+
+
+def _extract_metadata(soup: BeautifulSoup) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    interesting_meta_keys = {
+        "author",
+        "description",
+        "keywords",
+        "og:description",
+        "og:image",
+        "og:locale",
+        "og:site_name",
+        "og:title",
+        "og:type",
+        "og:url",
+        "robots",
+        "twitter:description",
+        "twitter:title",
+        "viewport",
+    }
+
+    for meta_tag in soup.find_all("meta"):
+        content = meta_tag.get("content")
+        if not content:
+            continue
+
+        meta_key = meta_tag.get("property") or meta_tag.get("name")
+        if not meta_key:
+            continue
+
+        normalized_key = meta_key.strip().lower()
+        if normalized_key not in interesting_meta_keys:
+            continue
+
+        metadata[normalized_key] = content.strip()
+        if normalized_key == "og:title":
+            metadata.setdefault("title", content.strip())
+
+    title_tag = soup.find("title")
+    if title_tag is not None:
+        title_text = title_tag.get_text(strip=True)
+        if title_text:
+            metadata.setdefault("title", title_text)
+
+    for link_tag in soup.find_all("link", href=True):
+        rel_values = link_tag.get("rel", [])
+        if isinstance(rel_values, str):
+            rel_tokens = {rel_values.lower()}
+        else:
+            rel_tokens = {str(value).lower() for value in rel_values}
+
+        if "canonical" in rel_tokens:
+            metadata["canonical"] = link_tag["href"].strip()
+            break
+
+    return metadata
+
+
+def _extract_links(soup: BeautifulSoup, *, base_url: str) -> list[LinkRef]:
+    parsed_base_url = urlparse(base_url)
+    links: list[LinkRef] = []
+
+    for anchor in soup.find_all("a", href=True):
+        raw_href = anchor["href"].strip()
+        if not raw_href:
+            continue
+
+        lower_href = raw_href.lower()
+        if raw_href.startswith("#") or lower_href.startswith(("javascript:", "mailto:")):
+            continue
+
+        resolved_href = urljoin(base_url, raw_href)
+        parsed_href = urlparse(resolved_href)
+        links.append(
+            LinkRef(
+                href=resolved_href,
+                text=anchor.get_text(strip=True)[:200],
+                internal=not parsed_href.netloc or parsed_href.netloc == parsed_base_url.netloc,
+            )
+        )
+
+    return links
+
+
+def _extract_tables(soup: BeautifulSoup) -> list[TableData]:
+    tables: list[TableData] = []
+
+    for table_tag in soup.find_all("table"):
+        rows = table_tag.find_all("tr")
+        headers: list[str] = []
+        data_rows: list[dict[str, str]] = []
+        header_row_index: int | None = None
+
+        for index, row in enumerate(rows):
+            header_cells = row.find_all("th")
+            if not header_cells:
+                continue
+
+            headers = [cell.get_text(strip=True) for cell in header_cells]
+            header_row_index = index
+            break
+
+        if header_row_index is None and rows:
+            header_row_index = 0
+            headers = [cell.get_text(strip=True) for cell in rows[0].find_all(["td", "th"])]
+
+        if header_row_index is not None:
+            for row in rows[header_row_index + 1 :]:
+                cell_values = [cell.get_text(strip=True) for cell in row.find_all(["td", "th"])]
+                if not cell_values:
+                    continue
+                data_rows.append(dict(zip(headers, cell_values, strict=False)))
+
+        if not headers and not data_rows:
+            continue
+
+        tables.append(TableData(headers=headers, rows=data_rows))
+
+    return tables
+
+
+def _extract_media(soup: BeautifulSoup, *, base_url: str) -> list[MediaRef]:
+    media: list[MediaRef] = []
+
+    for image in soup.find_all("img", src=True):
+        src = image["src"].strip()
+        if not src:
+            continue
+
+        media.append(
+            MediaRef(
+                src=urljoin(base_url, src),
+                alt=image.get("alt", ""),
+                kind="image",
+            )
+        )
+
+    for video in soup.find_all("video"):
+        video_src = video.get("src")
+        if isinstance(video_src, str) and video_src.strip():
+            media.append(
+                MediaRef(
+                    src=urljoin(base_url, video_src.strip()),
+                    kind="video",
+                )
+            )
+
+        for source in video.find_all("source", src=True):
+            source_src = source["src"].strip()
+            if not source_src:
+                continue
+            media.append(MediaRef(src=urljoin(base_url, source_src), kind="video"))
+
+    return media

--- a/autosearch/skills/channels/kr36/methods/api_search.py
+++ b/autosearch/skills/channels/kr36/methods/api_search.py
@@ -10,7 +10,7 @@ import httpx
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.html_scraper import HtmlFetchError, fetch_html
+from autosearch.lib.html_scraper import HtmlFetchError, fetch_html, fetch_page
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="kr36")
 
@@ -133,6 +133,37 @@ def _parse_results(html_text: str, *, fetched_at: datetime) -> list[Evidence]:
     return evidences
 
 
+async def _enrich_evidence(
+    evidence: Evidence,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> Evidence:
+    try:
+        page = await fetch_page(evidence.url, client=http_client)
+    except HtmlFetchError as exc:
+        LOGGER.warning(
+            "kr36_result_fetch_failed",
+            url=evidence.url,
+            reason=str(exc),
+        )
+        return evidence
+    except Exception as exc:
+        LOGGER.warning(
+            "kr36_result_fetch_failed",
+            url=evidence.url,
+            reason=str(exc),
+        )
+        return evidence
+
+    return evidence.model_copy(
+        update={
+            "snippet": page.markdown[:MAX_SNIPPET_LENGTH],
+            "content": page.markdown,
+            "source_page": page,
+        }
+    )
+
+
 async def search(
     query: SubQuery,
     *,
@@ -144,7 +175,7 @@ async def search(
             http_client=http_client,
             params={"searchType": "post", "q": query.text},
         )
-        return await asyncio.to_thread(
+        evidences = await asyncio.to_thread(
             _parse_results,
             html_text,
             fetched_at=datetime.now(UTC),
@@ -155,3 +186,7 @@ async def search(
     except Exception as exc:
         LOGGER.warning("kr36_search_failed", reason=str(exc))
         return []
+
+    return await asyncio.gather(
+        *[_enrich_evidence(evidence, http_client=http_client) for evidence in evidences]
+    )

--- a/autosearch/skills/channels/sogou_weixin/methods/api_search.py
+++ b/autosearch/skills/channels/sogou_weixin/methods/api_search.py
@@ -10,7 +10,7 @@ import httpx
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.html_scraper import HtmlFetchError, fetch_html
+from autosearch.lib.html_scraper import HtmlFetchError, fetch_html, fetch_page
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="sogou_weixin")
 
@@ -134,6 +134,37 @@ def _parse_results(html_text: str, *, fetched_at: datetime) -> list[Evidence]:
     return evidences
 
 
+async def _enrich_evidence(
+    evidence: Evidence,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> Evidence:
+    try:
+        page = await fetch_page(evidence.url, client=http_client)
+    except HtmlFetchError as exc:
+        LOGGER.warning(
+            "sogou_weixin_result_fetch_failed",
+            url=evidence.url,
+            reason=str(exc),
+        )
+        return evidence
+    except Exception as exc:
+        LOGGER.warning(
+            "sogou_weixin_result_fetch_failed",
+            url=evidence.url,
+            reason=str(exc),
+        )
+        return evidence
+
+    return evidence.model_copy(
+        update={
+            "snippet": page.markdown[:MAX_SNIPPET_LENGTH],
+            "content": page.markdown,
+            "source_page": page,
+        }
+    )
+
+
 async def search(
     query: SubQuery,
     *,
@@ -145,7 +176,7 @@ async def search(
             http_client=http_client,
             params={"type": "2", "query": query.text},
         )
-        return await asyncio.to_thread(
+        evidences = await asyncio.to_thread(
             _parse_results,
             html_text,
             fetched_at=datetime.now(UTC),
@@ -156,3 +187,7 @@ async def search(
     except Exception as exc:
         LOGGER.warning("sogou_weixin_search_failed", reason=str(exc))
         return []
+
+    return await asyncio.gather(
+        *[_enrich_evidence(evidence, http_client=http_client) for evidence in evidences]
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "AutoSearch v2 M1 skeleton"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+  "beautifulsoup4>=4.12",
   "aiosqlite",
   "ddgs",
   "fastapi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "httpx",
   "mcp",
   "markdown",
+  "markdownify>=0.11",
   "paper-search-mcp",
   "pydantic",
   "pytest",

--- a/tests/channels/kr36/test_api_search.py
+++ b/tests/channels/kr36/test_api_search.py
@@ -7,9 +7,10 @@ from pathlib import Path
 import httpx
 import pytest
 
-from autosearch.core.models import SubQuery
+from autosearch.core.models import FetchedPage, SubQuery
+from autosearch.lib.html_scraper import HtmlFetchError
 
-HTML_FIXTURE = """
+SEARCH_PAGE_HTML = """
 <html>
   <body>
     <div class="search-result">
@@ -39,6 +40,16 @@ HTML_FIXTURE = """
   </body>
 </html>
 """
+
+FIRST_ARTICLE_MARKDOWN = (
+    "# AI 芯片公司完成新一轮融资\n\n" + "边缘推理、国产算力与交付能力正在同步提升。 " * 20
+).strip()
+SECOND_ARTICLE_MARKDOWN = (
+    "## 具身智能 *机器人* 进入工厂\n\n" + "机器人团队开始进入制造、物流与质检等复杂环节。 " * 20
+).strip()
+THIRD_ARTICLE_MARKDOWN = (
+    "## 没有作者的文章\n\n" + "文章正文提供了更完整的背景信息。 " * 20
+).strip()
 
 
 def _load_module():
@@ -80,12 +91,66 @@ def _client(handler) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
+def _fetched_page(url: str, *, markdown: str) -> FetchedPage:
+    return FetchedPage(
+        url=url,
+        status_code=200,
+        html="<html></html>",
+        cleaned_html="<article></article>",
+        markdown=markdown,
+    )
+
+
+def _default_markdown_for_url(url: str) -> str:
+    if url.endswith("1234567890"):
+        return FIRST_ARTICLE_MARKDOWN
+    if url.endswith("2222222222"):
+        return SECOND_ARTICLE_MARKDOWN
+    return THIRD_ARTICLE_MARKDOWN
+
+
+def _patch_fetch_page(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    markdown_by_url: dict[str, str] | None = None,
+    error_urls: set[str] | None = None,
+) -> None:
+    async def fake_fetch_page(
+        url: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> FetchedPage:
+        _ = client
+        if error_urls and url in error_urls:
+            raise HtmlFetchError(url, reason="timeout")
+        markdown = (markdown_by_url or {}).get(url, _default_markdown_for_url(url))
+        return _fetched_page(url, markdown=markdown)
+
+    monkeypatch.setattr(MODULE, "fetch_page", fake_fetch_page)
+
+
 @pytest.mark.asyncio
-async def test_search_maps_article_items_to_evidence() -> None:
+async def test_search_maps_article_items_to_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_urls: list[str] = []
+    captured_clients: list[httpx.AsyncClient | None] = []
+
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.params["searchType"] == "post"
         assert request.url.params["q"] == "AI 芯片"
-        return httpx.Response(200, text=HTML_FIXTURE, request=request)
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    async def fake_fetch_page(
+        url: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> FetchedPage:
+        captured_urls.append(url)
+        captured_clients.append(client)
+        return _fetched_page(url, markdown=_default_markdown_for_url(url))
+
+    monkeypatch.setattr(MODULE, "fetch_page", fake_fetch_page)
 
     async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
@@ -94,20 +159,36 @@ async def test_search_maps_article_items_to_evidence() -> None:
 
     first = results[0]
     assert first.title == "AI 芯片公司完成新一轮融资"
-    assert first.snippet == "聚焦边缘推理与国产化部署，市场竞争开始加速。"
-    assert first.content == first.snippet
+    assert first.snippet == FIRST_ARTICLE_MARKDOWN[:300]
+    assert len(first.snippet or "") == 300
+    assert first.content == FIRST_ARTICLE_MARKDOWN
     assert first.source_channel == "kr36:36氪编辑部"
+    assert first.source_page is not None
+    assert first.source_page.markdown == FIRST_ARTICLE_MARKDOWN
 
     second = results[1]
     assert second.title == "具身智能 机器人 进入工厂"
-    assert second.snippet == "这是一段关于 机器人 进入制造场景的摘要。"
+    assert second.snippet == SECOND_ARTICLE_MARKDOWN[:300]
+    assert "<em>" not in (second.snippet or "")
+    assert "*机器人*" in (second.snippet or "")
+    assert second.content == SECOND_ARTICLE_MARKDOWN
     assert second.source_channel == "kr36:李响"
+    assert captured_urls == [
+        "https://www.36kr.com/p/1234567890",
+        "https://www.36kr.com/p/2222222222",
+        "https://www.36kr.com/p/3333333333",
+    ]
+    assert all(client is http_client for client in captured_clients)
 
 
 @pytest.mark.asyncio
-async def test_search_handles_relative_href() -> None:
+async def test_search_handles_relative_href(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text=HTML_FIXTURE, request=request)
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    _patch_fetch_page(monkeypatch)
 
     async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
@@ -116,14 +197,57 @@ async def test_search_handles_relative_href() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_handles_missing_author() -> None:
+async def test_search_handles_missing_author(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text=HTML_FIXTURE, request=request)
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    _patch_fetch_page(monkeypatch)
 
     async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
 
     assert results[2].source_channel == "kr36"
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_listing_snippet_on_fetch_page_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    _patch_fetch_page(
+        monkeypatch,
+        error_urls={"https://www.36kr.com/p/1234567890"},
+        markdown_by_url={
+            "https://www.36kr.com/p/2222222222": SECOND_ARTICLE_MARKDOWN,
+            "https://www.36kr.com/p/3333333333": THIRD_ARTICLE_MARKDOWN,
+        },
+    )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 3
+    assert results[0].snippet == "聚焦边缘推理与国产化部署，市场竞争开始加速。"
+    assert results[0].content == "聚焦边缘推理与国产化部署，市场竞争开始加速。"
+    assert results[0].source_page is None
+    assert results[1].snippet == SECOND_ARTICLE_MARKDOWN[:300]
+    assert results[1].source_page is not None
+    assert logger.events == [
+        (
+            "kr36_result_fetch_failed",
+            {
+                "url": "https://www.36kr.com/p/1234567890",
+                "reason": "html fetch failed: timeout (url=https://www.36kr.com/p/1234567890, status=None)",
+            },
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/channels/sogou_weixin/test_api_search.py
+++ b/tests/channels/sogou_weixin/test_api_search.py
@@ -7,9 +7,10 @@ from pathlib import Path
 import httpx
 import pytest
 
-from autosearch.core.models import SubQuery
+from autosearch.core.models import FetchedPage, SubQuery
+from autosearch.lib.html_scraper import HtmlFetchError
 
-HTML_FIXTURE = """
+SEARCH_PAGE_HTML = """
 <html>
   <body>
     <ul class="news-list">
@@ -56,6 +57,14 @@ HTML_FIXTURE = """
 </html>
 """
 
+FIRST_ARTICLE_MARKDOWN = (
+    "# AI *芯片* 创业公司拿下新融资\n\n" + "芯片公司完成新融资，开始推进量产和客户验证。 " * 20
+).strip()
+SECOND_ARTICLE_MARKDOWN = (
+    "## 企业服务 *出海* 怎么做\n\n" + "出海团队需要梳理渠道、合规与交付节奏。 " * 20
+).strip()
+THIRD_ARTICLE_MARKDOWN = ("## 没有账号名的结果\n\n" + "文章正文补充了更多背景信息。 " * 20).strip()
+
 
 def _load_module():
     module_path = (
@@ -96,12 +105,66 @@ def _client(handler) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
+def _fetched_page(url: str, *, markdown: str) -> FetchedPage:
+    return FetchedPage(
+        url=url,
+        status_code=200,
+        html="<html></html>",
+        cleaned_html="<article></article>",
+        markdown=markdown,
+    )
+
+
+def _default_markdown_for_url(url: str) -> str:
+    if url.endswith("example-1"):
+        return FIRST_ARTICLE_MARKDOWN
+    if url.endswith("example-2"):
+        return SECOND_ARTICLE_MARKDOWN
+    return THIRD_ARTICLE_MARKDOWN
+
+
+def _patch_fetch_page(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    markdown_by_url: dict[str, str] | None = None,
+    error_urls: set[str] | None = None,
+) -> None:
+    async def fake_fetch_page(
+        url: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> FetchedPage:
+        _ = client
+        if error_urls and url in error_urls:
+            raise HtmlFetchError(url, reason="timeout")
+        markdown = (markdown_by_url or {}).get(url, _default_markdown_for_url(url))
+        return _fetched_page(url, markdown=markdown)
+
+    monkeypatch.setattr(MODULE, "fetch_page", fake_fetch_page)
+
+
 @pytest.mark.asyncio
-async def test_search_maps_li_blocks_to_evidence() -> None:
+async def test_search_maps_li_blocks_to_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_urls: list[str] = []
+    captured_clients: list[httpx.AsyncClient | None] = []
+
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.params["type"] == "2"
         assert request.url.params["query"] == "AI 芯片"
-        return httpx.Response(200, text=HTML_FIXTURE, request=request)
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    async def fake_fetch_page(
+        url: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> FetchedPage:
+        captured_urls.append(url)
+        captured_clients.append(client)
+        return _fetched_page(url, markdown=_default_markdown_for_url(url))
+
+    monkeypatch.setattr(MODULE, "fetch_page", fake_fetch_page)
 
     async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
@@ -111,19 +174,40 @@ async def test_search_maps_li_blocks_to_evidence() -> None:
     first = results[0]
     assert first.url == "https://mp.weixin.qq.com/s/example-1"
     assert first.title == "AI 芯片 创业公司拿下新融资"
-    assert first.snippet == "这是一段关于 芯片 创业公司的摘要，包含最新进展与市场判断。"
-    assert first.content == first.snippet
+    assert first.snippet == FIRST_ARTICLE_MARKDOWN[:300]
+    assert len(first.snippet or "") == 300
+    assert first.content == FIRST_ARTICLE_MARKDOWN
     assert first.source_channel == "sogou_weixin:极客公园"
+    assert first.source_page is not None
+    assert first.source_page.markdown == FIRST_ARTICLE_MARKDOWN
 
     second = results[1]
     assert second.title == "企业服务 出海 怎么做"
+    assert second.snippet == SECOND_ARTICLE_MARKDOWN[:300]
+    assert second.content == SECOND_ARTICLE_MARKDOWN
     assert second.source_channel == "sogou_weixin:晚点团队"
+    assert captured_urls == [
+        "https://mp.weixin.qq.com/s/example-1",
+        "https://weixin.sogou.com/link?url=https%3A%2F%2Fmp.weixin.qq.com%2Fs%2Fexample-2",
+        "https://mp.weixin.qq.com/s/example-3",
+    ]
+    assert all(client is http_client for client in captured_clients)
 
 
 @pytest.mark.asyncio
-async def test_search_strips_em_markers_from_title_and_snippet() -> None:
+async def test_search_strips_em_markers_from_title_and_snippet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text=HTML_FIXTURE, request=request)
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    _patch_fetch_page(
+        monkeypatch,
+        markdown_by_url={
+            "https://mp.weixin.qq.com/s/example-1": FIRST_ARTICLE_MARKDOWN,
+            "https://weixin.sogou.com/link?url=https%3A%2F%2Fmp.weixin.qq.com%2Fs%2Fexample-2": SECOND_ARTICLE_MARKDOWN,
+        },
+    )
 
     async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
@@ -131,14 +215,20 @@ async def test_search_strips_em_markers_from_title_and_snippet() -> None:
     assert len(results) >= 2
     assert "<em>" not in results[0].title
     assert "<em>" not in (results[0].snippet or "")
+    assert "<em>" not in (results[1].snippet or "")
     assert "芯片" in results[0].title
-    assert "出海" in (results[1].snippet or "")
+    assert "*芯片*" in (results[0].snippet or "")
+    assert "*出海*" in (results[1].snippet or "")
 
 
 @pytest.mark.asyncio
-async def test_search_handles_link_redirect_url() -> None:
+async def test_search_handles_link_redirect_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text=HTML_FIXTURE, request=request)
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    _patch_fetch_page(monkeypatch)
 
     async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
@@ -150,14 +240,57 @@ async def test_search_handles_link_redirect_url() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_handles_missing_account() -> None:
+async def test_search_handles_missing_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, text=HTML_FIXTURE, request=request)
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    _patch_fetch_page(monkeypatch)
 
     async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
 
     assert results[2].source_channel == "sogou_weixin"
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_listing_snippet_on_fetch_page_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=SEARCH_PAGE_HTML, request=request)
+
+    _patch_fetch_page(
+        monkeypatch,
+        error_urls={"https://mp.weixin.qq.com/s/example-1"},
+        markdown_by_url={
+            "https://weixin.sogou.com/link?url=https%3A%2F%2Fmp.weixin.qq.com%2Fs%2Fexample-2": SECOND_ARTICLE_MARKDOWN,
+            "https://mp.weixin.qq.com/s/example-3": THIRD_ARTICLE_MARKDOWN,
+        },
+    )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 3
+    assert results[0].snippet == "这是一段关于 芯片 创业公司的摘要，包含最新进展与市场判断。"
+    assert results[0].content == "这是一段关于 芯片 创业公司的摘要，包含最新进展与市场判断。"
+    assert results[0].source_page is None
+    assert results[1].snippet == SECOND_ARTICLE_MARKDOWN[:300]
+    assert results[1].source_page is not None
+    assert logger.events == [
+        (
+            "sogou_weixin_result_fetch_failed",
+            {
+                "url": "https://mp.weixin.qq.com/s/example-1",
+                "reason": "html fetch failed: timeout (url=https://mp.weixin.qq.com/s/example-1, status=None)",
+            },
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cleaners/test_bm25_cleaner.py
+++ b/tests/unit/cleaners/test_bm25_cleaner.py
@@ -1,0 +1,106 @@
+# Self-written, plan v2.3 § 13.5 F104
+from bs4 import BeautifulSoup
+from rank_bm25 import BM25Okapi
+
+from autosearch.cleaners.bm25_cleaner import BM25Cleaner
+
+
+def test_none_query_returns_unchanged() -> None:
+    html = "<div><p>Keep original html.</p></div>"
+
+    assert BM25Cleaner().clean(html) == html
+
+
+def test_empty_query_treated_as_none() -> None:
+    html = "<div><p>Keep original html.</p></div>"
+
+    assert BM25Cleaner().clean(html, query="   ") == html
+
+
+def test_keeps_only_query_relevant_paragraphs() -> None:
+    html = """
+    <div>
+      <p>Python async programming uses the event loop for concurrency.</p>
+      <p>Async tasks in Python let concurrent workloads cooperate efficiently.</p>
+      <p>Gardening tips for basil and tomatoes in warm weather.</p>
+      <p>Mountain bike maintenance for weekend trail riders.</p>
+      <p>Soup recipes with roasted garlic and onions.</p>
+    </div>
+    """
+
+    cleaned = BM25Cleaner().clean(html, query="python async concurrency")
+
+    assert "Python async programming uses the event loop for concurrency." in cleaned
+    assert "Async tasks in Python let concurrent workloads cooperate efficiently." in cleaned
+    assert "Gardening tips for basil and tomatoes in warm weather." not in cleaned
+    assert "Mountain bike maintenance for weekend trail riders." not in cleaned
+    assert "Soup recipes with roasted garlic and onions." not in cleaned
+
+
+def test_preserves_document_order_not_score_order() -> None:
+    first = "Python async basics introduce cooperative scheduling."
+    second = "Python async concurrency event loop tasks futures coroutines guide."
+    third = "Async concurrency patterns help Python services scale cleanly."
+    html = f"""
+    <div>
+      <p>{first}</p>
+      <p>{second}</p>
+      <p>{third}</p>
+    </div>
+    """
+
+    cleaned = BM25Cleaner(top_k=3).clean(
+        html,
+        query="python async concurrency event loop coroutines",
+    )
+    ordered_text = [
+        paragraph.get_text(" ", strip=True)
+        for paragraph in BeautifulSoup(cleaned, "html.parser").find_all("p")
+    ]
+
+    assert ordered_text == [first, second, third]
+
+
+def test_top_k_limit() -> None:
+    html = "".join(f"<p>Python async concurrency example {index}</p>" for index in range(20))
+
+    cleaned = BM25Cleaner(top_k=5).clean(html, query="python async concurrency")
+    soup = BeautifulSoup(cleaned, "html.parser")
+
+    assert len(soup.find_all("p")) == 5
+
+
+def test_handles_headers() -> None:
+    html = """
+    <div>
+      <h1>Python Async Guide</h1>
+      <h2>Weekend Sports Roundup</h2>
+      <p>Unrelated topic about cooking.</p>
+    </div>
+    """
+
+    cleaned = BM25Cleaner().clean(html, query="python async")
+    soup = BeautifulSoup(cleaned, "html.parser")
+
+    assert soup.find("h1") is not None
+    assert "Python Async Guide" in cleaned
+    assert "Weekend Sports Roundup" not in cleaned
+    assert "Unrelated topic about cooking." not in cleaned
+
+
+def test_single_candidate_no_crash() -> None:
+    html = "<p>Only paragraph here.</p>"
+
+    assert BM25Cleaner().clean(html, query="nonmatching query") == html
+
+
+def test_empty_html_returns_empty() -> None:
+    assert BM25Cleaner().clean("", query="python") == ""
+
+
+def test_bm25_uses_rank_bm25_library() -> None:
+    bm25 = BM25Okapi([["python"], ["async"]])
+    cleaner = BM25Cleaner()
+
+    assert bm25 is not None
+    assert isinstance(cleaner, BM25Cleaner)

--- a/tests/unit/cleaners/test_bm25_cleaner.py
+++ b/tests/unit/cleaners/test_bm25_cleaner.py
@@ -98,6 +98,41 @@ def test_empty_html_returns_empty() -> None:
     assert BM25Cleaner().clean("", query="python") == ""
 
 
+def test_top_k_is_hard_cap_when_min_score_set() -> None:
+    html = "".join(f"<p>Python async concurrency token{index}</p>" for index in range(20))
+
+    cleaned = BM25Cleaner(top_k=5, min_score=0.01).clean(
+        html,
+        query="python async concurrency",
+    )
+    soup = BeautifulSoup(cleaned, "html.parser")
+
+    assert len(soup.find_all("p")) == 5
+
+
+def test_min_score_filter_without_top_k() -> None:
+    html = """
+    <div>
+      <p>Python async concurrency event loop futures coroutines scheduler token0</p>
+      <p>Python async concurrency event loop token1</p>
+      <p>Python async token2</p>
+      <p>Gardening basil token3</p>
+      <p>Python token4</p>
+    </div>
+    """
+
+    cleaned = BM25Cleaner(top_k=0, min_score=2.0).clean(
+        html,
+        query="python async concurrency event loop futures coroutines scheduler",
+    )
+
+    assert "Python async concurrency event loop futures coroutines scheduler token0" in cleaned
+    assert "Python async concurrency event loop token1" not in cleaned
+    assert "Python async token2" not in cleaned
+    assert "Gardening basil token3" not in cleaned
+    assert "Python token4" not in cleaned
+
+
 def test_bm25_uses_rank_bm25_library() -> None:
     bm25 = BM25Okapi([["python"], ["async"]])
     cleaner = BM25Cleaner()

--- a/tests/unit/cleaners/test_pruning_cleaner.py
+++ b/tests/unit/cleaners/test_pruning_cleaner.py
@@ -1,0 +1,105 @@
+# Self-written, plan v2.3 § 13.5 F103
+from bs4 import BeautifulSoup
+
+from autosearch.cleaners.pruning_cleaner import PruningCleaner
+
+
+def test_prunes_nav_footer_while_keeping_article() -> None:
+    cleaner = PruningCleaner()
+    html = """
+    <html>
+      <body>
+        <nav>Home About Contact</nav>
+        <article>
+          <p>Real article content stays in place.</p>
+          <p>It has enough words to be meaningful.</p>
+          <p>The cleaner should keep this section.</p>
+        </article>
+        <footer>Copyright links and legal text</footer>
+      </body>
+    </html>
+    """
+
+    cleaned = cleaner.clean(html)
+
+    assert "Real article content stays in place." in cleaned
+    assert "Home About Contact" not in cleaned
+    assert "Copyright links and legal text" not in cleaned
+
+
+def test_prunes_sidebar_by_class_hint() -> None:
+    cleaner = PruningCleaner()
+    html = """
+    <div class="sidebar">Promoted links and sponsored blocks</div>
+    <div class="content">
+      Useful content with enough words to remain visible.
+    </div>
+    """
+
+    cleaned = cleaner.clean(html)
+
+    assert "Promoted links and sponsored blocks" not in cleaned
+    assert "Useful content with enough words to remain visible." in cleaned
+
+
+def test_prunes_low_text_density_link_menu() -> None:
+    cleaner = PruningCleaner()
+    links = "".join(f"<li><a href='/{index}'>Menu item {index}</a></li>" for index in range(10))
+    html = f"<ul>{links}</ul>"
+
+    cleaned = cleaner.clean(html)
+
+    assert "Menu item 0" not in cleaned
+    assert cleaned == ""
+
+
+def test_keeps_code_and_pre_blocks() -> None:
+    cleaner = PruningCleaner()
+    html = "<pre><code>def foo(): pass</code></pre>"
+
+    cleaned = cleaner.clean(html)
+
+    assert "<pre>" in cleaned
+    assert "<code>" in cleaned
+    assert "def foo(): pass" in cleaned
+
+
+def test_threshold_adjustable() -> None:
+    html = "<section><p>Useful content for readers with enough words to stay.</p></section>"
+
+    low_threshold = PruningCleaner(threshold=0.1).clean(html)
+    high_threshold = PruningCleaner(threshold=0.9).clean(html)
+
+    assert "Useful content for readers with enough words to stay." in low_threshold
+    assert high_threshold == ""
+
+
+def test_empty_html_returns_empty() -> None:
+    assert PruningCleaner().clean("") == ""
+
+
+def test_min_word_count_filter() -> None:
+    cleaner = PruningCleaner(min_word_count=3)
+    html = """
+    <div>
+      <p>Hi</p>
+      <p>This is a full sentence with meaningful content.</p>
+    </div>
+    """
+
+    cleaned = cleaner.clean(html)
+
+    assert "Hi" not in cleaned
+    assert "This is a full sentence with meaningful content." in cleaned
+
+
+def test_preserves_html_structure_not_plain_text() -> None:
+    cleaner = PruningCleaner()
+    html = "<article><p>Structured content remains in HTML form.</p></article>"
+
+    cleaned = cleaner.clean(html)
+    soup = BeautifulSoup(cleaned, "html.parser")
+
+    assert "<" in cleaned
+    assert ">" in cleaned
+    assert soup.find("article") is not None

--- a/tests/unit/cleaners/test_pruning_cleaner.py
+++ b/tests/unit/cleaners/test_pruning_cleaner.py
@@ -93,6 +93,37 @@ def test_min_word_count_filter() -> None:
     assert "This is a full sentence with meaningful content." in cleaned
 
 
+def test_keeps_chinese_article_content() -> None:
+    cleaner = PruningCleaner()
+    html = """
+    <nav>菜单</nav>
+    <article>
+      <p>聚焦边缘推理与国产化部署，AI 芯片公司完成新一轮融资。</p>
+      <p>边缘推理、国产算力与交付能力正在同步提升。</p>
+    </article>
+    <footer>底部</footer>
+    """
+
+    cleaned = cleaner.clean(html)
+
+    assert "聚焦边缘推理与国产化部署，AI 芯片公司完成新一轮融资。" in cleaned
+    assert "边缘推理、国产算力与交付能力正在同步提升。" in cleaned
+    assert "菜单" not in cleaned
+    assert "底部" not in cleaned
+
+
+def test_word_count_counts_cjk_characters() -> None:
+    cleaner = PruningCleaner()
+
+    assert cleaner._word_count("聚焦边缘推理") == 6
+
+
+def test_word_count_mixed_cjk_and_ascii() -> None:
+    cleaner = PruningCleaner()
+
+    assert cleaner._word_count("AI 芯片公司") == 5
+
+
 def test_preserves_html_structure_not_plain_text() -> None:
     cleaner = PruningCleaner()
     html = "<article><p>Structured content remains in HTML form.</p></article>"

--- a/tests/unit/lib/test_fetch_page.py
+++ b/tests/unit/lib/test_fetch_page.py
@@ -1,0 +1,251 @@
+# Self-written for F102
+import pytest
+
+from autosearch.lib.html_scraper import HtmlFetchError, fetch_page
+
+
+def stub_fetch_html(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    html: str | None = None,
+    error: Exception | None = None,
+) -> None:
+    async def fake_fetch_html(*args, **kwargs) -> str:
+        if error is not None:
+            raise error
+        return html or ""
+
+    monkeypatch.setattr("autosearch.lib.html_scraper.fetch_html", fake_fetch_html)
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_basic_html(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <html>
+          <head><title>Example Page</title></head>
+          <body>
+            <article>
+              <p>Meaningful body content stays visible.</p>
+              <a href="/about">About</a>
+            </article>
+          </body>
+        </html>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert page.url == "https://example.com/page"
+    assert page.status_code == 200
+    assert page.markdown
+    assert len(page.links) == 1
+    assert page.metadata["title"] == "Example Page"
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_extracts_og_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <html>
+          <head>
+            <meta property="og:title" content="OG Title" />
+            <meta property="og:description" content="OG Description" />
+            <meta name="twitter:description" content="Tweet Description" />
+          </head>
+        </html>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert page.metadata["og:title"] == "OG Title"
+    assert page.metadata["og:description"] == "OG Description"
+    assert page.metadata["twitter:description"] == "Tweet Description"
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_classifies_internal_vs_external_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <article>
+          <a href="https://example.com/about">About</a>
+          <a href="https://external.example.org/post">Source</a>
+        </article>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert [link.internal for link in page.links] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_skips_anchor_javascript_mailto_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <article>
+          <a href="#top">Top</a>
+          <a href="javascript:alert('x')">JS</a>
+          <a href="mailto:test@example.com">Mail</a>
+          <a href="/keep">Keep</a>
+        </article>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert [link.href for link in page.links] == ["https://example.com/keep"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_extracts_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <table>
+          <tr><th>A</th><th>B</th></tr>
+          <tr><td>1</td><td>2</td></tr>
+        </table>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert page.tables[0].headers == ["A", "B"]
+    assert page.tables[0].rows[0] == {"A": "1", "B": "2"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_collects_images_and_videos(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <article>
+          <img src="/one.png" alt="One" />
+          <img src="https://cdn.example.com/two.png" alt="Two" />
+          <video src="/demo.mp4"></video>
+        </article>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert len(page.media) == 3
+    assert [item.kind for item in page.media] == ["image", "image", "video"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_markdown_contains_heading_and_paragraph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <article>
+          <h1>Page Title</h1>
+          <p>Body paragraph.</p>
+        </article>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page", run_prune=False)
+
+    assert "# Page Title" in page.markdown
+    assert "Body paragraph." in page.markdown
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_prune_removes_nav_footer_from_markdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <html>
+          <body>
+            <nav>menu links</nav>
+            <article>
+              <p>real content here in article for readers</p>
+            </article>
+            <footer>foot links</footer>
+          </body>
+        </html>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert "menu links" not in page.markdown
+    assert "foot links" not in page.markdown
+    assert "real content here in article for readers" in page.markdown
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_with_run_prune_false_keeps_nav(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <html>
+          <body>
+            <nav>menu links</nav>
+            <article>
+              <p>real content here in article for readers</p>
+            </article>
+            <footer>foot links</footer>
+          </body>
+        </html>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page", run_prune=False)
+
+    assert "menu links" in page.markdown
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_relative_urls_absolutized(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_fetch_html(
+        monkeypatch,
+        html="""
+        <article>
+          <a href="/about">About</a>
+        </article>
+        """,
+    )
+
+    page = await fetch_page("https://example.com/page")
+
+    assert page.links[0].href == "https://example.com/about"
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_empty_html_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_fetch_html(monkeypatch, html="")
+
+    page = await fetch_page("https://example.com/page")
+
+    assert page.markdown == ""
+    assert page.links == []
+    assert page.metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_http_error_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = HtmlFetchError("https://example.com/page", status_code=502, reason="http_error")
+    stub_fetch_html(monkeypatch, error=error)
+
+    with pytest.raises(HtmlFetchError) as exc_info:
+        await fetch_page("https://example.com/page")
+
+    assert exc_info.value is error

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -8,15 +8,158 @@ from autosearch.core.models import (
     ClarifyRequest,
     ClarifyResult,
     Evidence,
+    FetchedPage,
     Gap,
     KnowledgeRecall,
+    LinkRef,
+    MediaRef,
     Rubric,
     SearchMode,
     Section,
     SubQuery,
+    TableData,
 )
 
 FIXED_TIME = datetime(2026, 4, 17, 12, 0, tzinfo=UTC)
+
+
+def test_fetched_page_minimum_fields_roundtrip() -> None:
+    page = FetchedPage(url="https://example.com/article", status_code=200)
+
+    payload = page.model_dump_json()
+    restored = FetchedPage.model_validate_json(payload)
+
+    assert restored == page
+    assert restored.html == ""
+    assert restored.cleaned_html == ""
+    assert restored.markdown == ""
+    assert restored.links == []
+    assert restored.metadata == {}
+    assert restored.tables == []
+    assert restored.media == []
+
+
+def test_fetched_page_full_roundtrip() -> None:
+    page = FetchedPage(
+        url="https://example.com/article",
+        status_code=200,
+        fetched_at=FIXED_TIME,
+        html="<html><body><h1>Title</h1></body></html>",
+        cleaned_html="<article><h1>Title</h1></article>",
+        markdown="# Title\n\nBody",
+        links=[
+            LinkRef(
+                href="https://example.com/internal",
+                text="Read more",
+                internal=True,
+            ),
+            LinkRef(
+                href="https://external.example.org",
+                text="External source",
+            ),
+        ],
+        metadata={
+            "title": "Example Title",
+            "og:title": "Example OG Title",
+            "description": "Example description",
+            "author": "Author Name",
+            "published_at": "2026-04-17T12:00:00+00:00",
+        },
+        tables=[
+            TableData(
+                headers=["Name", "Value"],
+                rows=[
+                    {"Name": "foo", "Value": "1"},
+                    {"Name": "bar", "Value": "2"},
+                ],
+            )
+        ],
+        media=[
+            MediaRef(src="https://example.com/image.png", alt="Diagram"),
+            MediaRef(
+                src="https://example.com/video.mp4",
+                alt="Demo",
+                kind="video",
+            ),
+        ],
+    )
+
+    payload = page.model_dump_json()
+    restored = FetchedPage.model_validate_json(payload)
+
+    assert restored == page
+
+
+def test_evidence_with_source_page() -> None:
+    evidence = Evidence(
+        url="https://example.com",
+        title="Example",
+        snippet="snippet",
+        content="content",
+        source_channel="web",
+        fetched_at=FIXED_TIME,
+        score=0.8,
+        source_page=FetchedPage(
+            url="https://example.com",
+            status_code=200,
+            fetched_at=FIXED_TIME,
+            markdown="# Example",
+            links=[LinkRef(href="https://example.com/about", text="About", internal=True)],
+            metadata={"title": "Example"},
+        ),
+    )
+
+    payload = evidence.model_dump_json()
+    restored = Evidence.model_validate_json(payload)
+
+    assert restored == evidence
+    assert restored.source_page is not None
+    assert restored.source_page.markdown == "# Example"
+
+
+def test_evidence_without_source_page_still_valid() -> None:
+    evidence = Evidence(
+        url="https://example.com",
+        title="Example",
+        snippet="snippet",
+        content="content",
+        source_channel="web",
+        fetched_at=FIXED_TIME,
+        score=0.8,
+    )
+
+    payload = evidence.model_dump_json()
+    restored = Evidence.model_validate_json(payload)
+
+    assert restored == evidence
+    assert restored.source_page is None
+
+
+def test_link_ref_internal_flag() -> None:
+    link = LinkRef(href="https://example.com/about", text="About")
+
+    assert link.internal is False
+
+
+def test_table_data_roundtrip() -> None:
+    table = TableData(
+        headers=["Name", "Role"],
+        rows=[
+            {"Name": "Alice", "Role": "Maintainer"},
+            {"Name": "Bob", "Role": "Reviewer"},
+        ],
+    )
+
+    payload = table.model_dump_json()
+    restored = TableData.model_validate_json(payload)
+
+    assert restored == table
+
+
+def test_media_ref_default_kind_image() -> None:
+    media = MediaRef(src="https://example.com/image.png", alt="A screenshot")
+
+    assert media.kind == "image"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

W1 of plan `autosearch-0420-steal-3-patterns.md` — upgrade the tool layer by borrowing crawl4ai's heuristic ideas without vendoring its code. Zero new frameworks; 2 small deps (`beautifulsoup4`, `markdownify`).

- **FetchedPage** pydantic v2 structured document: url / status / html / cleaned_html / markdown / links / metadata / tables / media
- **PruningCleaner** heuristic HTML denoise (no LLM) — text density + link density + tag weight + class/id hints
- **BM25Cleaner** query-aware HTML compression using existing rank-bm25 dep
- **fetch_page()** new async function replacing bare `httpx.get → str` with structured FetchedPage
- **sogou_weixin + kr36** switched to fetch_page — Evidence.content becomes rich markdown, Evidence.source_page populated
- **CJK fix**: PruningCleaner word count is CJK-character-aware (would have silently wiped all Chinese articles otherwise)
- **BM25 fix**: top_k now a hard cap even when min_score is set

## Commits (6)

1. feat(models): add FetchedPage structured document and optional Evidence.source_page
2. feat(cleaners): pruning cleaner heuristic html denoise (no llm)
3. feat(cleaners): bm25 cleaner for query-aware html compression
4. feat(lib): fetch_page returns structured fetched page with markdown links metadata tables
5. refactor(channels): sogou_weixin and kr36 use fetch_page for rich markdown evidence
6. fix(cleaners): cjk-aware pruning word count and bm25 top_k hard cap (review-response)

## Test plan

- [x] 55 new unit tests (7 models + 8 pruning + 9 bm25 + 12 fetch_page + 9 channel refactor + 5 review fix + 5 combo fixes)
- [x] Full suite: 479 passed / 18 deselected / 0 failed
- [x] ruff check + ruff format --check clean
- [x] Pre-push hook rerun green (473 runnable under push-gate)
- [x] Code review pass via pr-review-toolkit:code-reviewer — found 1 P0 (CJK bug) + 1 P1 (top_k vs min_score) — both fixed in commit 6

## Gotchas for reviewer

- FetchedPage stores html + cleaned_html + markdown = 3 copies of page text; Evidence memory 3-5x per item. W2 (context compaction) will address.
- status_code=200 hardcoded in fetch_page; fetch_html raises on non-2xx so safe for success path.
- .gitattributes / .github/aw/ / tests/real_llm/_*.py remain untracked (other-session residue, Pending item in HANDOFF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now include full article content instead of snippets alone.
  * Results are cleaned to remove boilerplate and navigation elements.
  * Content automatically converted to markdown format for improved readability.
  * Extracted structured data from pages: links, tables, images, and videos.

* **Dependencies**
  * Added HTML parsing and markdown conversion libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->