### PR TITLE
feat: W2 iteration layer — ContextCompactor + per-search reflection (steal deepagents ideas)

### DIFF
--- a/autosearch/core/context_compaction.py
+++ b/autosearch/core/context_compaction.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import structlog
+from typing import TYPE_CHECKING
 
 from autosearch.core.models import Evidence, EvidenceDigest
 from autosearch.llm.client import LLMClient
 from autosearch.observability.cost import estimate_tokens
 from autosearch.skills.prompts import load_prompt
+
+if TYPE_CHECKING:
+    from autosearch.persistence.session_store import SessionStore
 
 EVIDENCE_COMPACTION_PROMPT = load_prompt("m3_evidence_compaction")
 _MAX_EVIDENCE_FIELD_CHARS = 1000
@@ -21,6 +25,8 @@ class ContextCompactor:
         hot_set_size: int = 10,
         compact_when_over_pct: float = 0.8,
         client: LLMClient | None = None,
+        store: SessionStore | None = None,
+        session_id: str | None = None,
     ) -> None:
         if token_budget <= 0:
             raise ValueError("token_budget must be greater than 0")
@@ -33,6 +39,8 @@ class ContextCompactor:
         self.hot_set_size = hot_set_size
         self.compact_when_over_pct = compact_when_over_pct
         self.client = client
+        self.store = store
+        self.session_id = session_id
         self.logger = structlog.get_logger(__name__).bind(component="context_compactor")
 
     async def compact(
@@ -68,6 +76,12 @@ class ContextCompactor:
             cold_count=len(cold),
         )
 
+        for item in cold:
+            await self._store_artifact_best_effort(
+                kind="evicted_evidence",
+                payload=item,
+            )
+
         prompt = self._build_prompt(query, cold)
         try:
             client = self.client or LLMClient()
@@ -77,6 +91,10 @@ class ContextCompactor:
             return evidence, None
 
         digest = self._finalize_digest(llm_digest, cold, cold_tokens)
+        await self._store_artifact_best_effort(
+            kind="compacted_digest",
+            payload=digest,
+        )
         self.logger.info(
             "compaction_completed",
             key_findings_count=len(digest.key_findings),
@@ -163,3 +181,25 @@ class ContextCompactor:
         if len(text) <= _MAX_EVIDENCE_FIELD_CHARS:
             return text
         return f"{text[:_MAX_EVIDENCE_FIELD_CHARS].rstrip()}..."
+
+    async def _store_artifact_best_effort(
+        self,
+        *,
+        kind: str,
+        payload: Evidence | EvidenceDigest,
+    ) -> None:
+        if self.store is None or self.session_id is None:
+            return
+
+        try:
+            await self.store.store_artifact(
+                session_id=self.session_id,
+                kind=kind,
+                payload=payload,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "compaction_artifact_store_failed",
+                kind=kind,
+                error=str(exc),
+            )

--- a/autosearch/core/context_compaction.py
+++ b/autosearch/core/context_compaction.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import structlog
+
+from autosearch.core.models import Evidence, EvidenceDigest
+from autosearch.llm.client import LLMClient
+from autosearch.observability.cost import estimate_tokens
+from autosearch.skills.prompts import load_prompt
+
+EVIDENCE_COMPACTION_PROMPT = load_prompt("m3_evidence_compaction")
+_MAX_EVIDENCE_FIELD_CHARS = 1000
+
+
+class ContextCompactor:
+    """Token-budget-triggered evidence compression."""
+
+    def __init__(
+        self,
+        *,
+        token_budget: int = 16000,
+        hot_set_size: int = 10,
+        compact_when_over_pct: float = 0.8,
+        client: LLMClient | None = None,
+    ) -> None:
+        if token_budget <= 0:
+            raise ValueError("token_budget must be greater than 0")
+        if hot_set_size < 0:
+            raise ValueError("hot_set_size must be greater than or equal to 0")
+        if not 0 < compact_when_over_pct <= 1:
+            raise ValueError("compact_when_over_pct must be between 0 and 1")
+
+        self.token_budget = token_budget
+        self.hot_set_size = hot_set_size
+        self.compact_when_over_pct = compact_when_over_pct
+        self.client = client
+        self.logger = structlog.get_logger(__name__).bind(component="context_compactor")
+
+    async def compact(
+        self,
+        evidence: list[Evidence],
+        query: str,
+    ) -> tuple[list[Evidence], EvidenceDigest | None]:
+        """Return a hot evidence tail and an optional digest for the evicted slice."""
+
+        if not evidence:
+            return [], None
+
+        total_tokens = sum(self._count_tokens(item) for item in evidence)
+        threshold = self.token_budget * self.compact_when_over_pct
+        if total_tokens < threshold:
+            return evidence, None
+
+        hot, cold = self._split_evidence(evidence)
+        if not cold:
+            self.logger.debug(
+                "compaction_skipped_no_cold_evidence",
+                total_tokens=total_tokens,
+                budget=self.token_budget,
+                hot_set_size=self.hot_set_size,
+            )
+            return evidence, None
+
+        cold_tokens = sum(self._count_tokens(item) for item in cold)
+        self.logger.info(
+            "compaction_triggered",
+            total_tokens=total_tokens,
+            budget=self.token_budget,
+            cold_count=len(cold),
+        )
+
+        prompt = self._build_prompt(query, cold)
+        try:
+            client = self.client or LLMClient()
+            llm_digest = await client.complete(prompt, EvidenceDigest)
+        except Exception as exc:
+            self.logger.warning("compaction_skipped_llm_error", error=str(exc))
+            return evidence, None
+
+        digest = self._finalize_digest(llm_digest, cold, cold_tokens)
+        self.logger.info(
+            "compaction_completed",
+            key_findings_count=len(digest.key_findings),
+            before_tokens=digest.token_count_before,
+            after_tokens=digest.token_count_after,
+        )
+        return hot, digest
+
+    def _count_tokens(self, evidence: Evidence) -> int:
+        return estimate_tokens(self._serialize_evidence_for_count(evidence))
+
+    def _build_prompt(self, query: str, cold_evidence: list[Evidence]) -> str:
+        return EVIDENCE_COMPACTION_PROMPT.format(
+            query=query,
+            cold_evidence_context=self._format_cold_evidence(cold_evidence),
+        )
+
+    def _split_evidence(self, evidence: list[Evidence]) -> tuple[list[Evidence], list[Evidence]]:
+        if self.hot_set_size == 0:
+            return [], list(evidence)
+        return list(evidence[-self.hot_set_size :]), list(evidence[: -self.hot_set_size])
+
+    def _finalize_digest(
+        self,
+        llm_digest: EvidenceDigest,
+        cold_evidence: list[Evidence],
+        cold_tokens: int,
+    ) -> EvidenceDigest:
+        digest = llm_digest.model_copy(
+            update={
+                "source_urls": self._collect_source_urls(cold_evidence),
+                "evidence_count": len(cold_evidence),
+                "token_count_before": cold_tokens,
+            }
+        )
+        token_count_after = estimate_tokens(self._render_digest_for_count(digest))
+        return digest.model_copy(update={"token_count_after": token_count_after})
+
+    def _serialize_evidence_for_count(self, evidence: Evidence) -> str:
+        parts = [
+            (evidence.title or "").strip(),
+            (evidence.snippet or "").strip(),
+            (evidence.content or "").strip(),
+        ]
+        return "\n".join(part for part in parts if part)
+
+    def _format_cold_evidence(self, evidence: list[Evidence]) -> str:
+        if not evidence:
+            return "- No cold evidence"
+
+        formatted: list[str] = []
+        for index, item in enumerate(evidence, start=1):
+            snippet = self._trim_text(item.snippet)
+            content = self._trim_text(item.content)
+            lines = [
+                f"[{index}] {item.title}",
+                f"URL: {item.url}",
+                f"Snippet: {snippet or '(none)'}",
+                f"Content: {content or '(none)'}",
+            ]
+            formatted.append("\n".join(lines))
+        return "\n\n".join(formatted)
+
+    def _collect_source_urls(self, evidence: list[Evidence]) -> list[str]:
+        seen: set[str] = set()
+        urls: list[str] = []
+        for item in evidence:
+            if item.url in seen:
+                continue
+            seen.add(item.url)
+            urls.append(item.url)
+        return urls
+
+    def _render_digest_for_count(self, digest: EvidenceDigest) -> str:
+        lines = [f"Topic: {digest.topic}", "Key findings:"]
+        lines.extend(f"- {finding}" for finding in digest.key_findings)
+        lines.append("Source URLs:")
+        lines.extend(f"- {url}" for url in digest.source_urls)
+        return "\n".join(lines)
+
+    def _trim_text(self, text: str | None) -> str:
+        if not text:
+            return ""
+        if len(text) <= _MAX_EVIDENCE_FIELD_CHARS:
+            return text
+        return f"{text[:_MAX_EVIDENCE_FIELD_CHARS].rstrip()}..."

--- a/autosearch/core/context_compaction.py
+++ b/autosearch/core/context_compaction.py
@@ -4,11 +4,11 @@ import structlog
 from typing import TYPE_CHECKING
 
 from autosearch.core.models import Evidence, EvidenceDigest
-from autosearch.llm.client import LLMClient
 from autosearch.observability.cost import estimate_tokens
 from autosearch.skills.prompts import load_prompt
 
 if TYPE_CHECKING:
+    from autosearch.llm.client import LLMClient
     from autosearch.persistence.session_store import SessionStore
 
 EVIDENCE_COMPACTION_PROMPT = load_prompt("m3_evidence_compaction")
@@ -41,6 +41,7 @@ class ContextCompactor:
         self.client = client
         self.store = store
         self.session_id = session_id
+        self.last_digest_artifact_id: int | None = None
         self.logger = structlog.get_logger(__name__).bind(component="context_compactor")
 
     async def compact(
@@ -50,6 +51,7 @@ class ContextCompactor:
     ) -> tuple[list[Evidence], EvidenceDigest | None]:
         """Return a hot evidence tail and an optional digest for the evicted slice."""
 
+        self.last_digest_artifact_id = None
         if not evidence:
             return [], None
 
@@ -68,6 +70,12 @@ class ContextCompactor:
             )
             return evidence, None
 
+        if self.client is None:
+            raise RuntimeError(
+                "ContextCompactor.compact requires a client when compaction is triggered; "
+                "pass client= explicitly"
+            )
+
         cold_tokens = sum(self._count_tokens(item) for item in cold)
         self.logger.info(
             "compaction_triggered",
@@ -84,14 +92,14 @@ class ContextCompactor:
 
         prompt = self._build_prompt(query, cold)
         try:
-            client = self.client or LLMClient()
+            client = self.client
             llm_digest = await client.complete(prompt, EvidenceDigest)
         except Exception as exc:
             self.logger.warning("compaction_skipped_llm_error", error=str(exc))
             return evidence, None
 
         digest = self._finalize_digest(llm_digest, cold, cold_tokens)
-        await self._store_artifact_best_effort(
+        self.last_digest_artifact_id = await self._store_artifact_best_effort(
             kind="compacted_digest",
             payload=digest,
         )
@@ -187,12 +195,12 @@ class ContextCompactor:
         *,
         kind: str,
         payload: Evidence | EvidenceDigest,
-    ) -> None:
+    ) -> int | None:
         if self.store is None or self.session_id is None:
-            return
+            return None
 
         try:
-            await self.store.store_artifact(
+            return await self.store.store_artifact(
                 session_id=self.session_id,
                 kind=kind,
                 payload=payload,
@@ -203,3 +211,4 @@ class ContextCompactor:
                 kind=kind,
                 error=str(exc),
             )
+            return None

--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -6,20 +6,28 @@ import structlog
 from pydantic import BaseModel, Field
 
 from autosearch.channels.base import Channel
+from autosearch.core.context_compaction import ContextCompactor
 from autosearch.core.evidence import EvidenceProcessor
-from autosearch.core.models import Evidence, Gap, SubQuery
+from autosearch.core.models import Evidence, EvidenceDigest, Gap, SubQuery
 from autosearch.llm.client import LLMClient
+from autosearch.persistence.session_store import SessionStore
 from autosearch.skills.prompts import load_prompt
 
 GAP_REFLECTION_PROMPT = load_prompt("m3_gap_reflection")
+SEARCH_REFLECTION_PROMPT = load_prompt("m3_search_reflection")
 FOLLOW_UP_QUERY_PROMPT = load_prompt("m3_follow_up_query")
 FALLBACK_THRESHOLD = 5
+SUBQUERY_BATCH_SIZE = 3
 
 
 @dataclass(frozen=True)
 class IterationBudget:
     max_iterations: int = 5
     per_channel_rate_limit: float = 0.5
+    subquery_batch_size: int = SUBQUERY_BATCH_SIZE
+    context_token_budget: int = 16000
+    compact_hot_set_size: int = 10
+    compact_trigger_pct: float = 0.8
 
 
 class _GapReflectionResponse(BaseModel):
@@ -31,11 +39,19 @@ class _FollowUpQueryResponse(BaseModel):
 
 
 class IterationController:
-    def __init__(self, evidence_processor: EvidenceProcessor | None = None) -> None:
+    def __init__(
+        self,
+        evidence_processor: EvidenceProcessor | None = None,
+        *,
+        store: SessionStore | None = None,
+        session_id: str | None = None,
+    ) -> None:
         self.evidence_processor = evidence_processor or EvidenceProcessor()
         self.routing_trace: dict[str, object] = {}
         self.logger = structlog.get_logger(__name__).bind(component="iteration_controller")
         self._empty_counts: dict[str, int] = {}
+        self._store = store
+        self._session_id = session_id
 
     async def run(
         self,
@@ -46,7 +62,7 @@ class IterationController:
         client: LLMClient,
         priority_channels: set[str] | None = None,
         skip_channels: set[str] | None = None,
-    ) -> list[Evidence]:
+    ) -> tuple[list[Evidence], list[dict[str, object]]]:
         self._empty_counts = {}
         effective_priority = set(priority_channels or [])
         effective_skip = set(skip_channels or [])
@@ -55,11 +71,23 @@ class IterationController:
             priority_channels=effective_priority,
             skip_channels=effective_skip,
         )
+        research_trace: list[dict[str, object]] = []
         if budget.max_iterations <= 0 or not initial_queries or not channels:
-            return []
+            return [], research_trace
 
         active_queries = _dedup_subqueries(initial_queries)
         accumulated_evidence: list[Evidence] = []
+        compactor = ContextCompactor(
+            token_budget=budget.context_token_budget,
+            hot_set_size=budget.compact_hot_set_size,
+            compact_when_over_pct=budget.compact_trigger_pct,
+            client=client,
+            store=self._store if self._store is not None and self._session_id is not None else None,
+            session_id=self._session_id
+            if self._store is not None and self._session_id is not None
+            else None,
+        )
+        batch_size = max(1, budget.subquery_batch_size)
 
         for iteration in range(1, budget.max_iterations + 1):
             if not active_queries:
@@ -72,25 +100,78 @@ class IterationController:
                 )
                 break
 
+            collected_batch_gaps: list[Gap] = []
+            subquery_batches = _partition_subqueries(active_queries, batch_size)
+            round_evidence_count = 0
             self.logger.info(
                 "iteration_phase_started",
                 phase="search",
                 iteration=iteration,
                 channels=len(channels),
                 subqueries=len(active_queries),
+                batches=len(subquery_batches),
             )
-            round_evidence = await self._search(
-                active_queries,
-                channels,
-                iteration,
-                priority_channels=effective_priority,
-                skip_channels=effective_skip,
-            )
+            # When an iteration collapses to one batch, the aggregate reflection already sees the
+            # same evidence, so skip the narrower reflection call to avoid duplicate LLM work.
+            run_batch_reflection = len(subquery_batches) > 1
+            for batch_index, batch_subqueries in enumerate(subquery_batches, start=1):
+                self.logger.info(
+                    "iteration_batch_started",
+                    iteration=iteration,
+                    batch_index=batch_index,
+                    subqueries=len(batch_subqueries),
+                    channels=len(channels),
+                )
+                batch_evidence = await self._search(
+                    batch_subqueries,
+                    channels,
+                    iteration,
+                    priority_channels=effective_priority,
+                    skip_channels=effective_skip,
+                )
+                round_evidence_count += len(batch_evidence)
+                accumulated_evidence = self._dedup_accumulated_evidence(
+                    accumulated_evidence + batch_evidence
+                )
+                batch_gaps: list[Gap] = []
+                if run_batch_reflection:
+                    batch_gaps = await self._per_search_reflect(
+                        batch_evidence=batch_evidence,
+                        query=query,
+                        client=client,
+                        batch_subqueries=batch_subqueries,
+                    )
+                    collected_batch_gaps.extend(batch_gaps)
+
+                digest_id: int | str | None = None
+                hot, digest = await compactor.compact(accumulated_evidence, query)
+                if digest is not None:
+                    accumulated_evidence = hot
+                    digest_id = await self._resolve_digest_trace_id(digest)
+
+                research_trace.append(
+                    {
+                        "iteration": iteration,
+                        "batch_index": batch_index,
+                        "subqueries": [subquery.text for subquery in batch_subqueries],
+                        "gaps": [gap.model_dump(mode="json") for gap in batch_gaps],
+                        "digest_id_if_any": digest_id,
+                    }
+                )
+                self.logger.info(
+                    "iteration_batch_completed",
+                    iteration=iteration,
+                    batch_index=batch_index,
+                    evidences=len(batch_evidence),
+                    accumulated=len(accumulated_evidence),
+                    gaps=len(batch_gaps),
+                    compacted=digest is not None,
+                )
             self.logger.info(
                 "iteration_phase_completed",
                 phase="search",
                 iteration=iteration,
-                evidences=len(round_evidence),
+                evidences=round_evidence_count,
             )
 
             self.logger.info(
@@ -99,7 +180,7 @@ class IterationController:
                 iteration=iteration,
                 accumulated_before=len(accumulated_evidence),
             )
-            accumulated_evidence = self._summarize(accumulated_evidence + round_evidence, query)
+            accumulated_evidence = self._summarize(accumulated_evidence, query)
             self.logger.info(
                 "iteration_phase_completed",
                 phase="summarize",
@@ -123,7 +204,9 @@ class IterationController:
                 gaps=len(gaps),
             )
 
-            if iteration >= budget.max_iterations or not gaps:
+            all_gaps = _dedup_gaps(gaps + collected_batch_gaps)
+
+            if iteration >= budget.max_iterations or not all_gaps:
                 self.logger.info(
                     "iteration_phase_completed",
                     phase="route",
@@ -140,7 +223,7 @@ class IterationController:
             self.logger.info("iteration_phase_started", phase="followup", iteration=iteration)
             active_queries = await self._follow_up(
                 query=query,
-                gaps=gaps,
+                gaps=all_gaps,
                 evidences=accumulated_evidence,
                 client=client,
             )
@@ -172,7 +255,7 @@ class IterationController:
             if budget.per_channel_rate_limit > 0:
                 await asyncio.sleep(budget.per_channel_rate_limit)
 
-        return accumulated_evidence
+        return accumulated_evidence, research_trace
 
     def empty_counts_by_channel(self) -> dict[str, int]:
         return dict(self._empty_counts)
@@ -306,9 +389,12 @@ class IterationController:
         )
 
     def _summarize(self, evidences: list[Evidence], query: str) -> list[Evidence]:
-        deduped = self.evidence_processor.dedup_urls(evidences)
-        deduped = self.evidence_processor.dedup_simhash(deduped)
+        deduped = self._dedup_accumulated_evidence(evidences)
         return self.evidence_processor.rerank_bm25(deduped, query, top_k=len(deduped))
+
+    def _dedup_accumulated_evidence(self, evidences: list[Evidence]) -> list[Evidence]:
+        deduped = self.evidence_processor.dedup_urls(evidences)
+        return self.evidence_processor.dedup_simhash(deduped)
 
     async def _reflect(
         self,
@@ -329,6 +415,22 @@ class IterationController:
         response = await client.complete(prompt, _GapReflectionResponse)
         return _dedup_gaps(response.gaps)
 
+    async def _per_search_reflect(
+        self,
+        *,
+        batch_evidence: list[Evidence],
+        query: str,
+        client: LLMClient,
+        batch_subqueries: list[SubQuery] | None = None,
+    ) -> list[Gap]:
+        prompt = SEARCH_REFLECTION_PROMPT.format(
+            query=query,
+            batch_subqueries=_format_subqueries(batch_subqueries or []),
+            batch_evidence_context=_format_evidence(batch_evidence, max_items=6),
+        )
+        response = await client.complete(prompt, _GapReflectionResponse)
+        return _dedup_gaps(response.gaps)
+
     async def _follow_up(
         self,
         query: str,
@@ -344,6 +446,28 @@ class IterationController:
         response = await client.complete(prompt, _FollowUpQueryResponse)
         return _dedup_subqueries(response.subqueries)
 
+    async def _resolve_digest_trace_id(
+        self,
+        digest: EvidenceDigest,
+    ) -> int | str:
+        fallback_id = digest.compressed_at.isoformat()
+        if self._store is None or self._session_id is None:
+            return fallback_id
+
+        try:
+            artifacts = await self._store.load_artifacts(
+                session_id=self._session_id,
+                kind="compacted_digest",
+            )
+        except Exception:
+            return fallback_id
+
+        latest_artifact = artifacts[-1] if artifacts else None
+        artifact_id = latest_artifact.get("id") if isinstance(latest_artifact, dict) else None
+        if isinstance(artifact_id, int):
+            return artifact_id
+        return fallback_id
+
 
 def _dedup_subqueries(subqueries: list[SubQuery]) -> list[SubQuery]:
     seen: set[str] = set()
@@ -355,6 +479,16 @@ def _dedup_subqueries(subqueries: list[SubQuery]) -> list[SubQuery]:
         seen.add(normalized)
         deduped.append(subquery)
     return deduped
+
+
+def _partition_subqueries(subqueries: list[SubQuery], batch_size: int) -> list[list[SubQuery]]:
+    if not subqueries:
+        return []
+    normalized_batch_size = max(1, batch_size)
+    return [
+        subqueries[index : index + normalized_batch_size]
+        for index in range(0, len(subqueries), normalized_batch_size)
+    ]
 
 
 def _dedup_gaps(gaps: list[Gap]) -> list[Gap]:

--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from autosearch.channels.base import Channel
 from autosearch.core.context_compaction import ContextCompactor
 from autosearch.core.evidence import EvidenceProcessor
-from autosearch.core.models import Evidence, EvidenceDigest, Gap, SubQuery
+from autosearch.core.models import Evidence, Gap, SubQuery
 from autosearch.llm.client import LLMClient
 from autosearch.persistence.session_store import SessionStore
 from autosearch.skills.prompts import load_prompt
@@ -147,7 +147,11 @@ class IterationController:
                 hot, digest = await compactor.compact(accumulated_evidence, query)
                 if digest is not None:
                     accumulated_evidence = hot
-                    digest_id = await self._resolve_digest_trace_id(digest)
+                    digest_id = (
+                        compactor.last_digest_artifact_id
+                        if compactor.last_digest_artifact_id is not None
+                        else digest.compressed_at.isoformat()
+                    )
 
                 research_trace.append(
                     {
@@ -445,28 +449,6 @@ class IterationController:
         )
         response = await client.complete(prompt, _FollowUpQueryResponse)
         return _dedup_subqueries(response.subqueries)
-
-    async def _resolve_digest_trace_id(
-        self,
-        digest: EvidenceDigest,
-    ) -> int | str:
-        fallback_id = digest.compressed_at.isoformat()
-        if self._store is None or self._session_id is None:
-            return fallback_id
-
-        try:
-            artifacts = await self._store.load_artifacts(
-                session_id=self._session_id,
-                kind="compacted_digest",
-            )
-        except Exception:
-            return fallback_id
-
-        latest_artifact = artifacts[-1] if artifacts else None
-        artifact_id = latest_artifact.get("id") if isinstance(latest_artifact, dict) else None
-        if isinstance(artifact_id, int):
-            return artifact_id
-        return fallback_id
 
 
 def _dedup_subqueries(subqueries: list[SubQuery]) -> list[SubQuery]:

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -71,6 +71,18 @@ class Evidence(BaseModel):
     source_page: FetchedPage | None = None
 
 
+class EvidenceDigest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    topic: str = ""
+    key_findings: list[str] = Field(default_factory=list)
+    source_urls: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
+    compressed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    token_count_before: int = 0
+    token_count_after: int = 0
+
+
 class Gap(BaseModel):
     model_config = ConfigDict(frozen=True)
 

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -152,6 +152,7 @@ class PipelineResult:
     evidences: list[Evidence] = field(default_factory=list)
     channel_empty_calls: dict[str, int] = field(default_factory=dict)
     reasoning_events: list[dict[str, object]] = field(default_factory=list)
+    research_trace: list[dict[str, object]] = field(default_factory=list)
     routing_trace: dict[str, object] = field(default_factory=dict)
     quality: EvaluationResult | None = None
     iterations: int = 0

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -86,6 +86,7 @@ class Pipeline:
         final_status = "error"
         final_markdown: str | None = None
         current_phase = "M0"
+        research_trace: list[dict[str, object]] = []
 
         try:
             active_channels = self.channels
@@ -158,6 +159,7 @@ class Pipeline:
                     clarification=clarification,
                     iterations=0,
                     reasoning_events=list(self._captured_reasoning_events or []),
+                    research_trace=research_trace,
                     routing_trace=routing_trace,
                     session_id=session_id,
                     cost=self._current_cost(),
@@ -211,7 +213,7 @@ class Pipeline:
                 channels=len(active_channels),
                 max_iterations=self.budget.max_iterations,
             )
-            evidences = await iteration_controller.run(
+            evidences, research_trace = await iteration_controller.run(
                 query=query,
                 initial_queries=initial_queries,
                 channels=active_channels,
@@ -307,7 +309,7 @@ class Pipeline:
                         "pipeline_quality_retry_started",
                         retry_subqueries=len(retry_queries),
                     )
-                    retry_evidences = await iteration_controller.run(
+                    retry_evidences, retry_research_trace = await iteration_controller.run(
                         query=query,
                         initial_queries=retry_queries,
                         channels=active_channels,
@@ -317,6 +319,7 @@ class Pipeline:
                         skip_channels=set(clarification.channel_skip),
                     )
                     await self._emit_phase_event(current_phase, "complete")
+                    research_trace.extend(retry_research_trace)
                     processed_evidences = self._finalize_evidences(
                         processed_evidences + retry_evidences,
                         query,
@@ -354,6 +357,7 @@ class Pipeline:
                 evidences=processed_evidences,
                 channel_empty_calls=iteration_controller.empty_counts_by_channel(),
                 reasoning_events=list(self._captured_reasoning_events or []),
+                research_trace=research_trace,
                 routing_trace=routing_trace,
                 quality=quality,
                 iterations=iteration_controller.iterations_executed,
@@ -502,12 +506,17 @@ class _TrackingIterationController(IterationController):
         session_id: str | None = None,
         on_event: Callable[[PipelineEvent], Awaitable[None]] | None = None,
     ) -> None:
-        super().__init__(evidence_processor=evidence_processor)
+        super().__init__(
+            evidence_processor=evidence_processor,
+            store=session_store,
+            session_id=session_id,
+        )
         self.iterations_executed = 0
         self.session_store = session_store
         self.session_id = session_id
         self.on_event = on_event
         self._latest_new_evidence_count = 0
+        self._latest_iteration_for_search: int | None = None
 
     async def _search(
         self,
@@ -524,7 +533,10 @@ class _TrackingIterationController(IterationController):
             priority_channels=priority_channels,
             skip_channels=skip_channels,
         )
-        self._latest_new_evidence_count = len(evidences)
+        if self._latest_iteration_for_search != iteration:
+            self._latest_iteration_for_search = iteration
+            self._latest_new_evidence_count = 0
+        self._latest_new_evidence_count += len(evidences)
         return evidences
 
     async def _handle_search_result(
@@ -597,6 +609,8 @@ class _TrackingIterationController(IterationController):
                         "reason": gap.reason,
                     }
                 )
+        self._latest_iteration_for_search = None
+        self._latest_new_evidence_count = 0
         return gaps
 
 

--- a/autosearch/persistence/session_store.py
+++ b/autosearch/persistence/session_store.py
@@ -5,7 +5,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Self
 
-from autosearch.core.models import Evidence
+from pydantic import BaseModel
+
+from autosearch.core.models import Evidence, EvidenceDigest
 
 try:
     import aiosqlite
@@ -14,6 +16,10 @@ except ImportError:  # pragma: no cover - compatibility path for blocked install
     class _FallbackCursor:
         def __init__(self, cursor: sqlite3.Cursor) -> None:
             self._cursor = cursor
+
+        @property
+        def lastrowid(self) -> int | None:
+            return self._cursor.lastrowid
 
         async def fetchone(self) -> sqlite3.Row | None:
             return self._cursor.fetchone()
@@ -172,6 +178,75 @@ class SessionStore:
             )
             await self._connection_or_raise().commit()
 
+    async def store_artifact(
+        self,
+        *,
+        session_id: str,
+        kind: str,
+        payload: BaseModel,
+    ) -> int:
+        async with self._write_lock:
+            cursor = await self._connection_or_raise().execute(
+                """
+                INSERT INTO evidence_artifacts (session_id, kind, payload_json)
+                VALUES (?, ?, ?)
+                """,
+                (session_id, kind, payload.model_dump_json()),
+            )
+            try:
+                row_id = cursor.lastrowid
+            finally:
+                await cursor.close()
+
+            await self._connection_or_raise().commit()
+            if row_id is None:
+                raise RuntimeError("Failed to determine inserted artifact row id.")
+            return int(row_id)
+
+    async def load_artifacts(
+        self,
+        *,
+        session_id: str,
+        kind: str | None = None,
+    ) -> list[dict[str, Any]]:
+        connection = self._connection_or_raise()
+        if kind is None:
+            rows = await self._fetch_all(
+                connection,
+                """
+                SELECT id, kind, payload_json, created_at
+                FROM evidence_artifacts
+                WHERE session_id = ?
+                ORDER BY id ASC
+                """,
+                (session_id,),
+            )
+        else:
+            rows = await self._fetch_all(
+                connection,
+                """
+                SELECT id, kind, payload_json, created_at
+                FROM evidence_artifacts
+                WHERE session_id = ? AND kind = ?
+                ORDER BY id ASC
+                """,
+                (session_id, kind),
+            )
+        return [dict(row) for row in rows]
+
+    async def load_digests(
+        self,
+        *,
+        session_id: str,
+    ) -> list[EvidenceDigest]:
+        artifacts = await self.load_artifacts(
+            session_id=session_id,
+            kind="compacted_digest",
+        )
+        return [
+            EvidenceDigest.model_validate_json(artifact["payload_json"]) for artifact in artifacts
+        ]
+
     async def fetch_session(self, session_id: str) -> dict[str, Any] | None:
         connection = self._connection_or_raise()
         session = await self._fetch_one(
@@ -262,6 +337,21 @@ class SessionStore:
                     results INTEGER NOT NULL,
                     FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
                 );
+
+                CREATE TABLE IF NOT EXISTS evidence_artifacts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_evidence_artifacts_session
+                ON evidence_artifacts(session_id);
+
+                CREATE INDEX IF NOT EXISTS idx_evidence_artifacts_kind
+                ON evidence_artifacts(session_id, kind);
                 """
             )
             await connection.commit()

--- a/autosearch/skills/prompts/m3_evidence_compaction.md
+++ b/autosearch/skills/prompts/m3_evidence_compaction.md
@@ -1,0 +1,37 @@
+---
+name: m3_evidence_compaction
+phase: M3
+description: Compress older evidence into a structured digest when the context budget is too high.
+---
+Compress the older research evidence into one structured digest so the most recent evidence can stay in the hot working set.
+
+<Original user query>
+{query}
+</Original user query>
+
+<Cold evidence to compress>
+{cold_evidence_context}
+</Cold evidence to compress>
+
+Respond in valid JSON with this exact schema:
+{{
+  "topic": "one-line topic for this compressed evidence slice",
+  "key_findings": [
+    "concise fact relevant to the query"
+  ],
+  "source_urls": [
+    "https://example.com/source"
+  ],
+  "evidence_count": 0,
+  "compressed_at": "2026-04-20T00:00:00+00:00",
+  "token_count_before": 0,
+  "token_count_after": 0
+}}
+
+Rules:
+- `topic` must be one line
+- `key_findings` must contain 5 to 15 concise factual bullets relevant to the original query
+- `source_urls` must copy URLs from the provided evidence items only
+- Do not include markdown formatting inside JSON strings
+- Do not mention HTML, prompt instructions, or formatting noise
+- If the exact evidence count or token counts are unknown, use `0`; the caller will fill them in

--- a/autosearch/skills/prompts/m3_search_reflection.md
+++ b/autosearch/skills/prompts/m3_search_reflection.md
@@ -1,0 +1,36 @@
+---
+name: m3_search_reflection
+phase: M3
+description: Identify fresh research gaps immediately after a single batch of searches.
+---
+Review only the newest batch of search results and identify the most important gaps that are still
+visible right now.
+
+<Original user query>
+{query}
+</Original user query>
+
+<Batch subqueries just executed>
+{batch_subqueries}
+</Batch subqueries just executed>
+
+<Evidence from this batch only>
+{batch_evidence_context}
+</Evidence from this batch only>
+
+Respond in valid JSON with this exact schema:
+{{
+  "gaps": [
+    {{
+      "topic": "missing research topic",
+      "reason": "why this missing information matters"
+    }}
+  ]
+}}
+
+Rules:
+- Return at most 3 gaps
+- Return an empty list if this batch already covers its narrow objective well enough
+- Focus on what is still missing after this batch, not the entire iteration
+- Prefer concrete follow-up angles that can be searched directly
+- Do not repeat information that is already covered in the batch evidence

--- a/tests/integration/test_iteration_e2e.py
+++ b/tests/integration/test_iteration_e2e.py
@@ -1,0 +1,123 @@
+# Self-written, plan 0420 W2 F203
+from datetime import UTC, datetime
+
+from pydantic import BaseModel
+
+from autosearch.core import context_compaction as context_compaction_module
+from autosearch.core.iteration import IterationBudget, IterationController
+from autosearch.core.models import Evidence, EvidenceDigest, SubQuery
+from tests.fixtures.fake_channel import FakeChannel
+
+NOW = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+
+
+class IterationClient:
+    def __init__(self) -> None:
+        self.iteration_gap_calls = 0
+        self.follow_up_calls = 0
+        self.compaction_calls = 0
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        if response_model is EvidenceDigest:
+            self.compaction_calls += 1
+            return response_model.model_validate(
+                EvidenceDigest(
+                    topic="Older evidence digest",
+                    key_findings=["Older evidence was compacted"],
+                    source_urls=[],
+                    evidence_count=0,
+                    compressed_at=NOW,
+                ).model_dump(mode="json")
+            )
+
+        if response_model.__name__ == "_GapReflectionResponse":
+            if "<Current iteration>" in prompt:
+                self.iteration_gap_calls += 1
+                return response_model.model_validate(
+                    {
+                        "gaps": [
+                            {
+                                "topic": f"follow-up topic {self.iteration_gap_calls}",
+                                "reason": "keep the research loop moving",
+                            }
+                        ]
+                    }
+                )
+            return response_model.model_validate({"gaps": []})
+
+        if response_model.__name__ == "_FollowUpQueryResponse":
+            self.follow_up_calls += 1
+            return response_model.model_validate(
+                {
+                    "subqueries": [
+                        {
+                            "text": f"follow up query {self.follow_up_calls}",
+                            "rationale": "continue the deep search",
+                        }
+                    ]
+                }
+            )
+
+        raise AssertionError(f"Unexpected response model: {response_model.__name__}")
+
+
+def fake_estimate_tokens(text: str) -> int:
+    marker = "[TOKENS="
+    if marker not in text:
+        return max(len(text.split()), 1) if text else 0
+    start = text.index(marker) + len(marker)
+    end = text.index("]", start)
+    return int(text[start:end])
+
+
+def make_evidence(query: SubQuery, call_index: int) -> list[Evidence]:
+    return [
+        Evidence(
+            url=f"https://example.com/{call_index}",
+            title=f"Evidence {call_index}",
+            snippet=f"Snippet for {query.text}",
+            content=f"[TOKENS=3000] Evidence body for {query.text}",
+            source_channel="web",
+            fetched_at=NOW,
+        )
+    ]
+
+
+async def test_iteration_runs_full_cycle_with_compaction(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    controller = IterationController()
+    client = IterationClient()
+    call_index = 0
+
+    def factory(query: SubQuery) -> list[Evidence]:
+        nonlocal call_index
+        call_index += 1
+        return make_evidence(query, call_index)
+
+    channel = FakeChannel(name="web", factory=factory)
+    budget = IterationBudget(
+        max_iterations=5,
+        per_channel_rate_limit=0.0,
+        subquery_batch_size=2,
+        context_token_budget=16000,
+        compact_hot_set_size=3,
+        compact_trigger_pct=0.8,
+    )
+
+    evidences, research_trace = await controller.run(
+        query="deep iteration compaction flow",
+        initial_queries=[
+            SubQuery(text="initial topic 1", rationale="seed"),
+            SubQuery(text="initial topic 2", rationale="seed"),
+            SubQuery(text="initial topic 3", rationale="seed"),
+            SubQuery(text="initial topic 4", rationale="seed"),
+        ],
+        channels=[channel],
+        budget=budget,
+        client=client,
+    )
+
+    assert client.iteration_gap_calls == 5
+    assert client.compaction_calls >= 1
+    assert len(evidences) <= budget.compact_hot_set_size + 2
+    assert any(entry["digest_id_if_any"] is not None for entry in research_trace)

--- a/tests/unit/core/test_context_compaction.py
+++ b/tests/unit/core/test_context_compaction.py
@@ -1,0 +1,247 @@
+# Self-written, plan v2.3 § 13.5
+import re
+from datetime import UTC, datetime
+
+from autosearch.core import context_compaction as context_compaction_module
+from autosearch.core.context_compaction import ContextCompactor
+from autosearch.core.models import Evidence, EvidenceDigest, FetchedPage
+
+NOW = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+
+
+class FakeLLMClient:
+    def __init__(self, result: EvidenceDigest | Exception) -> None:
+        self.result = result
+        self.calls = 0
+        self.prompts: list[str] = []
+
+    async def complete(self, prompt: str, response_model: type[EvidenceDigest]) -> EvidenceDigest:
+        self.calls += 1
+        self.prompts.append(prompt)
+        _ = response_model
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class RecordingLogger:
+    def __init__(self) -> None:
+        self.warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    def debug(self, event: str, **kwargs: object) -> None:
+        _ = (event, kwargs)
+
+    def info(self, event: str, **kwargs: object) -> None:
+        _ = (event, kwargs)
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warning_calls.append((event, kwargs))
+
+
+def make_digest() -> EvidenceDigest:
+    return EvidenceDigest(
+        topic="Cold evidence digest",
+        key_findings=[
+            "Finding one",
+            "Finding two",
+            "Finding three",
+            "Finding four",
+            "Finding five",
+        ],
+        source_urls=["https://placeholder.example/digest"],
+        evidence_count=1,
+        compressed_at=NOW,
+        token_count_before=1,
+        token_count_after=1,
+    )
+
+
+def make_evidence(
+    index: int,
+    *,
+    tokens: int,
+    with_source_page: bool = False,
+    content: str | None = None,
+) -> Evidence:
+    page = None
+    if with_source_page:
+        page = FetchedPage(
+            url=f"https://example.com/{index}",
+            status_code=200,
+            fetched_at=NOW,
+            html="<html>" + ("H" * 5000) + "</html>",
+            cleaned_html="<article>" + ("C" * 5000) + "</article>",
+            markdown="# Page\n\n" + ("M" * 5000),
+        )
+    return Evidence(
+        url=f"https://example.com/{index}",
+        title=f"Evidence {index}",
+        snippet=f"Snippet {index}",
+        content=content or f"[TOKENS={tokens}] Content {index}",
+        source_channel="test",
+        fetched_at=NOW,
+        source_page=page,
+    )
+
+
+def fake_estimate_tokens(text: str) -> int:
+    marker = re.search(r"\[TOKENS=(\d+)\]", text)
+    if marker is not None:
+        return int(marker.group(1))
+    return max(len(text.split()), 1) if text else 0
+
+
+async def test_no_compaction_when_under_budget(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [
+        make_evidence(1, tokens=150),
+        make_evidence(2, tokens=175),
+        make_evidence(3, tokens=175),
+    ]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=16000, client=client)
+
+    hot, digest = await compactor.compact(evidence, "budget test")
+
+    assert hot == evidence
+    assert digest is None
+    assert client.calls == 0
+
+
+async def test_compaction_triggered_when_over_threshold(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1000) for index in range(1, 21)]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=16000, client=client)
+
+    hot, digest = await compactor.compact(evidence, "over threshold")
+
+    assert hot == evidence[10:]
+    assert digest is not None
+    assert digest.evidence_count == 10
+    assert client.calls == 1
+
+
+async def test_hot_set_preserves_chronological_order(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=900) for index in range(1, 16)]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=10000, hot_set_size=4, client=client)
+
+    hot, _ = await compactor.compact(evidence, "order test")
+
+    assert [item.url for item in hot] == [item.url for item in evidence[-4:]]
+
+
+async def test_skip_compaction_when_evidence_count_less_than_hot_set(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=3000) for index in range(1, 6)]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=10000, hot_set_size=10, client=client)
+
+    hot, digest = await compactor.compact(evidence, "small evidence list")
+
+    assert hot == evidence
+    assert digest is None
+    assert client.calls == 0
+
+
+def test_does_not_include_source_page_in_token_count(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    compactor = ContextCompactor()
+    plain = make_evidence(1, tokens=250)
+    with_page = make_evidence(1, tokens=250, with_source_page=True)
+
+    assert compactor._count_tokens(plain) == compactor._count_tokens(with_page)
+
+
+async def test_does_not_include_source_page_in_summarize_prompt(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    visible_content = "Important visible content"
+    evidence = [
+        make_evidence(1, tokens=800, with_source_page=True, content=visible_content),
+        make_evidence(2, tokens=800),
+        make_evidence(3, tokens=800),
+    ]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=1000, hot_set_size=1, client=client)
+
+    _, digest = await compactor.compact(evidence, "prompt test")
+
+    assert digest is not None
+    assert client.calls == 1
+    assert visible_content in client.prompts[0]
+    assert evidence[0].source_page is not None
+    assert evidence[0].source_page.html not in client.prompts[0]
+
+
+async def test_llm_error_fallback_returns_original(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1500) for index in range(1, 12)]
+    client = FakeLLMClient(RuntimeError("llm unavailable"))
+    compactor = ContextCompactor(token_budget=10000, client=client)
+    logger = RecordingLogger()
+    monkeypatch.setattr(compactor, "logger", logger)
+
+    hot, digest = await compactor.compact(evidence, "llm error")
+
+    assert hot == evidence
+    assert digest is None
+    assert logger.warning_calls == [
+        (
+            "compaction_skipped_llm_error",
+            {"error": "llm unavailable"},
+        )
+    ]
+
+
+async def test_digest_captures_source_urls(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1000) for index in range(1, 13)]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=10000, hot_set_size=2, client=client)
+
+    _, digest = await compactor.compact(evidence, "urls test")
+
+    assert digest is not None
+    assert digest.source_urls == [item.url for item in evidence[:-2]]
+
+
+async def test_token_count_before_after_recorded(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1000) for index in range(1, 13)]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=10000, hot_set_size=2, client=client)
+
+    _, digest = await compactor.compact(evidence, "token accounting")
+
+    assert digest is not None
+    expected_before = sum(compactor._count_tokens(item) for item in evidence[:-2])
+    expected_after = fake_estimate_tokens(compactor._render_digest_for_count(digest))
+    assert digest.token_count_before == expected_before
+    assert digest.token_count_after == expected_after
+
+
+async def test_empty_evidence_list_no_op(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(client=client)
+
+    hot, digest = await compactor.compact([], "empty")
+
+    assert hot == []
+    assert digest is None
+    assert client.calls == 0
+
+
+async def test_hot_set_size_zero_compacts_everything(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1200) for index in range(1, 6)]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=1000, hot_set_size=0, client=client)
+
+    hot, digest = await compactor.compact(evidence, "compact everything")
+
+    assert hot == []
+    assert digest is not None
+    assert digest.evidence_count == len(evidence)

--- a/tests/unit/core/test_context_compaction.py
+++ b/tests/unit/core/test_context_compaction.py
@@ -2,6 +2,8 @@
 import re
 from datetime import UTC, datetime
 
+import pytest
+
 from autosearch.core import context_compaction as context_compaction_module
 from autosearch.core.context_compaction import ContextCompactor
 from autosearch.core.models import Evidence, EvidenceDigest, FetchedPage
@@ -210,6 +212,21 @@ async def test_llm_error_fallback_returns_original(monkeypatch) -> None:
             {"error": "llm unavailable"},
         )
     ]
+
+
+async def test_compaction_requires_explicit_client_when_triggered(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1500) for index in range(1, 12)]
+    compactor = ContextCompactor(token_budget=10000)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "ContextCompactor\\.compact requires a client when compaction is triggered; "
+            "pass client= explicitly"
+        ),
+    ):
+        await compactor.compact(evidence, "missing client")
 
 
 async def test_digest_captures_source_urls(monkeypatch) -> None:

--- a/tests/unit/core/test_context_compaction.py
+++ b/tests/unit/core/test_context_compaction.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from autosearch.core import context_compaction as context_compaction_module
 from autosearch.core.context_compaction import ContextCompactor
 from autosearch.core.models import Evidence, EvidenceDigest, FetchedPage
+from autosearch.persistence.session_store import SessionStore
 
 NOW = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
 
@@ -36,6 +37,22 @@ class RecordingLogger:
 
     def warning(self, event: str, **kwargs: object) -> None:
         self.warning_calls.append((event, kwargs))
+
+
+class ExplodingStore:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def store_artifact(
+        self,
+        *,
+        session_id: str,
+        kind: str,
+        payload: object,
+    ) -> int:
+        _ = payload
+        self.calls.append((session_id, kind))
+        raise RuntimeError("artifact write failed")
 
 
 def make_digest() -> EvidenceDigest:
@@ -245,3 +262,108 @@ async def test_hot_set_size_zero_compacts_everything(monkeypatch) -> None:
     assert hot == []
     assert digest is not None
     assert digest.evidence_count == len(evidence)
+
+
+async def test_compaction_persists_digest_when_store_and_session_id_set(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1000) for index in range(1, 13)]
+    client = FakeLLMClient(make_digest())
+    store = await SessionStore.open(tmp_path / "context-compaction.sqlite")
+
+    try:
+        await store.create_session("session-1", "persist digest", "deep")
+        compactor = ContextCompactor(
+            token_budget=10000,
+            hot_set_size=2,
+            client=client,
+            store=store,
+            session_id="session-1",
+        )
+
+        _, digest = await compactor.compact(evidence, "persist digest")
+        persisted = await store.load_digests(session_id="session-1")
+    finally:
+        await store.close()
+
+    assert digest is not None
+    assert persisted == [digest]
+
+
+async def test_compaction_persists_evicted_evidence(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1000) for index in range(1, 13)]
+    client = FakeLLMClient(make_digest())
+    store = await SessionStore.open(tmp_path / "evicted-evidence.sqlite")
+
+    try:
+        await store.create_session("session-1", "persist evicted evidence", "deep")
+        compactor = ContextCompactor(
+            token_budget=10000,
+            hot_set_size=2,
+            client=client,
+            store=store,
+            session_id="session-1",
+        )
+
+        await compactor.compact(evidence, "persist evicted evidence")
+        artifacts = await store.load_artifacts(
+            session_id="session-1",
+            kind="evicted_evidence",
+        )
+    finally:
+        await store.close()
+
+    assert len(artifacts) == len(evidence[:-2])
+    restored = [Evidence.model_validate_json(artifact["payload_json"]) for artifact in artifacts]
+    assert restored == evidence[:-2]
+
+
+async def test_compaction_without_store_no_persistence(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1000) for index in range(1, 13)]
+    client = FakeLLMClient(make_digest())
+    compactor = ContextCompactor(token_budget=10000, hot_set_size=2, client=client)
+
+    hot, digest = await compactor.compact(evidence, "no store")
+
+    assert hot == evidence[-2:]
+    assert digest is not None
+    assert client.calls == 1
+
+
+async def test_compaction_store_error_is_best_effort(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    evidence = [make_evidence(index, tokens=1000) for index in range(1, 13)]
+    client = FakeLLMClient(make_digest())
+    store = ExplodingStore()
+    compactor = ContextCompactor(
+        token_budget=10000,
+        hot_set_size=2,
+        client=client,
+        store=store,
+        session_id="session-1",
+    )
+    logger = RecordingLogger()
+    monkeypatch.setattr(compactor, "logger", logger)
+
+    hot, digest = await compactor.compact(evidence, "store error")
+
+    assert hot == evidence[-2:]
+    assert digest is not None
+    assert store.calls == [("session-1", "evicted_evidence")] * 10 + [
+        ("session-1", "compacted_digest")
+    ]
+    assert logger.warning_calls == [
+        (
+            "compaction_artifact_store_failed",
+            {"kind": "evicted_evidence", "error": "artifact write failed"},
+        )
+    ] * 10 + [
+        (
+            "compaction_artifact_store_failed",
+            {"kind": "compacted_digest", "error": "artifact write failed"},
+        )
+    ]

--- a/tests/unit/persistence/test_session_store_artifacts.py
+++ b/tests/unit/persistence/test_session_store_artifacts.py
@@ -1,8 +1,6 @@
 # Self-written, plan v2.3 § 13.5
 from datetime import UTC, datetime
 
-import pytest
-
 from autosearch.core.models import Evidence, EvidenceDigest
 from autosearch.persistence.session_store import SessionStore
 
@@ -125,9 +123,8 @@ async def test_store_artifact_foreign_key_cascade() -> None:
         finally:
             await cursor.close()
 
-        if row is None or row[0] != 1:
-            pytest.skip("TODO: enable SQLite foreign keys for artifact cascade coverage.")
-
+        assert row is not None
+        assert row[0] == 1
         await connection.execute("DELETE FROM sessions WHERE id = ?", ("session-1",))
         await connection.commit()
         artifacts = await store.load_artifacts(session_id="session-1")

--- a/tests/unit/persistence/test_session_store_artifacts.py
+++ b/tests/unit/persistence/test_session_store_artifacts.py
@@ -1,0 +1,180 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import UTC, datetime
+
+import pytest
+
+from autosearch.core.models import Evidence, EvidenceDigest
+from autosearch.persistence.session_store import SessionStore
+
+NOW = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+
+
+def make_digest(index: int = 1) -> EvidenceDigest:
+    return EvidenceDigest(
+        topic=f"Digest {index}",
+        key_findings=[
+            f"Finding {index}.1",
+            f"Finding {index}.2",
+        ],
+        source_urls=[f"https://example.com/digest/{index}"],
+        evidence_count=index,
+        compressed_at=NOW,
+        token_count_before=100 * index,
+        token_count_after=10 * index,
+    )
+
+
+def make_evidence(index: int) -> Evidence:
+    return Evidence(
+        url=f"https://example.com/evidence/{index}",
+        title=f"Evidence {index}",
+        snippet=f"Snippet {index}",
+        content=f"Content {index}",
+        source_channel="web",
+        fetched_at=NOW,
+        score=0.5 + (index * 0.1),
+    )
+
+
+async def test_store_and_load_digest_artifact() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        digest = make_digest()
+
+        row_id = await store.store_artifact(
+            session_id="session-1",
+            kind="compacted_digest",
+            payload=digest,
+        )
+        loaded = await store.load_digests(session_id="session-1")
+    finally:
+        await store.close()
+
+    assert row_id > 0
+    assert loaded == [digest]
+
+
+async def test_store_multiple_kinds_and_filter() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        for index in range(1, 3):
+            await store.store_artifact(
+                session_id="session-1",
+                kind="compacted_digest",
+                payload=make_digest(index),
+            )
+        for index in range(1, 4):
+            await store.store_artifact(
+                session_id="session-1",
+                kind="evicted_evidence",
+                payload=make_evidence(index),
+            )
+
+        all_artifacts = await store.load_artifacts(session_id="session-1")
+        digest_artifacts = await store.load_artifacts(
+            session_id="session-1",
+            kind="compacted_digest",
+        )
+    finally:
+        await store.close()
+
+    assert len(all_artifacts) == 5
+    assert [artifact["kind"] for artifact in all_artifacts] == [
+        "compacted_digest",
+        "compacted_digest",
+        "evicted_evidence",
+        "evicted_evidence",
+        "evicted_evidence",
+    ]
+    assert len(digest_artifacts) == 2
+    assert all(artifact["kind"] == "compacted_digest" for artifact in digest_artifacts)
+
+
+async def test_load_artifacts_empty_session() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+
+        artifacts = await store.load_artifacts(session_id="session-1")
+    finally:
+        await store.close()
+
+    assert artifacts == []
+
+
+async def test_store_artifact_foreign_key_cascade() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        await store.store_artifact(
+            session_id="session-1",
+            kind="compacted_digest",
+            payload=make_digest(),
+        )
+
+        connection = store._connection_or_raise()
+        cursor = await connection.execute("PRAGMA foreign_keys")
+        try:
+            row = await cursor.fetchone()
+        finally:
+            await cursor.close()
+
+        if row is None or row[0] != 1:
+            pytest.skip("TODO: enable SQLite foreign keys for artifact cascade coverage.")
+
+        await connection.execute("DELETE FROM sessions WHERE id = ?", ("session-1",))
+        await connection.commit()
+        artifacts = await store.load_artifacts(session_id="session-1")
+    finally:
+        await store.close()
+
+    assert artifacts == []
+
+
+async def test_created_at_auto_populated() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        await store.store_artifact(
+            session_id="session-1",
+            kind="compacted_digest",
+            payload=make_digest(),
+        )
+
+        artifacts = await store.load_artifacts(session_id="session-1")
+    finally:
+        await store.close()
+
+    assert len(artifacts) == 1
+    assert artifacts[0]["created_at"]
+
+
+async def test_artifact_payload_roundtrip_for_evidence_digest() -> None:
+    store = await SessionStore.open(":memory:")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        digest = make_digest()
+        await store.store_artifact(
+            session_id="session-1",
+            kind="compacted_digest",
+            payload=digest,
+        )
+
+        artifacts = await store.load_artifacts(
+            session_id="session-1",
+            kind="compacted_digest",
+        )
+    finally:
+        await store.close()
+
+    assert len(artifacts) == 1
+    restored = EvidenceDigest.model_validate_json(artifacts[0]["payload_json"])
+    assert restored == digest

--- a/tests/unit/test_iteration.py
+++ b/tests/unit/test_iteration.py
@@ -39,6 +39,28 @@ class FakeChannel:
         return self.responses.pop(0)
 
 
+class ArtifactStoreWithoutLookup:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def store_artifact(
+        self,
+        *,
+        session_id: str,
+        kind: str,
+        payload: BaseModel,
+    ) -> int:
+        _ = payload
+        self.calls.append((session_id, kind))
+        return len(self.calls)
+
+    async def load_artifacts(self, *, session_id: str, kind: str | None = None) -> list[dict]:
+        _ = (session_id, kind)
+        raise AssertionError(
+            "IterationController should not reload artifacts to resolve digest ids."
+        )
+
+
 def make_evidence(url: str, title: str, content: str) -> Evidence:
     return Evidence(
         url=url,
@@ -463,6 +485,55 @@ async def test_store_and_session_id_propagated_to_compactor(monkeypatch) -> None
 
     assert len(digests) == 1
     assert isinstance(research_trace[-1]["digest_id_if_any"], int)
+
+
+async def test_digest_trace_id_uses_insert_rowid_without_reload(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    store = ArtifactStoreWithoutLookup()
+    controller = IterationController(store=store, session_id="session-1")
+    channel = FakeChannel(
+        [
+            [
+                make_evidence(
+                    f"https://example.com/{index}",
+                    f"Result {index}",
+                    f"[TOKENS=3000] content {index}",
+                )
+            ]
+            for index in range(1, 5)
+        ]
+    )
+    client = DummyClient([make_digest_payload()])
+
+    async def no_batch_gaps(**_: object) -> list[Gap]:
+        return []
+
+    async def no_iteration_gaps(**_: object) -> list[Gap]:
+        return []
+
+    monkeypatch.setattr(controller, "_per_search_reflect", no_batch_gaps)
+    monkeypatch.setattr(controller, "_reflect", no_iteration_gaps)
+
+    _, research_trace = await controller.run(
+        query="compact using insert rowid",
+        initial_queries=make_subqueries(4),
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=2,
+            context_token_budget=10000,
+            compact_hot_set_size=2,
+        ),
+        client=client,
+    )
+
+    assert store.calls == [
+        ("session-1", "evicted_evidence"),
+        ("session-1", "evicted_evidence"),
+        ("session-1", "compacted_digest"),
+    ]
+    assert research_trace[-1]["digest_id_if_any"] == 3
 
 
 async def test_backward_compat_when_store_none(monkeypatch) -> None:

--- a/tests/unit/test_iteration.py
+++ b/tests/unit/test_iteration.py
@@ -1,14 +1,16 @@
 # Self-written, plan v2.3 § 13.5
 from dataclasses import FrozenInstanceError
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import BaseModel
 
+from autosearch.core import context_compaction as context_compaction_module
 from autosearch.core.iteration import IterationBudget, IterationController
-from autosearch.core.models import Evidence, SubQuery
+from autosearch.core.models import Evidence, EvidenceDigest, Gap, SubQuery
+from autosearch.persistence.session_store import SessionStore
 
-NOW = datetime(2026, 4, 17, 12, 0, 0)
+NOW = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
 
 
 class DummyClient:
@@ -47,6 +49,32 @@ def make_evidence(url: str, title: str, content: str) -> Evidence:
     )
 
 
+def make_digest_payload() -> dict[str, object]:
+    return EvidenceDigest(
+        topic="Compacted evidence digest",
+        key_findings=["Older evidence remains useful"],
+        source_urls=[],
+        evidence_count=0,
+        compressed_at=NOW,
+    ).model_dump(mode="json")
+
+
+def make_subqueries(count: int) -> list[SubQuery]:
+    return [
+        SubQuery(text=f"subquery {index}", rationale=f"covers slice {index}")
+        for index in range(1, count + 1)
+    ]
+
+
+def fake_estimate_tokens(text: str) -> int:
+    marker = "[TOKENS="
+    if marker not in text:
+        return max(len(text.split()), 1) if text else 0
+    start = text.index(marker) + len(marker)
+    end = text.index("]", start)
+    return int(text[start:end])
+
+
 async def test_iteration_run_stops_after_one_round_when_no_gaps_remain() -> None:
     controller = IterationController()
     channel = FakeChannel(
@@ -54,7 +82,7 @@ async def test_iteration_run_stops_after_one_round_when_no_gaps_remain() -> None
     )
     client = DummyClient([{"gaps": []}])
 
-    result = await controller.run(
+    result, research_trace = await controller.run(
         query="pricing update",
         initial_queries=[SubQuery(text="pricing update", rationale="seed query")],
         channels=[channel],
@@ -65,6 +93,15 @@ async def test_iteration_run_stops_after_one_round_when_no_gaps_remain() -> None
     assert channel.queries == ["pricing update"]
     assert [evidence.url for evidence in result] == ["https://example.com/one"]
     assert result[0].score is not None
+    assert research_trace == [
+        {
+            "iteration": 1,
+            "batch_index": 1,
+            "subqueries": ["pricing update"],
+            "gaps": [],
+            "digest_id_if_any": None,
+        }
+    ]
     assert client.calls == 1
 
 
@@ -91,7 +128,7 @@ async def test_iteration_run_generates_follow_up_queries_for_second_round() -> N
         ]
     )
 
-    result = await controller.run(
+    result, research_trace = await controller.run(
         query="provider latency limits",
         initial_queries=[SubQuery(text="provider latency limits", rationale="seed query")],
         channels=[channel],
@@ -105,7 +142,371 @@ async def test_iteration_run_generates_follow_up_queries_for_second_round() -> N
         "https://example.com/two",
     }
     assert len(result) == 2
+    assert len(research_trace) == 2
     assert client.calls == 3
+
+
+async def test_per_search_reflection_called_per_batch(monkeypatch) -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        [
+            [make_evidence(f"https://example.com/{index}", f"Result {index}", "batch evidence")]
+            for index in range(1, 6)
+        ]
+    )
+    client = DummyClient([])
+    batch_calls: list[list[str]] = []
+    follow_up_gaps: list[Gap] = []
+
+    async def fake_per_search_reflect(
+        *,
+        batch_evidence: list[Evidence],
+        query: str,
+        client: DummyClient,
+        batch_subqueries: list[SubQuery] | None = None,
+    ) -> list[Gap]:
+        _ = (batch_evidence, query, client)
+        batch_number = len(batch_calls) + 1
+        batch_calls.append([subquery.text for subquery in batch_subqueries or []])
+        return [Gap(topic=f"batch-gap-{batch_number}", reason="fresh batch gap")]
+
+    async def fake_reflect(
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        client: DummyClient,
+    ) -> list[Gap]:
+        _ = (query, iteration, max_iterations, subqueries, evidences, client)
+        return [Gap(topic="iteration-gap", reason="aggregate gap")]
+
+    async def fake_follow_up(
+        query: str,
+        gaps: list[Gap],
+        evidences: list[Evidence],
+        client: DummyClient,
+    ) -> list[SubQuery]:
+        _ = (query, evidences, client)
+        follow_up_gaps.extend(gaps)
+        return []
+
+    monkeypatch.setattr(controller, "_per_search_reflect", fake_per_search_reflect)
+    monkeypatch.setattr(controller, "_reflect", fake_reflect)
+    monkeypatch.setattr(controller, "_follow_up", fake_follow_up)
+
+    _, research_trace = await controller.run(
+        query="batched search reflection",
+        initial_queries=make_subqueries(5),
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=2,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=3,
+        ),
+        client=client,
+    )
+
+    assert batch_calls == [
+        ["subquery 1", "subquery 2", "subquery 3"],
+        ["subquery 4", "subquery 5"],
+    ]
+    assert [gap.topic for gap in follow_up_gaps] == [
+        "iteration-gap",
+        "batch-gap-1",
+        "batch-gap-2",
+    ]
+    assert [entry["gaps"] for entry in research_trace] == [
+        [{"topic": "batch-gap-1", "reason": "fresh batch gap"}],
+        [{"topic": "batch-gap-2", "reason": "fresh batch gap"}],
+    ]
+
+
+async def test_compaction_triggered_when_evidence_token_budget_exceeded(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    controller = IterationController()
+    channel = FakeChannel(
+        [
+            [
+                make_evidence(
+                    f"https://example.com/{index}",
+                    f"Result {index}",
+                    f"[TOKENS=3000] content {index}",
+                )
+            ]
+            for index in range(1, 5)
+        ]
+    )
+    client = DummyClient([make_digest_payload()])
+
+    async def no_batch_gaps(**_: object) -> list[Gap]:
+        return []
+
+    async def no_iteration_gaps(**_: object) -> list[Gap]:
+        return []
+
+    monkeypatch.setattr(controller, "_per_search_reflect", no_batch_gaps)
+    monkeypatch.setattr(controller, "_reflect", no_iteration_gaps)
+
+    evidences, research_trace = await controller.run(
+        query="compact large evidence set",
+        initial_queries=make_subqueries(4),
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=2,
+            context_token_budget=10000,
+            compact_hot_set_size=2,
+        ),
+        client=client,
+    )
+
+    assert len(evidences) == 2
+    assert evidences[0].score is not None
+    assert [entry["digest_id_if_any"] for entry in research_trace] == [None, NOW.isoformat()]
+    assert client.calls == 1
+
+
+async def test_compaction_not_triggered_under_budget(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    controller = IterationController()
+    channel = FakeChannel(
+        [
+            [
+                make_evidence(
+                    f"https://example.com/{index}",
+                    f"Result {index}",
+                    f"[TOKENS=1000] content {index}",
+                )
+            ]
+            for index in range(1, 5)
+        ]
+    )
+    client = DummyClient([])
+
+    async def no_batch_gaps(**_: object) -> list[Gap]:
+        return []
+
+    async def no_iteration_gaps(**_: object) -> list[Gap]:
+        return []
+
+    monkeypatch.setattr(controller, "_per_search_reflect", no_batch_gaps)
+    monkeypatch.setattr(controller, "_reflect", no_iteration_gaps)
+
+    evidences, research_trace = await controller.run(
+        query="keep evidence under budget",
+        initial_queries=make_subqueries(4),
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=2,
+            context_token_budget=10000,
+            compact_hot_set_size=2,
+        ),
+        client=client,
+    )
+
+    assert len(evidences) == 4
+    assert all(entry["digest_id_if_any"] is None for entry in research_trace)
+    assert client.calls == 0
+
+
+async def test_research_trace_returned_alongside_evidence(monkeypatch) -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        [
+            [make_evidence(f"https://example.com/{index}", f"Result {index}", "trace evidence")]
+            for index in range(1, 9)
+        ]
+    )
+    client = DummyClient([])
+    reflect_calls = 0
+
+    async def no_batch_gaps(**_: object) -> list[Gap]:
+        return []
+
+    async def fake_reflect(
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        client: DummyClient,
+    ) -> list[Gap]:
+        _ = (query, iteration, max_iterations, subqueries, evidences, client)
+        nonlocal reflect_calls
+        reflect_calls += 1
+        if reflect_calls == 1:
+            return [Gap(topic="continue", reason="run another round")]
+        return []
+
+    async def repeat_batches(
+        query: str,
+        gaps: list[Gap],
+        evidences: list[Evidence],
+        client: DummyClient,
+    ) -> list[SubQuery]:
+        _ = (query, gaps, evidences, client)
+        return make_subqueries(4)
+
+    monkeypatch.setattr(controller, "_per_search_reflect", no_batch_gaps)
+    monkeypatch.setattr(controller, "_reflect", fake_reflect)
+    monkeypatch.setattr(controller, "_follow_up", repeat_batches)
+
+    evidences, research_trace = await controller.run(
+        query="return research trace",
+        initial_queries=make_subqueries(4),
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=2,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=2,
+        ),
+        client=client,
+    )
+
+    assert isinstance(evidences, list)
+    assert isinstance(research_trace, list)
+    assert len(research_trace) == 4
+    assert [entry["batch_index"] for entry in research_trace] == [1, 2, 1, 2]
+
+
+async def test_subquery_batch_size_respected(monkeypatch) -> None:
+    controller = IterationController()
+    client = DummyClient([])
+    batch_sizes: list[int] = []
+
+    async def fake_search(
+        subqueries: list[SubQuery],
+        channels: list[FakeChannel],
+        iteration: int,
+        priority_channels: set[str] | None = None,
+        skip_channels: set[str] | None = None,
+    ) -> list[Evidence]:
+        _ = (channels, iteration, priority_channels, skip_channels)
+        batch_sizes.append(len(subqueries))
+        return []
+
+    async def no_batch_gaps(**_: object) -> list[Gap]:
+        return []
+
+    async def no_iteration_gaps(**_: object) -> list[Gap]:
+        return []
+
+    monkeypatch.setattr(controller, "_search", fake_search)
+    monkeypatch.setattr(controller, "_per_search_reflect", no_batch_gaps)
+    monkeypatch.setattr(controller, "_reflect", no_iteration_gaps)
+
+    _, research_trace = await controller.run(
+        query="batch subqueries",
+        initial_queries=make_subqueries(10),
+        channels=[FakeChannel([])],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=3,
+        ),
+        client=client,
+    )
+
+    assert batch_sizes == [3, 3, 3, 1]
+    assert len(research_trace) == 4
+
+
+async def test_store_and_session_id_propagated_to_compactor(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    store = await SessionStore.open(":memory:")
+    try:
+        await store.create_session("session-1", "persist compaction", "deep")
+        controller = IterationController(store=store, session_id="session-1")
+        channel = FakeChannel(
+            [
+                [
+                    make_evidence(
+                        f"https://example.com/{index}",
+                        f"Result {index}",
+                        f"[TOKENS=3000] content {index}",
+                    )
+                ]
+                for index in range(1, 5)
+            ]
+        )
+        client = DummyClient([make_digest_payload()])
+
+        async def no_batch_gaps(**_: object) -> list[Gap]:
+            return []
+
+        async def no_iteration_gaps(**_: object) -> list[Gap]:
+            return []
+
+        monkeypatch.setattr(controller, "_per_search_reflect", no_batch_gaps)
+        monkeypatch.setattr(controller, "_reflect", no_iteration_gaps)
+
+        _, research_trace = await controller.run(
+            query="persist compacted digest",
+            initial_queries=make_subqueries(4),
+            channels=[channel],
+            budget=IterationBudget(
+                max_iterations=1,
+                per_channel_rate_limit=0.0,
+                subquery_batch_size=2,
+                context_token_budget=10000,
+                compact_hot_set_size=2,
+            ),
+            client=client,
+        )
+        digests = await store.load_digests(session_id="session-1")
+    finally:
+        await store.close()
+
+    assert len(digests) == 1
+    assert isinstance(research_trace[-1]["digest_id_if_any"], int)
+
+
+async def test_backward_compat_when_store_none(monkeypatch) -> None:
+    monkeypatch.setattr(context_compaction_module, "estimate_tokens", fake_estimate_tokens)
+    controller = IterationController()
+    channel = FakeChannel(
+        [
+            [
+                make_evidence(
+                    f"https://example.com/{index}",
+                    f"Result {index}",
+                    f"[TOKENS=3000] content {index}",
+                )
+            ]
+            for index in range(1, 5)
+        ]
+    )
+    client = DummyClient([make_digest_payload()])
+
+    async def no_batch_gaps(**_: object) -> list[Gap]:
+        return []
+
+    async def no_iteration_gaps(**_: object) -> list[Gap]:
+        return []
+
+    monkeypatch.setattr(controller, "_per_search_reflect", no_batch_gaps)
+    monkeypatch.setattr(controller, "_reflect", no_iteration_gaps)
+
+    evidences, research_trace = await controller.run(
+        query="compact without persistence",
+        initial_queries=make_subqueries(4),
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=2,
+            context_token_budget=10000,
+            compact_hot_set_size=2,
+        ),
+        client=client,
+    )
+
+    assert len(evidences) == 2
+    assert research_trace[-1]["digest_id_if_any"] == NOW.isoformat()
 
 
 def test_iteration_budget_is_frozen() -> None:

--- a/tests/unit/test_iteration_routing.py
+++ b/tests/unit/test_iteration_routing.py
@@ -119,7 +119,7 @@ async def test_iteration_fallback_triggered_when_priority_empty() -> None:
     ]
     client = DummyClient([{"gaps": []}])
 
-    evidences = await controller.run(
+    evidences, _ = await controller.run(
         query="empty priority evidence",
         initial_queries=[SubQuery(text="empty priority evidence", rationale="seed")],
         channels=channels,
@@ -157,7 +157,7 @@ async def test_iteration_fallback_not_triggered_when_priority_sufficient() -> No
     ]
     client = DummyClient([{"gaps": []}])
 
-    evidences = await controller.run(
+    evidences, _ = await controller.run(
         query="sufficient priority evidence",
         initial_queries=[SubQuery(text="sufficient priority evidence", rationale="seed")],
         channels=channels,


### PR DESCRIPTION
## Summary

W2 of plan `autosearch-0420-steal-3-patterns.md` — borrow deepagents' context-management ideas without vendoring LangGraph. Zero new frameworks. Zero new runtime deps.

- **ContextCompactor** — token-budget triggered evidence compression. When total evidence tokens exceed 80% of budget (default 16K), the cold tail is summarized into one `EvidenceDigest` and the hot tail (last 10 items) stays raw. source_page is excluded from tokenization per W1 review advisory.
- **EvidenceDigest** pydantic model — topic / key_findings / source_urls / evidence_count / timestamps / before+after token counts.
- **evidence_artifacts SQLite table** — `session_id, kind, payload_json, created_at` with FK cascade. Two kinds: `compacted_digest` and `evicted_evidence` (full audit trail).
- **Iteration batch loop** — subqueries split into batches of 3. Each batch does search → per-search reflection (narrow, fresh-from-the-batch gaps) → compaction (if triggered). Existing per-iteration gap reflection stays (aggregate view). Single-batch rounds skip per-search reflect to avoid duplicate LLM call.
- **research_trace** — new return from `IterationController.run()` as `list[dict]` (W3 will promote to typed model). Threaded through `PipelineResult`. Digest rowids captured directly from SQLite insert (no N+1 lookup).

## Commits (4)

1. feat(core): context compactor for token-budgeted evidence summarization
2. feat(persistence): evidence_artifacts table and compactor persistence wire-up
3. refactor(core): per-search reflection and context compaction in iteration loop
4. fix(core): stricter compactor client requirement and drop n+1 artifact lookup (review-response)

## Test plan

- [x] 29 new tests (11 compactor + 6 artifact store + 4 compactor persistence + 8 iteration refactor) plus 5 updated
- [x] Full suite: **510 passed / 18 deselected / 0 failed** (baseline was 479 after W1)
- [x] ruff + ruff format clean
- [x] pr-review-toolkit:code-reviewer pass: no blocking issues, 3 P1 (safety / perf / dead-code) all folded into commit 4

## Gotchas for reviewer

- ContextCompactor now **raises** if compaction triggers without a client (was: silently instantiated real LLMClient and risked hitting network in tests). Tests that didn't pass a client only passed before because compaction never triggered on small fixtures.
- PipelineResult gained `research_trace: list[dict]` (default_factory=list). W3 will change this to a typed `ResearchTurn` model; dict keys are `{iteration, batch_index, subqueries, gaps, digest_trace_id}`.
- Compaction is **best-effort**: LLM failure, store failure, or missing store each fall back gracefully with structured-log warnings.
- source_page is explicitly excluded from token counting AND from summarize prompt (W1 review advisory honored). This means digests see only `title + snippet + content` from each Evidence.
- Depends on **W1 merged** (✓ merged as #170).

🤖 Generated with [Claude Code](https://claude.com/claude-code)