### PR TITLE
feat: W3 synthesis layer — two-stage outline + per-section retrieval + citation hardening (steal storm ideas)

### DIFF
--- a/autosearch/core/evidence.py
+++ b/autosearch/core/evidence.py
@@ -222,7 +222,7 @@ def _evidence_id(evidence: Evidence) -> str:
         return evidence.url
     preview = (evidence.content or evidence.snippet or "")[:100]
     payload = f"{evidence.title}\n{preview}"
-    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _simhash_text(evidence: Evidence) -> str:

--- a/autosearch/core/evidence.py
+++ b/autosearch/core/evidence.py
@@ -1,6 +1,15 @@
 # Source: deer-flow/deerflow/community/infoquest/infoquest_client.py:L183-L230 (adapted)
 # Self-written, plan v2.3 § 13.5 M5 BM25 + SimHash
-from autosearch.core.models import Evidence
+from __future__ import annotations
+
+import hashlib
+import re
+
+from autosearch.cleaners.pruning_cleaner import PruningCleaner
+from autosearch.core.models import Evidence, EvidenceSnippet
+
+_CJK_CHAR_RE = PruningCleaner.CJK_CHAR_RE
+_NON_WHITESPACE_RE = re.compile(r"\S+")
 
 
 class EvidenceProcessor:
@@ -32,8 +41,8 @@ class EvidenceProcessor:
         if top_k <= 0 or not evs:
             return []
 
-        tokenized_corpus = [_bm25_text(evidence).split() for evidence in evs]
-        query_tokens = query.split()
+        tokenized_corpus = [_tokenize_bm25_text(_bm25_text(evidence)) for evidence in evs]
+        query_tokens = _tokenize_bm25_text(query)
 
         if not query_tokens or not any(tokens for tokens in tokenized_corpus):
             reranked = [evidence.model_copy(update={"score": 0.0}) for evidence in evs]
@@ -49,6 +58,171 @@ class EvidenceProcessor:
         ]
         scored.sort(key=lambda evidence: evidence.score or 0.0, reverse=True)
         return scored[:top_k]
+
+    @staticmethod
+    def split_into_snippets(evidence: Evidence, **kwargs: object) -> list[EvidenceSnippet]:
+        return split_into_snippets(evidence, **kwargs)
+
+    @staticmethod
+    def retrieve_for_section(
+        section_query: str,
+        snippets: list[EvidenceSnippet],
+        top_k: int = 15,
+    ) -> list[EvidenceSnippet]:
+        return retrieve_for_section(section_query, snippets, top_k=top_k)
+
+
+def split_into_snippets(
+    evidence: Evidence,
+    *,
+    window_tokens: int = 200,
+    overlap_tokens: int = 40,
+) -> list[EvidenceSnippet]:
+    """Split evidence text into overlapping snippet windows."""
+    source_text = _snippet_source_text(evidence)
+    if not source_text:
+        return []
+
+    step = max(1, window_tokens - overlap_tokens)
+    evidence_id = _evidence_id(evidence)
+    source_title = evidence.title or ""
+    source_url = evidence.url or ""
+
+    if _should_use_character_chunking(source_text):
+        if len(source_text) <= window_tokens:
+            return [
+                EvidenceSnippet(
+                    evidence_id=evidence_id,
+                    text=source_text,
+                    offset=0,
+                    source_url=source_url,
+                    source_title=source_title,
+                )
+            ]
+        return [
+            EvidenceSnippet(
+                evidence_id=evidence_id,
+                text=source_text[start : min(start + window_tokens, len(source_text))],
+                offset=start,
+                source_url=source_url,
+                source_title=source_title,
+            )
+            for start in _window_starts(len(source_text), window_tokens, step)
+        ]
+
+    token_spans = list(_NON_WHITESPACE_RE.finditer(source_text))
+    if not token_spans:
+        return []
+    if len(token_spans) <= window_tokens:
+        return [
+            EvidenceSnippet(
+                evidence_id=evidence_id,
+                text=source_text,
+                offset=0,
+                source_url=source_url,
+                source_title=source_title,
+            )
+        ]
+
+    snippets: list[EvidenceSnippet] = []
+    for start in _window_starts(len(token_spans), window_tokens, step):
+        end = min(start + window_tokens, len(token_spans))
+        start_char = token_spans[start].start()
+        end_char = token_spans[end - 1].end()
+        snippets.append(
+            EvidenceSnippet(
+                evidence_id=evidence_id,
+                text=source_text[start_char:end_char],
+                offset=start_char,
+                source_url=source_url,
+                source_title=source_title,
+            )
+        )
+    return snippets
+
+
+def retrieve_for_section(
+    section_query: str,
+    snippets: list[EvidenceSnippet],
+    *,
+    top_k: int = 15,
+) -> list[EvidenceSnippet]:
+    """BM25-rank snippets against a section query and return the best matches."""
+    if not snippets or not section_query.strip():
+        return []
+    if len(snippets) == 1:
+        return snippets[:]
+
+    tokenized_corpus = [_tokenize_bm25_text(snippet.text) for snippet in snippets]
+    query_tokens = _tokenize_bm25_text(section_query)
+    if not query_tokens:
+        return []
+    if not any(tokens for tokens in tokenized_corpus):
+        return snippets[:] if top_k <= 0 else snippets[:top_k]
+
+    from rank_bm25 import BM25Okapi
+
+    bm25 = BM25Okapi(tokenized_corpus)
+    scores = bm25.get_scores(query_tokens)
+    ranked = list(zip(snippets, scores, strict=True))
+    ranked.sort(key=lambda item: float(item[1]), reverse=True)
+    ordered = [snippet for snippet, _ in ranked]
+    return ordered if top_k <= 0 else ordered[:top_k]
+
+
+def split_all_evidence(
+    evidences: list[Evidence],
+    *,
+    window_tokens: int = 200,
+    overlap_tokens: int = 40,
+) -> list[EvidenceSnippet]:
+    """Chunk every evidence item and flatten the snippets into one list."""
+    snippets: list[EvidenceSnippet] = []
+    for evidence in evidences:
+        snippets.extend(
+            split_into_snippets(
+                evidence,
+                window_tokens=window_tokens,
+                overlap_tokens=overlap_tokens,
+            )
+        )
+    return snippets
+
+
+def _window_starts(total_units: int, window_size: int, step: int) -> list[int]:
+    starts: list[int] = []
+    start = 0
+    while start < total_units:
+        starts.append(start)
+        if start + window_size >= total_units:
+            break
+        start += step
+    return starts
+
+
+def _snippet_source_text(evidence: Evidence) -> str:
+    return evidence.content or evidence.snippet or ""
+
+
+def _should_use_character_chunking(text: str) -> bool:
+    cjk_chars = len(_CJK_CHAR_RE.findall(text))
+    if cjk_chars == 0:
+        return False
+    whitespace_tokens = len(text.split())
+    return whitespace_tokens <= max(1, cjk_chars // 8)
+
+
+def _tokenize_bm25_text(text: str) -> list[str]:
+    separated_cjk = _CJK_CHAR_RE.sub(lambda match: f" {match.group(0)} ", text)
+    return separated_cjk.split()
+
+
+def _evidence_id(evidence: Evidence) -> str:
+    if evidence.url:
+        return evidence.url
+    preview = (evidence.content or evidence.snippet or "")[:100]
+    payload = f"{evidence.title}\n{preview}"
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
 
 
 def _simhash_text(evidence: Evidence) -> str:

--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -1,4 +1,6 @@
 # Self-written, plan v2.3 § 13.5
+import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -83,6 +85,91 @@ class EvidenceDigest(BaseModel):
     token_count_after: int = 0
 
 
+class OutlineNode(BaseModel):
+    """Hierarchical outline tree used by synthesis for section-scoped retrieval."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    heading: str
+    level: int = Field(ge=0, le=6)
+    children: list["OutlineNode"] = Field(default_factory=list)
+    section_query: str | None = None
+
+    def get_subtree_headings(
+        self,
+        root_name: str | None = None,
+        separator: str = " > ",
+    ) -> list[str]:
+        """Return this subtree as breadcrumb headings in depth-first order."""
+        headings: list[str] = []
+        prefix = [root_name] if root_name else []
+
+        def visit(node: OutlineNode, ancestors: list[str]) -> None:
+            current = ancestors
+            if node.heading:
+                current = [*ancestors, node.heading]
+                headings.append(separator.join(current))
+            for child in node.children:
+                visit(child, current)
+
+        visit(self, prefix)
+        return headings
+
+    def walk_leaves(self) -> Iterator["OutlineNode"]:
+        """Yield leaf nodes in document order."""
+        if not self.children:
+            yield self
+            return
+        for child in self.children:
+            yield from child.walk_leaves()
+
+    def walk_depth_first(self) -> Iterator["OutlineNode"]:
+        """Yield this node and all descendants in document order."""
+        yield self
+        for child in self.children:
+            yield from child.walk_depth_first()
+
+
+_MARKDOWN_HEADING_RE = re.compile(r"^\s*(#{1,6})\s+(.*?)\s*$")
+_TRAILING_HASHES_RE = re.compile(r"\s+#+\s*$")
+
+
+def parse_markdown_outline(markdown: str) -> OutlineNode:
+    """Parse a markdown heading outline into an OutlineNode tree."""
+    root = OutlineNode(heading="", level=0)
+    parsed_headings: list[tuple[int, str]] = []
+
+    for raw_line in markdown.splitlines():
+        match = _MARKDOWN_HEADING_RE.match(raw_line)
+        if not match:
+            continue
+        heading = _TRAILING_HASHES_RE.sub("", match.group(2)).strip()
+        if not heading:
+            continue
+        parsed_headings.append((len(match.group(1)), heading))
+
+    if not parsed_headings:
+        root.children.extend(
+            OutlineNode(heading=line.strip(), level=1)
+            for line in markdown.splitlines()
+            if line.strip()
+        )
+        return root
+
+    stack: list[OutlineNode] = [root]
+    for level, heading in parsed_headings:
+        node = OutlineNode(heading=heading, level=level)
+        while stack and stack[-1].level >= level:
+            stack.pop()
+        parent = stack[-1] if stack else root
+        parent.children.append(node)
+        stack.append(node)
+
+    if len(root.children) == 1 and root.children[0].level == 1:
+        return root.children[0]
+    return root
+
+
 class Gap(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -144,6 +231,33 @@ class EvaluationResult(BaseModel):
     follow_up_gaps: list[Gap]
 
 
+class ResearchTurn(BaseModel):
+    """One research step the iteration engine took."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    iteration: int
+    batch_index: int = 0
+    perspective: str | None = None
+    question: str
+    answer: str
+    search_queries: list[str] = Field(default_factory=list)
+    evidence_ids: list[str] = Field(default_factory=list)
+    digest_trace_id: int | None = None
+
+
+class EvidenceSnippet(BaseModel):
+    """A chunk of evidence content used for section-scoped retrieval."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_id: str
+    text: str
+    offset: int = Field(ge=0)
+    source_url: str
+    source_title: str = ""
+
+
 @dataclass(frozen=True)
 class PipelineResult:
     delivery_status: Literal["ok", "needs_clarification"]
@@ -160,3 +274,6 @@ class PipelineResult:
     cost: float = 0.0
     prompt_tokens: int = 0
     completion_tokens: int = 0
+
+
+OutlineNode.model_rebuild()

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -254,12 +254,14 @@ class Pipeline:
                 phase="m7_synthesis",
                 evidences=len(processed_evidences),
             )
-            markdown = await self.report_synthesizer.synthesize(
+            report = await self.report_synthesizer.synthesize(
                 query=query,
                 evidences=processed_evidences,
                 rubrics=clarification.rubrics,
                 client=self.llm,
+                research_trace=research_trace,
             )
+            markdown = report.markdown
             self.logger.info(
                 "pipeline_phase_completed",
                 phase="m7_synthesis",
@@ -326,12 +328,14 @@ class Pipeline:
                     )
                     current_phase = "M7"
                     await self._emit_phase_event(current_phase, "start")
-                    markdown = await self.report_synthesizer.synthesize(
+                    report = await self.report_synthesizer.synthesize(
                         query=query,
                         evidences=processed_evidences,
                         rubrics=clarification.rubrics,
                         client=self.llm,
+                        research_trace=research_trace,
                     )
+                    markdown = report.markdown
                     await self._emit_phase_event(current_phase, "complete")
                     self.logger.info(
                         "pipeline_quality_retry_completed",

--- a/autosearch/skills/prompts/m4_draft_outline.md
+++ b/autosearch/skills/prompts/m4_draft_outline.md
@@ -1,0 +1,18 @@
+---
+name: m4_draft_outline
+phase: M4
+description: Draft a report outline from the query alone before research-specific refinement.
+---
+Draft a report outline for the research task below using only your parametric knowledge of the
+topic.
+
+<User query>
+{query}
+</User query>
+
+Output requirements:
+- Return only a markdown outline using `#` for top-level sections and `##` for subsections
+- Produce 3 to 6 top-level sections
+- Give each top-level section 0 to 2 subsections when helpful
+- Keep the outline concise, specific, and non-overlapping
+- Do not include any prose, explanation, numbering, or code fences before or after the outline

--- a/autosearch/skills/prompts/m4_refine_outline.md
+++ b/autosearch/skills/prompts/m4_refine_outline.md
@@ -1,0 +1,26 @@
+---
+name: m4_refine_outline
+phase: M4
+description: Refine a draft outline using what the research process actually discovered.
+---
+Refine the draft outline so it matches the evidence shape that emerged during research.
+
+<User query>
+{query}
+</User query>
+
+<Draft outline>
+{draft_outline_markdown}
+</Draft outline>
+
+<Research dialogue>
+{research_dialogue}
+</Research dialogue>
+
+Output requirements:
+- Return only a markdown outline using `#` for top-level sections and `##` for subsections
+- Keep 3 to 6 top-level sections
+- Rearrange, split, merge, or rename sections when the research trace suggests a better structure
+- Remove sections that the research trace does not support and add missing sections it clearly needs
+- Keep the outline concise, specific, and non-overlapping
+- Do not include any prose, explanation, numbering, or code fences before or after the outline

--- a/autosearch/skills/prompts/m7_section_write_v2.md
+++ b/autosearch/skills/prompts/m7_section_write_v2.md
@@ -1,0 +1,37 @@
+---
+name: m7_section_write_v2
+phase: M7
+description: Write a report section using only the provided per-section snippets and inline citations.
+---
+Write the body content for this report section using only the provided snippets.
+
+<Research topic>
+{topic}
+</Research topic>
+
+<Section heading>
+{section_heading}
+</Section heading>
+
+<Local section outline>
+{section_outline}
+</Local section outline>
+
+<Snippet list>
+{snippets_context}
+</Snippet list>
+
+Respond in valid JSON with this exact schema:
+{{
+  "content": "plain markdown section body"
+}}
+
+Rules:
+- Write the section on {section_heading} using only the provided snippets
+- Use the local section outline for context, but only write this section body
+- Use inline citations like [1], [2], ... where N matches the snippet number
+- Do NOT cite snippets you did not use
+- Do NOT invent content that is not grounded in the snippets
+- Target length: 2-4 paragraphs unless the available content is sparse
+- Do not include the section heading line itself in the content
+- Do not add a references section

--- a/autosearch/synthesis/citation.py
+++ b/autosearch/synthesis/citation.py
@@ -1,6 +1,8 @@
 # Source: open_deep_research/src/open_deep_research/prompts.py:L186-L220 (adapted)
 import re
+from collections.abc import Iterable
 from collections import Counter
+from typing import Any
 
 from autosearch.core.models import Evidence, Section
 
@@ -27,6 +29,18 @@ class CitationRenderer:
         sections: list[Section],
         evidences: list[Evidence],
     ) -> tuple[list[Section], list[Evidence]]:
+        scrubbed_sections = [
+            section.model_copy(
+                update={
+                    "content": scrub_invalid_inline_citations(
+                        section.content,
+                        valid_ids=section.ref_ids,
+                    )
+                }
+            )
+            for section in sections
+        ]
+
         canonical_by_url: dict[str, int] = {}
         for old_ref_id, evidence in enumerate(evidences, start=1):
             canonical_by_url.setdefault(evidence.url, old_ref_id)
@@ -35,7 +49,7 @@ class CitationRenderer:
         old_to_new: dict[int, int] = {}
         remapped_evidences: list[Evidence] = []
 
-        for section in sections:
+        for section in scrubbed_sections:
             for old_ref_id in _ordered_ref_ids(section):
                 if old_ref_id < 1 or old_ref_id > len(evidences):
                     continue
@@ -56,10 +70,60 @@ class CitationRenderer:
                     "ref_ids": _remap_ref_ids(section, old_to_new),
                 }
             )
-            for section in sections
+            for section in scrubbed_sections
         ]
 
         return remapped_sections, remapped_evidences
+
+    def renumber_by_first_appearance(
+        self,
+        content: str,
+        ref_table: dict[int, Any],
+    ) -> tuple[str, dict[int, Any]]:
+        return renumber_by_first_appearance(content, ref_table)
+
+
+def scrub_invalid_inline_citations(content: str, valid_ids: Iterable[int]) -> str:
+    """Remove inline citation markers whose ids are not valid for the section."""
+    valid_id_set = set(valid_ids)
+
+    scrubbed = _INLINE_CITATION_RE.sub(
+        lambda match: match.group(0) if int(match.group(1)) in valid_id_set else "",
+        content,
+    )
+    scrubbed = re.sub(r"[ \t]{2,}", " ", scrubbed)
+    scrubbed = re.sub(r"[ \t]+([,.])", r"\1", scrubbed)
+    scrubbed = re.sub(r"[ \t]+(?=\n)", "", scrubbed)
+    scrubbed = re.sub(r"[ \t]+$", "", scrubbed)
+    return scrubbed
+
+
+def renumber_by_first_appearance(
+    content: str,
+    ref_table: dict[int, Any],
+) -> tuple[str, dict[int, Any]]:
+    """Rewrite citations by first use order and drop uncited references."""
+    if not content:
+        return content, {}
+
+    old_to_new: dict[int, int] = {}
+    reordered_ref_table: dict[int, Any] = {}
+
+    def replacer(match: re.Match[str]) -> str:
+        old_ref_id = int(match.group(1))
+        reference = ref_table.get(old_ref_id)
+        if reference is None:
+            return match.group(0)
+
+        new_ref_id = old_to_new.get(old_ref_id)
+        if new_ref_id is None:
+            new_ref_id = len(old_to_new) + 1
+            old_to_new[old_ref_id] = new_ref_id
+            reordered_ref_table[new_ref_id] = reference
+        return f"[{new_ref_id}]"
+
+    renumbered_content = _INLINE_CITATION_RE.sub(replacer, content)
+    return renumbered_content, reordered_ref_table
 
 
 def _ordered_ref_ids(section: Section) -> list[int]:

--- a/autosearch/synthesis/citation.py
+++ b/autosearch/synthesis/citation.py
@@ -1,12 +1,14 @@
 # Source: open_deep_research/src/open_deep_research/prompts.py:L186-L220 (adapted)
 import re
-from collections.abc import Iterable
 from collections import Counter
+from collections.abc import Callable, Iterable
 from typing import Any
 
 from autosearch.core.models import Evidence, Section
 
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
 
 
 class CitationRenderer:
@@ -83,18 +85,42 @@ class CitationRenderer:
         return renumber_by_first_appearance(content, ref_table)
 
 
+def apply_to_prose(content: str, fn: Callable[[str], str]) -> str:
+    """Apply a text transform while preserving fenced and inline code verbatim."""
+    protected_segments: list[str] = []
+
+    def protect(match: re.Match[str]) -> str:
+        protected_segments.append(match.group(0))
+        return f"\x00AUT_SEARCH_CODE_{len(protected_segments) - 1}\x00"
+
+    masked_content = _FENCED_CODE_RE.sub(protect, content)
+    masked_content = _INLINE_CODE_RE.sub(protect, masked_content)
+    transformed_content = fn(masked_content)
+
+    for index, segment in enumerate(protected_segments):
+        transformed_content = transformed_content.replace(
+            f"\x00AUT_SEARCH_CODE_{index}\x00",
+            segment,
+        )
+    return transformed_content
+
+
 def scrub_invalid_inline_citations(content: str, valid_ids: Iterable[int]) -> str:
     """Remove inline citation markers whose ids are not valid for the section."""
     valid_id_set = set(valid_ids)
 
-    scrubbed = _INLINE_CITATION_RE.sub(
-        lambda match: match.group(0) if int(match.group(1)) in valid_id_set else "",
-        content,
-    )
-    scrubbed = re.sub(r"[ \t]{2,}", " ", scrubbed)
-    scrubbed = re.sub(r"[ \t]+([,.])", r"\1", scrubbed)
-    scrubbed = re.sub(r"[ \t]+(?=\n)", "", scrubbed)
-    scrubbed = re.sub(r"[ \t]+$", "", scrubbed)
+    def scrub_plain_text(text: str) -> str:
+        scrubbed_text = _INLINE_CITATION_RE.sub(
+            lambda match: match.group(0) if int(match.group(1)) in valid_id_set else "",
+            text,
+        )
+        scrubbed_text = re.sub(r"[ \t]{2,}", " ", scrubbed_text)
+        scrubbed_text = re.sub(r"[ \t]+([,.])", r"\1", scrubbed_text)
+        scrubbed_text = re.sub(r"[ \t]+(?=\n)", "", scrubbed_text)
+        scrubbed_text = re.sub(r"[ \t]+$", "", scrubbed_text)
+        return scrubbed_text
+
+    scrubbed = apply_to_prose(content, scrub_plain_text)
     return scrubbed
 
 
@@ -122,14 +148,15 @@ def renumber_by_first_appearance(
             reordered_ref_table[new_ref_id] = reference
         return f"[{new_ref_id}]"
 
-    renumbered_content = _INLINE_CITATION_RE.sub(replacer, content)
+    renumbered_content = apply_to_prose(
+        content,
+        lambda text: _INLINE_CITATION_RE.sub(replacer, text),
+    )
     return renumbered_content, reordered_ref_table
 
 
 def _ordered_ref_ids(section: Section) -> list[int]:
-    content_ref_ids = [
-        int(match.group(1)) for match in _INLINE_CITATION_RE.finditer(section.content)
-    ]
+    content_ref_ids = _prose_ref_ids(section.content)
     ordered_ref_ids = content_ref_ids + section.ref_ids
 
     seen: set[int] = set()
@@ -150,14 +177,12 @@ def _replace_citations(content: str, old_to_new: dict[int, int]) -> str:
             return match.group(0)
         return f"[{new_ref_id}]"
 
-    return _INLINE_CITATION_RE.sub(replacer, content)
+    return apply_to_prose(content, lambda text: _INLINE_CITATION_RE.sub(replacer, text))
 
 
 def _remap_ref_ids(section: Section, old_to_new: dict[int, int]) -> list[int]:
     updated_content = _replace_citations(section.content, old_to_new)
-    content_ref_ids = [
-        int(match.group(1)) for match in _INLINE_CITATION_RE.finditer(updated_content)
-    ]
+    content_ref_ids = _prose_ref_ids(updated_content)
     mapped_ref_ids = [old_to_new[ref_id] for ref_id in section.ref_ids if ref_id in old_to_new]
     ordered_ref_ids = content_ref_ids + mapped_ref_ids
 
@@ -169,3 +194,14 @@ def _remap_ref_ids(section: Section, old_to_new: dict[int, int]) -> list[int]:
         seen.add(ref_id)
         deduped.append(ref_id)
     return deduped
+
+
+def _prose_ref_ids(content: str) -> list[int]:
+    ref_ids: list[int] = []
+
+    def collect_ref_ids(text: str) -> str:
+        ref_ids.extend(int(match.group(1)) for match in _INLINE_CITATION_RE.finditer(text))
+        return text
+
+    apply_to_prose(content, collect_ref_ids)
+    return ref_ids

--- a/autosearch/synthesis/outline.py
+++ b/autosearch/synthesis/outline.py
@@ -1,16 +1,100 @@
-# Source: storm/knowledge_storm/storm_wiki/modules/outline_generation.py:L128-L167 (adapted)
+# Source: storm/knowledge_storm/storm_wiki/modules/outline_generation.py:L84-L125 (adapted)
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
 import structlog
 from pydantic import BaseModel, Field
 
-from autosearch.core.models import Evidence
+from autosearch.core.models import Evidence, OutlineNode, ResearchTurn, parse_markdown_outline
 from autosearch.llm.client import LLMClient
 from autosearch.skills.prompts import load_prompt
 
-OUTLINE_PROMPT = load_prompt("m7_outline")
+DRAFT_OUTLINE_PROMPT = load_prompt("m4_draft_outline")
+REFINE_OUTLINE_PROMPT = load_prompt("m4_refine_outline")
+RESEARCH_TRACE_CHAR_CAP = 8000
+_MARKDOWN_HEADING_RE = re.compile(r"^\s*#{1,6}\s+\S", re.MULTILINE)
+_DEFAULT_RESEARCH_ANSWER = "No explicit reflection answer was recorded."
 
 
 class OutlineResponse(BaseModel):
     headings: list[str] = Field(default_factory=list)
+    markdown: str = ""
+
+
+@dataclass(frozen=True)
+class _NormalizedResearchTurn:
+    iteration: int
+    batch_index: int
+    question: str
+    answer: str
+    search_queries: tuple[str, ...]
+
+
+async def draft_outline(query: str, client: LLMClient) -> OutlineNode:
+    """Stage 1: draft an outline from the query using parametric knowledge."""
+    logger = structlog.get_logger(__name__).bind(component="outline_generator", stage="draft")
+    logger.info("outline_draft_started", query=query)
+
+    prompt = DRAFT_OUTLINE_PROMPT.format(query=query)
+    response = await client.complete(prompt, OutlineResponse)
+    outline = _parse_outline_response(
+        response=response,
+        fallback_heading=query,
+        logger=logger,
+    )
+
+    logger.info(
+        "outline_draft_completed",
+        top_level_sections=len(_top_level_headings(outline)),
+    )
+    return outline
+
+
+async def refine_outline(
+    query: str,
+    draft: OutlineNode,
+    research_trace: list[ResearchTurn] | list[dict],
+    client: LLMClient,
+) -> OutlineNode:
+    """Stage 2: refine a draft outline using the research trace."""
+    logger = structlog.get_logger(__name__).bind(component="outline_generator", stage="refine")
+    normalized_draft = _normalize_outline_tree(draft)
+    normalized_trace = _normalize_research_trace(research_trace)
+
+    if not normalized_trace:
+        logger.info("outline_refine_skipped", reason="empty_research_trace")
+        return _ensure_valid_outline(
+            outline=normalized_draft,
+            fallback_heading=query,
+            logger=logger,
+            raw_markdown=_outline_to_markdown(normalized_draft),
+        )
+
+    research_dialogue = _format_research_dialogue(
+        normalized_trace,
+        char_cap=RESEARCH_TRACE_CHAR_CAP,
+    )
+    prompt = REFINE_OUTLINE_PROMPT.format(
+        query=query,
+        draft_outline_markdown=_outline_to_markdown(normalized_draft),
+        research_dialogue=research_dialogue,
+    )
+    response = await client.complete(prompt, OutlineResponse)
+    outline = _parse_outline_response(
+        response=response,
+        fallback_heading=query,
+        logger=logger,
+    )
+
+    logger.info(
+        "outline_refine_completed",
+        top_level_sections=len(_top_level_headings(outline)),
+        research_turns=len(normalized_trace),
+    )
+    return outline
 
 
 class OutlineGenerator:
@@ -28,19 +112,75 @@ class OutlineGenerator:
             query=query,
             evidences=len(evidences),
         )
-        prompt = OUTLINE_PROMPT.format(
-            query=query,
-            evidence_context=_format_evidence(evidences),
-        )
-        response = await client.complete(prompt, OutlineResponse)
-        headings = _normalize_headings(response.headings)
+        draft = await draft_outline(query, client)
+        refined = await refine_outline(query, draft, [], client)
+        headings = _top_level_headings(refined)
         if not headings:
-            headings = ["Overview"]
+            headings = [query.strip() or "Overview"]
         self.logger.info("outline_generation_completed", headings=len(headings))
         return headings
 
 
-def _normalize_headings(headings: list[str]) -> list[str]:
+def _parse_outline_response(
+    *,
+    response: OutlineResponse,
+    fallback_heading: str,
+    logger: structlog.stdlib.BoundLogger,
+) -> OutlineNode:
+    raw_markdown = _outline_markdown_from_response(response)
+    try:
+        outline = parse_markdown_outline(raw_markdown)
+    except Exception as exc:  # pragma: no cover - defensive guard around parser failures
+        logger.warning(
+            "outline_parse_failed",
+            error=str(exc),
+            reason="parser_exception",
+        )
+        return _fallback_outline(fallback_heading)
+
+    return _ensure_valid_outline(
+        outline=outline,
+        fallback_heading=fallback_heading,
+        logger=logger,
+        raw_markdown=raw_markdown,
+    )
+
+
+def _ensure_valid_outline(
+    *,
+    outline: OutlineNode,
+    fallback_heading: str,
+    logger: structlog.stdlib.BoundLogger,
+    raw_markdown: str,
+) -> OutlineNode:
+    normalized = _normalize_outline_tree(outline)
+    if _MARKDOWN_HEADING_RE.search(raw_markdown) is None:
+        logger.warning("outline_parse_failed", reason="missing_markdown_headings")
+        return _fallback_outline(fallback_heading)
+    if not _outline_has_content(normalized):
+        logger.warning("outline_parse_failed", reason="empty_outline_tree")
+        return _fallback_outline(fallback_heading)
+    return normalized
+
+
+def _outline_markdown_from_response(response: OutlineResponse) -> str:
+    markdown = response.markdown.strip()
+    if markdown and _MARKDOWN_HEADING_RE.search(markdown):
+        return markdown
+
+    headings_markdown = _headings_to_markdown(response.headings)
+    if headings_markdown:
+        return headings_markdown
+
+    return markdown
+
+
+def _headings_to_markdown(headings: Sequence[str]) -> str:
+    normalized_headings = _normalize_headings(headings)
+    return "\n".join(f"# {heading}" for heading in normalized_headings)
+
+
+def _normalize_headings(headings: Sequence[str]) -> list[str]:
     seen: set[str] = set()
     normalized: list[str] = []
     for heading in headings:
@@ -53,10 +193,224 @@ def _normalize_headings(headings: list[str]) -> list[str]:
     return normalized
 
 
-def _format_evidence(evidences: list[Evidence]) -> str:
-    if not evidences:
-        return "- No evidence collected"
-    return "\n".join(
-        f"- {evidence.title} ({evidence.source_channel}) — {evidence.url}"
-        for evidence in evidences[:20]
+def _outline_has_content(outline: OutlineNode) -> bool:
+    if outline.heading.strip():
+        return True
+    return any(_outline_has_content(child) for child in outline.children)
+
+
+def _normalize_outline_tree(outline: OutlineNode) -> OutlineNode:
+    if not outline.heading and not outline.children:
+        return OutlineNode(heading="", level=0)
+    if not outline.heading:
+        return OutlineNode(
+            heading="",
+            level=0,
+            children=[_clone_outline_node(child, level=1) for child in outline.children],
+        )
+    return _clone_outline_node(outline, level=1)
+
+
+def _clone_outline_node(node: OutlineNode, *, level: int) -> OutlineNode:
+    normalized_heading = node.heading.strip()
+    return OutlineNode(
+        heading=normalized_heading,
+        level=min(level, 6),
+        section_query=node.section_query,
+        children=[
+            _clone_outline_node(child, level=min(level + 1, 6))
+            for child in node.children
+            if child.heading.strip() or child.children
+        ],
     )
+
+
+def _top_level_headings(outline: OutlineNode) -> list[str]:
+    normalized = _normalize_outline_tree(outline)
+    if normalized.heading:
+        return [normalized.heading]
+    return [child.heading for child in normalized.children if child.heading.strip()]
+
+
+def _outline_to_markdown(outline: OutlineNode) -> str:
+    normalized = _normalize_outline_tree(outline)
+    lines: list[str] = []
+    roots = normalized.children if not normalized.heading else [normalized]
+    for root in roots:
+        _append_outline_lines(root, level=1, lines=lines)
+    return "\n".join(lines)
+
+
+def _append_outline_lines(node: OutlineNode, *, level: int, lines: list[str]) -> None:
+    if node.heading.strip():
+        lines.append(f"{'#' * level} {node.heading.strip()}")
+    for child in node.children:
+        _append_outline_lines(child, level=min(level + 1, 6), lines=lines)
+
+
+def _normalize_research_trace(
+    research_trace: Sequence[ResearchTurn | Mapping[str, object]],
+) -> list[_NormalizedResearchTurn]:
+    normalized: list[_NormalizedResearchTurn] = []
+    for index, entry in enumerate(research_trace, start=1):
+        if isinstance(entry, ResearchTurn):
+            normalized_turn = _normalize_typed_turn(entry, fallback_iteration=index)
+        elif isinstance(entry, Mapping):
+            normalized_turn = _normalize_legacy_turn(entry, fallback_iteration=index)
+        else:
+            continue
+        if normalized_turn is not None:
+            normalized.append(normalized_turn)
+    return normalized
+
+
+def _normalize_typed_turn(
+    turn: ResearchTurn,
+    *,
+    fallback_iteration: int,
+) -> _NormalizedResearchTurn | None:
+    search_queries = tuple(_clean_text_list(turn.search_queries))
+    question = (
+        turn.question.strip() or "; ".join(search_queries) or f"Research turn {fallback_iteration}"
+    )
+    answer = turn.answer.strip() or _DEFAULT_RESEARCH_ANSWER
+    if not question and not answer and not search_queries:
+        return None
+    return _NormalizedResearchTurn(
+        iteration=turn.iteration or fallback_iteration,
+        batch_index=turn.batch_index,
+        question=question,
+        answer=answer,
+        search_queries=search_queries,
+    )
+
+
+def _normalize_legacy_turn(
+    entry: Mapping[str, object],
+    *,
+    fallback_iteration: int,
+) -> _NormalizedResearchTurn | None:
+    subqueries = _clean_text_list(entry.get("subqueries"))
+    search_queries = _clean_text_list(entry.get("search_queries")) or subqueries
+    question = _clean_text(entry.get("question")) or "; ".join(search_queries)
+    answer = _clean_text(entry.get("answer")) or _answer_from_legacy_turn(entry)
+    if not question:
+        question = f"Research turn {fallback_iteration}"
+    if not answer:
+        answer = _DEFAULT_RESEARCH_ANSWER
+    return _NormalizedResearchTurn(
+        iteration=_coerce_int(entry.get("iteration"), default=fallback_iteration),
+        batch_index=_coerce_int(entry.get("batch_index"), default=0),
+        question=question,
+        answer=answer,
+        search_queries=tuple(search_queries),
+    )
+
+
+def _answer_from_legacy_turn(entry: Mapping[str, object]) -> str:
+    gaps = entry.get("gaps")
+    if isinstance(gaps, Sequence) and not isinstance(gaps, str):
+        gap_parts = [_format_gap_item(item) for item in gaps]
+        gap_parts = [part for part in gap_parts if part]
+        if gap_parts:
+            return "Observed gaps: " + "; ".join(gap_parts)
+
+    digest_trace_id = entry.get("digest_trace_id")
+    if digest_trace_id is None:
+        digest_trace_id = entry.get("digest_id_if_any")
+    if digest_trace_id is not None:
+        return f"Context compaction digest recorded as {digest_trace_id}."
+
+    return _DEFAULT_RESEARCH_ANSWER
+
+
+def _format_gap_item(item: object) -> str:
+    if isinstance(item, Mapping):
+        topic = _clean_text(item.get("topic"))
+        reason = _clean_text(item.get("reason"))
+        if topic and reason:
+            return f"{topic} ({reason})"
+        return topic or reason
+    return _clean_text(item)
+
+
+def _clean_text(value: object) -> str:
+    if isinstance(value, str):
+        return " ".join(value.strip().split())
+    return ""
+
+
+def _clean_text_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    cleaned: list[str] = []
+    for item in value:
+        text = _clean_text(item)
+        if text:
+            cleaned.append(text)
+    return cleaned
+
+
+def _coerce_int(value: object, *, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
+def _format_research_dialogue(
+    turns: Sequence[_NormalizedResearchTurn],
+    *,
+    char_cap: int,
+) -> str:
+    if not turns:
+        return "No research trace available."
+
+    blocks = [
+        _format_turn_block(index=index, turn=turn) for index, turn in enumerate(turns, start=1)
+    ]
+    selected: list[str] = []
+    current_length = 0
+
+    for block in reversed(blocks):
+        separator_length = 2 if selected else 0
+        projected_length = current_length + len(block) + separator_length
+        if projected_length > char_cap and selected:
+            break
+        if not selected and len(block) > char_cap:
+            selected.append(block[-char_cap:])
+            current_length = len(selected[0])
+            break
+        selected.append(block)
+        current_length = projected_length
+
+    selected.reverse()
+    dialogue = "\n\n".join(selected)
+    if len(selected) < len(blocks):
+        prefix = "[... earlier turns omitted ...]\n\n"
+        available = max(char_cap - len(prefix), 0)
+        dialogue = prefix + dialogue[-available:]
+    return dialogue[-char_cap:]
+
+
+def _format_turn_block(*, index: int, turn: _NormalizedResearchTurn) -> str:
+    searched = "; ".join(turn.search_queries) if turn.search_queries else "(none)"
+    return "\n".join(
+        [
+            f"Turn {index} (iteration {turn.iteration}, batch {turn.batch_index}):",
+            f"  Q: {turn.question}",
+            f"  A: {turn.answer}",
+            f"  Searched: {searched}",
+        ]
+    )
+
+
+def _fallback_outline(heading: str) -> OutlineNode:
+    fallback_heading = heading.strip() or "Overview"
+    return OutlineNode(heading=fallback_heading, level=1)

--- a/autosearch/synthesis/report.py
+++ b/autosearch/synthesis/report.py
@@ -1,23 +1,48 @@
 # Self-written, plan v2.3 § 2 + § 13.5 M7
-import asyncio
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
 
 import structlog
 
-from autosearch.core.models import Evidence, Rubric, Section
+from autosearch.core.evidence import retrieve_for_section, split_all_evidence
+from autosearch.core.models import (
+    Evidence,
+    EvidenceSnippet,
+    OutlineNode,
+    ResearchTurn,
+    Rubric,
+    Section,
+)
 from autosearch.llm.client import LLMClient
-from autosearch.synthesis.citation import CitationRenderer
-from autosearch.synthesis.outline import OutlineGenerator
+from autosearch.synthesis.citation import CitationRenderer, scrub_invalid_inline_citations
+from autosearch.synthesis.outline import draft_outline, refine_outline
 from autosearch.synthesis.section import SectionWriter
+
+_INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
+_EMPTY_SECTION_FALLBACK = "No evidence was available for this section."
+
+
+@dataclass(frozen=True)
+class Report:
+    title: str
+    outline: OutlineNode
+    sections: list[Section]
+    content: str
+    ref_table: dict[int, Evidence]
+    markdown: str
 
 
 class ReportSynthesizer:
+    SECTION_TOP_K = 15
+
     def __init__(
         self,
-        outline_generator: OutlineGenerator | None = None,
         section_writer: SectionWriter | None = None,
         citation_renderer: CitationRenderer | None = None,
     ) -> None:
-        self.outline_generator = outline_generator or OutlineGenerator()
         self.section_writer = section_writer or SectionWriter()
         self.citation_renderer = citation_renderer or CitationRenderer()
         self.logger = structlog.get_logger(__name__).bind(component="report_synthesizer")
@@ -26,37 +51,219 @@ class ReportSynthesizer:
         self,
         query: str,
         evidences: list[Evidence],
-        rubrics: list[Rubric],
+        rubrics: list[Rubric] | None,
         client: LLMClient,
-    ) -> str:
+        *,
+        research_trace: list[ResearchTurn] | list[dict] | None = None,
+    ) -> Report:
+        rubrics = rubrics or []
+        normalized_research_trace = research_trace or []
         self.logger.info(
             "report_synthesis_started",
             query=query,
             evidences=len(evidences),
             rubrics=len(rubrics),
+            research_turns=len(normalized_research_trace),
         )
-        headings = await self.outline_generator.outline(query, evidences, client)
-        sections = await asyncio.gather(
-            *[self.section_writer.write_section(heading, evidences, client) for heading in headings]
-        )
+
+        draft = await draft_outline(query, client)
+        outline = await refine_outline(query, draft, normalized_research_trace, client)
+        all_snippets = split_all_evidence(evidences)
+        snippet_ref_table = _build_snippet_ref_table(all_snippets, evidences)
+        snippet_ids = {
+            _snippet_identity(snippet): index for index, snippet in enumerate(all_snippets, start=1)
+        }
+
+        sections: list[Section] = []
+        for node in outline.walk_leaves():
+            if not node.heading.strip():
+                continue
+            section_query = _section_query_for_node(node)
+            selected = retrieve_for_section(
+                section_query,
+                all_snippets,
+                top_k=self.SECTION_TOP_K,
+            )
+            self.logger.info(
+                "section_retrieval",
+                heading=node.heading,
+                section_query=section_query,
+                snippets_selected=len(selected),
+            )
+            section = await self.section_writer.write_section_from_snippets(
+                node=node,
+                snippets=selected,
+                topic=query,
+                client=client,
+            )
+            section = _rewrite_section_to_global_snippet_ids(
+                section=section,
+                selected=selected,
+                snippet_ids=snippet_ids,
+            )
+            if not section.content.strip():
+                section = section.model_copy(
+                    update={"content": _EMPTY_SECTION_FALLBACK, "ref_ids": []}
+                )
+            self.logger.info(
+                "section_writer",
+                heading=section.heading,
+                ref_ids_count=len(section.ref_ids),
+            )
+            sections.append(section)
+
+        if not sections:
+            sections = [
+                Section(
+                    heading=query.strip() or "Overview",
+                    content=_EMPTY_SECTION_FALLBACK,
+                    ref_ids=[],
+                )
+            ]
+
         remapped_sections, remapped_evidences = self.citation_renderer.remap_citations(
             sections,
-            evidences,
+            _ordered_snippet_evidences(all_snippets, snippet_ref_table),
         )
-        section_markdown = "\n\n".join(_render_section(section) for section in remapped_sections)
-        references = self.citation_renderer.render_references(remapped_evidences)
-        sources = self.citation_renderer.sources_breakdown(remapped_evidences)
-        report = "\n\n".join(part for part in [section_markdown, references, sources] if part)
+        content = "\n\n".join(_render_section(section) for section in remapped_sections)
+        remapped_ref_table = {
+            index: evidence for index, evidence in enumerate(remapped_evidences, start=1)
+        }
+        final_content, final_ref_table = self.citation_renderer.renumber_by_first_appearance(
+            content,
+            remapped_ref_table,
+        )
+        references = self.citation_renderer.render_references(list(final_ref_table.values()))
+        sources = self.citation_renderer.sources_breakdown(list(final_ref_table.values()))
+        markdown = "\n\n".join(part for part in [final_content, references, sources] if part)
+
         self.logger.info(
-            "report_synthesis_completed",
-            headings=len(headings),
+            "report_synthesized",
             sections=len(remapped_sections),
-            cited_evidences=len(remapped_evidences),
+            total_evidence=len(evidences),
+            total_snippets=len(all_snippets),
+            ref_table_size=len(final_ref_table),
         )
-        return report
+        return Report(
+            title=query,
+            outline=outline,
+            sections=remapped_sections,
+            content=final_content,
+            ref_table=final_ref_table,
+            markdown=markdown,
+        )
 
 
 def _render_section(section: Section) -> str:
     if section.content:
         return f"## {section.heading}\n\n{section.content}"
     return f"## {section.heading}"
+
+
+def _section_query_for_node(node: OutlineNode) -> str:
+    headings = node.get_subtree_headings()
+    section_query = " ".join(heading for heading in headings if heading.strip())
+    return section_query or node.heading
+
+
+def _rewrite_section_to_global_snippet_ids(
+    *,
+    section: Section,
+    selected: list[EvidenceSnippet],
+    snippet_ids: dict[tuple[str, int, str, str], int],
+) -> Section:
+    if not selected:
+        return section.model_copy(update={"content": "", "ref_ids": []})
+
+    scrubbed_content = scrub_invalid_inline_citations(section.content, valid_ids=section.ref_ids)
+    local_to_global = {
+        local_index: snippet_ids[_snippet_identity(snippet)]
+        for local_index, snippet in enumerate(selected, start=1)
+    }
+
+    def replacer(match: re.Match[str]) -> str:
+        local_ref_id = int(match.group(1))
+        global_ref_id = local_to_global.get(local_ref_id)
+        if global_ref_id is None:
+            return ""
+        return f"[{global_ref_id}]"
+
+    rewritten_content = _INLINE_CITATION_RE.sub(replacer, scrubbed_content)
+    rewritten_content = re.sub(r"[ \t]{2,}", " ", rewritten_content)
+    rewritten_content = re.sub(r"[ \t]+([,.])", r"\1", rewritten_content)
+    rewritten_content = re.sub(r"[ \t]+(?=\n)", "", rewritten_content)
+    rewritten_content = re.sub(r"[ \t]+$", "", rewritten_content)
+    rewritten_ref_ids = [
+        local_to_global[ref_id] for ref_id in section.ref_ids if ref_id in local_to_global
+    ]
+
+    return section.model_copy(
+        update={
+            "content": rewritten_content.strip(),
+            "ref_ids": _dedup_ints(rewritten_ref_ids),
+        }
+    )
+
+
+def _ordered_snippet_evidences(
+    snippets: list[EvidenceSnippet],
+    snippet_ref_table: dict[int, Evidence],
+) -> list[Evidence]:
+    return [snippet_ref_table[index] for index in range(1, len(snippets) + 1)]
+
+
+def _build_snippet_ref_table(
+    snippets: list[EvidenceSnippet],
+    evidences: list[Evidence],
+) -> dict[int, Evidence]:
+    evidence_by_id = {_evidence_lookup_key(evidence): evidence for evidence in evidences}
+    fallback_fetched_at = evidences[0].fetched_at if evidences else None
+
+    ref_table: dict[int, Evidence] = {}
+    for index, snippet in enumerate(snippets, start=1):
+        evidence = evidence_by_id.get(snippet.evidence_id)
+        if evidence is None:
+            evidence = Evidence(
+                url=snippet.source_url,
+                title=snippet.source_title or "Untitled",
+                snippet=snippet.text,
+                content=snippet.text,
+                source_channel="unknown",
+                fetched_at=fallback_fetched_at or _fallback_timestamp(),
+            )
+        ref_table[index] = evidence
+    return ref_table
+
+
+def _evidence_lookup_key(evidence: Evidence) -> str:
+    if evidence.url:
+        return evidence.url
+    preview = (evidence.content or evidence.snippet or "")[:100]
+    payload = f"{evidence.title}\n{preview}"
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _snippet_identity(snippet: EvidenceSnippet) -> tuple[str, int, str, str]:
+    return (
+        snippet.evidence_id,
+        snippet.offset,
+        snippet.source_url,
+        snippet.text,
+    )
+
+
+def _dedup_ints(values: list[int]) -> list[int]:
+    seen: set[int] = set()
+    deduped: list[int] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _fallback_timestamp():
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC)

--- a/autosearch/synthesis/report.py
+++ b/autosearch/synthesis/report.py
@@ -17,7 +17,11 @@ from autosearch.core.models import (
     Section,
 )
 from autosearch.llm.client import LLMClient
-from autosearch.synthesis.citation import CitationRenderer, scrub_invalid_inline_citations
+from autosearch.synthesis.citation import (
+    CitationRenderer,
+    apply_to_prose,
+    scrub_invalid_inline_citations,
+)
 from autosearch.synthesis.outline import draft_outline, refine_outline
 from autosearch.synthesis.section import SectionWriter
 
@@ -188,11 +192,11 @@ def _rewrite_section_to_global_snippet_ids(
             return ""
         return f"[{global_ref_id}]"
 
-    rewritten_content = _INLINE_CITATION_RE.sub(replacer, scrubbed_content)
-    rewritten_content = re.sub(r"[ \t]{2,}", " ", rewritten_content)
-    rewritten_content = re.sub(r"[ \t]+([,.])", r"\1", rewritten_content)
-    rewritten_content = re.sub(r"[ \t]+(?=\n)", "", rewritten_content)
-    rewritten_content = re.sub(r"[ \t]+$", "", rewritten_content)
+    rewritten_content = apply_to_prose(
+        scrubbed_content,
+        lambda text: _INLINE_CITATION_RE.sub(replacer, text),
+    )
+    rewritten_content = apply_to_prose(rewritten_content, _normalize_citation_spacing)
     rewritten_ref_ids = [
         local_to_global[ref_id] for ref_id in section.ref_ids if ref_id in local_to_global
     ]
@@ -261,6 +265,14 @@ def _dedup_ints(values: list[int]) -> list[int]:
         seen.add(value)
         deduped.append(value)
     return deduped
+
+
+def _normalize_citation_spacing(text: str) -> str:
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    text = re.sub(r"[ \t]+([,.])", r"\1", text)
+    text = re.sub(r"[ \t]+(?=\n)", "", text)
+    text = re.sub(r"[ \t]+$", "", text)
+    return text
 
 
 def _fallback_timestamp():

--- a/autosearch/synthesis/report.py
+++ b/autosearch/synthesis/report.py
@@ -244,7 +244,7 @@ def _evidence_lookup_key(evidence: Evidence) -> str:
         return evidence.url
     preview = (evidence.content or evidence.snippet or "")[:100]
     payload = f"{evidence.title}\n{preview}"
-    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _snippet_identity(snippet: EvidenceSnippet) -> tuple[str, int, str, str]:

--- a/autosearch/synthesis/section.py
+++ b/autosearch/synthesis/section.py
@@ -4,11 +4,15 @@ import re
 import structlog
 from pydantic import BaseModel, Field
 
-from autosearch.core.models import Evidence, Section
+from autosearch.core.models import Evidence, EvidenceSnippet, OutlineNode, Section
 from autosearch.llm.client import LLMClient
 from autosearch.skills.prompts import load_prompt
 
 SECTION_WRITE_PROMPT = load_prompt("m7_section_write")
+SECTION_WRITE_FROM_SNIPPETS_PROMPT = load_prompt("m7_section_write_v2")
+
+_MAX_SNIPPETS_PER_PROMPT = 12
+_MAX_SNIPPET_EXCERPT_CHARS = 600
 
 _INLINE_CITATION_RE = re.compile(r"\[(\d+)\]")
 
@@ -21,6 +25,48 @@ class _SectionWriteResponse(BaseModel):
 class SectionWriter:
     def __init__(self) -> None:
         self.logger = structlog.get_logger(__name__).bind(component="section_writer")
+
+    async def write_section_from_snippets(
+        self,
+        node: OutlineNode,
+        snippets: list[EvidenceSnippet],
+        topic: str,
+        client: LLMClient,
+    ) -> Section:
+        prompt_snippets = snippets[:_MAX_SNIPPETS_PER_PROMPT]
+        self.logger.info(
+            "section_write_started",
+            heading=node.heading,
+            snippets=len(snippets),
+            prompt_snippets=len(prompt_snippets),
+        )
+        if not prompt_snippets:
+            self.logger.info(
+                "section_write_completed",
+                heading=node.heading,
+                ref_ids=0,
+                prompt_snippets=0,
+            )
+            return Section(heading=node.heading, content="", ref_ids=[])
+
+        snippets_context, _ = _format_snippets_for_prompt(prompt_snippets)
+        prompt = SECTION_WRITE_FROM_SNIPPETS_PROMPT.format(
+            topic=topic,
+            section_heading=node.heading,
+            section_outline=_format_section_outline(node),
+            snippets_context=snippets_context,
+        )
+        response = await client.complete(prompt, _SectionWriteResponse)
+        content = _normalize_content(response.content, node.heading)
+        ref_ids = _normalize_ref_ids(content, response.ref_ids, len(prompt_snippets))
+        section = Section(heading=node.heading, content=content, ref_ids=ref_ids)
+        self.logger.info(
+            "section_write_completed",
+            heading=section.heading,
+            ref_ids=len(section.ref_ids),
+            prompt_snippets=len(prompt_snippets),
+        )
+        return section
 
     async def write_section(
         self,
@@ -77,6 +123,28 @@ def _normalize_ref_ids(content: str, ref_ids: list[int], evidence_count: int) ->
     return normalized
 
 
+def _format_section_outline(node: OutlineNode) -> str:
+    headings = node.get_subtree_headings()
+    if not headings:
+        return "- No local subsection context provided"
+    return "\n".join(f"- {heading}" for heading in headings)
+
+
+def _format_snippets_for_prompt(snippets: list[EvidenceSnippet]) -> tuple[str, list[str]]:
+    prompt_snippets = snippets[:_MAX_SNIPPETS_PER_PROMPT]
+    if not prompt_snippets:
+        return "- No snippets provided", []
+
+    formatted: list[str] = []
+    url_ordered_list: list[str] = []
+    for index, snippet in enumerate(prompt_snippets, start=1):
+        excerpt = _truncate_excerpt(snippet.text)
+        source_url = snippet.source_url or "unknown"
+        formatted.append(f'[{index}] "{excerpt}" (source: {source_url})')
+        url_ordered_list.append(source_url)
+    return "\n".join(formatted), url_ordered_list
+
+
 def _format_evidence(evidences: list[Evidence]) -> str:
     if not evidences:
         return "- No evidence provided"
@@ -96,3 +164,12 @@ def _format_evidence(evidences: list[Evidence]) -> str:
             )
         )
     return "\n\n".join(formatted)
+
+
+def _truncate_excerpt(text: str, limit: int = _MAX_SNIPPET_EXCERPT_CHARS) -> str:
+    normalized = " ".join(text.split())
+    if not normalized:
+        return "(no excerpt available)"
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[:limit].rstrip() + "..."

--- a/tests/integration/test_full_synthesis.py
+++ b/tests/integration/test_full_synthesis.py
@@ -1,0 +1,263 @@
+# Self-written for F306 full synthesis coverage
+import re
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import BaseModel
+
+from autosearch.core.models import Evidence
+from autosearch.synthesis.outline import OutlineResponse
+from autosearch.synthesis.report import ReportSynthesizer
+import autosearch.synthesis.report as report_module
+
+NOW = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+OUTLINE_MARKDOWN = "# Intro\n# Methods\n# Results\n# Conclusion"
+
+
+class FakeLLMClient:
+    def __init__(
+        self,
+        *,
+        draft_markdown: str = OUTLINE_MARKDOWN,
+        refine_markdown: str = OUTLINE_MARKDOWN,
+        section_payloads: list[dict[str, object]] | None = None,
+    ) -> None:
+        self.draft_markdown = draft_markdown
+        self.refine_markdown = refine_markdown
+        self.section_payloads = list(section_payloads or [])
+        self.prompts: list[str] = []
+        self.response_models: list[type[BaseModel]] = []
+        self.outline_calls = 0
+        self.section_calls = 0
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        self.prompts.append(prompt)
+        self.response_models.append(response_model)
+        if response_model is OutlineResponse:
+            self.outline_calls += 1
+            markdown = self.draft_markdown if self.outline_calls == 1 else self.refine_markdown
+            return response_model.model_validate({"markdown": markdown})
+
+        payload = self.section_payloads[self.section_calls]
+        self.section_calls += 1
+        return response_model.model_validate(payload)
+
+
+def make_evidence(index: int, *, url: str | None = None) -> Evidence:
+    return Evidence(
+        url=url or f"https://example.com/source-{index}",
+        title=f"Source {index}",
+        snippet=f"Evidence snippet {index}",
+        content=(
+            f"Evidence body {index} with intro methods results conclusion context and "
+            f"distinct facts for section retrieval."
+        ),
+        source_channel="web",
+        fetched_at=NOW,
+    )
+
+
+def make_research_trace() -> list[dict[str, object]]:
+    return [
+        {
+            "iteration": 1,
+            "batch_index": 1,
+            "subqueries": ["autosearch synthesis outline retrieval"],
+            "gaps": [],
+            "digest_id_if_any": None,
+        }
+    ]
+
+
+def install_retrieve_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    selections: list[list[int]],
+) -> list[tuple[str, int]]:
+    calls: list[tuple[str, int]] = []
+
+    def fake_retrieve(section_query: str, snippets, *, top_k: int):
+        call_index = len(calls)
+        calls.append((section_query, top_k))
+        selected_indexes = selections[call_index]
+        return [snippets[index] for index in selected_indexes if index < len(snippets)]
+
+    monkeypatch.setattr(report_module, "retrieve_for_section", fake_retrieve)
+    return calls
+
+
+def cited_numbers(content: str) -> list[int]:
+    return [int(match.group(1)) for match in re.finditer(r"\[(\d+)\]", content)]
+
+
+@pytest.mark.asyncio
+async def test_full_synthesis_produces_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeLLMClient(
+        section_payloads=[
+            {"content": "Intro section [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Methods section [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Results section [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Conclusion section [1] and [2].", "ref_ids": [1, 2]},
+        ]
+    )
+    evidences = [make_evidence(index) for index in range(1, 11)]
+    install_retrieve_stub(
+        monkeypatch,
+        selections=[[0, 1], [2, 3], [4, 5], [6, 7]],
+    )
+
+    report = await ReportSynthesizer().synthesize(
+        query="x",
+        evidences=evidences,
+        rubrics=[],
+        client=client,
+        research_trace=make_research_trace(),
+    )
+
+    assert [section.heading for section in report.sections] == [
+        "Intro",
+        "Methods",
+        "Results",
+        "Conclusion",
+    ]
+    assert report.content
+    assert report.ref_table
+    cited = cited_numbers(report.content)
+    assert cited
+    assert set(cited) <= set(report.ref_table)
+    assert all(number >= 1 for number in cited)
+    assert client.outline_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_full_synthesis_per_section_retrieval_happens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeLLMClient(
+        section_payloads=[
+            {"content": "Intro [1].", "ref_ids": [1]},
+            {"content": "Methods [1].", "ref_ids": [1]},
+            {"content": "Results [1].", "ref_ids": [1]},
+            {"content": "Conclusion [1].", "ref_ids": [1]},
+        ]
+    )
+    evidences = [make_evidence(index) for index in range(1, 6)]
+    calls = install_retrieve_stub(
+        monkeypatch,
+        selections=[[0], [1], [2], [3]],
+    )
+
+    report = await ReportSynthesizer().synthesize(
+        query="x",
+        evidences=evidences,
+        rubrics=[],
+        client=client,
+        research_trace=make_research_trace(),
+    )
+
+    assert len(calls) == len(list(report.outline.walk_leaves()))
+    assert [query for query, _ in calls] == ["Intro", "Methods", "Results", "Conclusion"]
+    assert all(top_k == ReportSynthesizer.SECTION_TOP_K for _, top_k in calls)
+
+
+@pytest.mark.asyncio
+async def test_full_synthesis_citation_renumber_is_monotonic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeLLMClient(
+        section_payloads=[
+            {"content": "Intro [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Methods [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Results [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Conclusion [1] and [2].", "ref_ids": [1, 2]},
+        ]
+    )
+    evidences = [make_evidence(index) for index in range(1, 7)]
+    install_retrieve_stub(
+        monkeypatch,
+        selections=[[0, 1], [1, 2], [2, 3], [3, 4]],
+    )
+
+    report = await ReportSynthesizer().synthesize(
+        query="x",
+        evidences=evidences,
+        rubrics=[],
+        client=client,
+        research_trace=make_research_trace(),
+    )
+
+    first_seen: list[int] = []
+    seen: set[int] = set()
+    for number in cited_numbers(report.content):
+        if number in seen:
+            continue
+        seen.add(number)
+        first_seen.append(number)
+
+    assert first_seen == list(range(1, len(first_seen) + 1))
+
+
+@pytest.mark.asyncio
+async def test_full_synthesis_handles_empty_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeLLMClient(section_payloads=[])
+    calls = install_retrieve_stub(
+        monkeypatch,
+        selections=[[], [], [], []],
+    )
+
+    report = await ReportSynthesizer().synthesize(
+        query="x",
+        evidences=[],
+        rubrics=[],
+        client=client,
+        research_trace=make_research_trace(),
+    )
+
+    assert report.content
+    assert "No evidence was available" in report.content
+    assert report.ref_table == {}
+    assert client.outline_calls == 2
+    assert client.section_calls == 0
+    assert len(calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_full_synthesis_uses_all_distinct_urls_in_ref_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeLLMClient(
+        section_payloads=[
+            {"content": "Intro [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Methods [1] and [2].", "ref_ids": [1, 2]},
+            {"content": "Results [1].", "ref_ids": [1]},
+            {"content": "Conclusion [1].", "ref_ids": [1]},
+        ]
+    )
+    evidences = [
+        make_evidence(1, url="https://example.com/shared"),
+        make_evidence(2, url="https://example.com/shared"),
+        make_evidence(3, url="https://example.com/unique-a"),
+        make_evidence(4, url="https://example.com/unique-b"),
+    ]
+    install_retrieve_stub(
+        monkeypatch,
+        selections=[[0, 2], [1, 3], [2], [3]],
+    )
+
+    report = await ReportSynthesizer().synthesize(
+        query="x",
+        evidences=evidences,
+        rubrics=[],
+        client=client,
+        research_trace=make_research_trace(),
+    )
+
+    cited_urls = [evidence.url for evidence in report.ref_table.values()]
+    assert cited_urls == [
+        "https://example.com/shared",
+        "https://example.com/unique-a",
+        "https://example.com/unique-b",
+    ]
+    assert len(cited_urls) == len(set(cited_urls))

--- a/tests/integration/test_full_synthesis.py
+++ b/tests/integration/test_full_synthesis.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import BaseModel
 
-from autosearch.core.models import Evidence
+from autosearch.core.models import Evidence, EvidenceSnippet, Section
 from autosearch.synthesis.outline import OutlineResponse
 from autosearch.synthesis.report import ReportSynthesizer
 import autosearch.synthesis.report as report_module
@@ -88,6 +88,35 @@ def install_retrieve_stub(
 
 def cited_numbers(content: str) -> list[int]:
     return [int(match.group(1)) for match in re.finditer(r"\[(\d+)\]", content)]
+
+
+def test_report_local_to_global_rewrite_skips_code_blocks() -> None:
+    section = Section(
+        heading="Claim",
+        content="Claim [1].\n```\nmatrix[1]\n```\nDone.",
+        ref_ids=[1],
+    )
+    selected = [
+        EvidenceSnippet(
+            evidence_id="evidence-2",
+            text="Second snippet",
+            offset=1,
+            source_url="https://example.com/2",
+            source_title="Source 2",
+        )
+    ]
+    snippet_ids = {
+        report_module._snippet_identity(selected[0]): 2,
+    }
+
+    rewritten = report_module._rewrite_section_to_global_snippet_ids(
+        section=section,
+        selected=selected,
+        snippet_ids=snippet_ids,
+    )
+
+    assert rewritten.content == "Claim [2].\n```\nmatrix[1]\n```\nDone."
+    assert rewritten.ref_ids == [2]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -123,6 +123,12 @@ async def test_pipeline_run_produces_report_and_quality_pass() -> None:
                 ),
             ),
             CompletionStep(
+                response_model=OutlineResponse,
+                payload=OutlineResponse(headings=["Overview", "Practical Takeaways"]).model_dump(
+                    mode="json"
+                ),
+            ),
+            CompletionStep(
                 response_model=_SectionWriteResponse,
                 payload=_SectionWriteResponse(
                     content=(

--- a/tests/integration/test_pipeline_with_session.py
+++ b/tests/integration/test_pipeline_with_session.py
@@ -120,6 +120,12 @@ async def test_pipeline_run_records_session_queries_evidence_and_cost() -> None:
                 ),
             ),
             CompletionStep(
+                response_model=OutlineResponse,
+                payload=OutlineResponse(headings=["Overview", "Practical Takeaways"]).model_dump(
+                    mode="json"
+                ),
+            ),
+            CompletionStep(
                 response_model=_SectionWriteResponse,
                 payload=_SectionWriteResponse(
                     content=(

--- a/tests/unit/core/test_evidence_snippet_retrieval.py
+++ b/tests/unit/core/test_evidence_snippet_retrieval.py
@@ -1,0 +1,229 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import datetime
+
+from autosearch.core.evidence import (
+    EvidenceProcessor,
+    retrieve_for_section,
+    split_all_evidence,
+    split_into_snippets,
+)
+from autosearch.core.models import Evidence, EvidenceSnippet
+
+NOW = datetime(2026, 4, 20, 12, 0, 0)
+
+
+def make_evidence(
+    url: str = "https://example.com/source",
+    title: str = "Example source",
+    *,
+    snippet: str | None = None,
+    content: str | None = None,
+) -> Evidence:
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=content,
+        source_channel="web",
+        fetched_at=NOW,
+    )
+
+
+def make_snippet(
+    evidence_id: str,
+    text: str,
+    offset: int = 0,
+    source_url: str = "https://example.com/source",
+    source_title: str = "Example source",
+) -> EvidenceSnippet:
+    return EvidenceSnippet(
+        evidence_id=evidence_id,
+        text=text,
+        offset=offset,
+        source_url=source_url,
+        source_title=source_title,
+    )
+
+
+def _words(count: int, prefix: str = "word") -> str:
+    return " ".join(f"{prefix}{index}" for index in range(count))
+
+
+def test_split_into_snippets_short_text_one_chunk() -> None:
+    text = _words(50)
+    evidence = make_evidence(content=text)
+
+    snippets = split_into_snippets(evidence)
+
+    assert len(snippets) == 1
+    assert snippets[0].text == text
+    assert snippets[0].offset == 0
+
+
+def test_split_into_snippets_long_text_multiple_chunks() -> None:
+    evidence = make_evidence(content=_words(600))
+
+    snippets = split_into_snippets(evidence, window_tokens=200, overlap_tokens=40)
+
+    assert 3 <= len(snippets) <= 5
+    assert [snippet.offset for snippet in snippets] == sorted(
+        snippet.offset for snippet in snippets
+    )
+
+
+def test_split_into_snippets_offsets_strictly_increasing() -> None:
+    evidence = make_evidence(content=_words(600))
+
+    snippets = split_into_snippets(evidence, window_tokens=200, overlap_tokens=40)
+
+    assert all(
+        left.offset < right.offset for left, right in zip(snippets, snippets[1:], strict=False)
+    )
+
+
+def test_split_into_snippets_cjk_character_based() -> None:
+    evidence = make_evidence(content="中" * 500)
+
+    snippets = split_into_snippets(evidence, window_tokens=200, overlap_tokens=40)
+
+    assert len(snippets) >= 3
+    assert all(len(snippet.text) <= 200 for snippet in snippets)
+    assert snippets[0].offset == 0
+    assert snippets[1].offset > snippets[0].offset
+
+
+def test_split_into_snippets_empty_content_returns_empty() -> None:
+    evidence = make_evidence(content="", snippet="")
+
+    assert split_into_snippets(evidence) == []
+
+
+def test_split_into_snippets_uses_snippet_when_content_empty() -> None:
+    fallback = _words(20, prefix="fallback")
+    evidence = make_evidence(content="", snippet=fallback)
+
+    snippets = split_into_snippets(evidence)
+
+    assert len(snippets) == 1
+    assert snippets[0].text == fallback
+
+
+def test_split_into_snippets_preserves_source_url_and_title() -> None:
+    evidence = make_evidence(
+        url="https://example.com/preserved",
+        title="Preserved title",
+        content=_words(300),
+    )
+
+    snippets = split_into_snippets(evidence, window_tokens=200, overlap_tokens=40)
+
+    assert snippets
+    assert all(snippet.source_url == evidence.url for snippet in snippets)
+    assert all(snippet.source_title == evidence.title for snippet in snippets)
+
+
+def test_split_into_snippets_missing_url_generates_stable_id() -> None:
+    evidence = make_evidence(url="", title="Stable id", content=_words(30))
+
+    first = split_into_snippets(evidence)
+    second = split_into_snippets(evidence)
+
+    assert len(first) == 1
+    assert first[0].evidence_id
+    assert first[0].evidence_id == second[0].evidence_id
+
+
+def test_retrieve_for_section_returns_top_k() -> None:
+    snippets = [
+        make_snippet(f"snippet-{index}", f"python async guide {index}", offset=index)
+        for index in range(10)
+    ]
+
+    ranked = retrieve_for_section("python async", snippets, top_k=3)
+
+    assert len(ranked) == 3
+
+
+def test_retrieve_for_section_empty_query_returns_empty() -> None:
+    snippets = [make_snippet("snippet-1", "python async guide")]
+
+    assert retrieve_for_section("   ", snippets) == []
+
+
+def test_retrieve_for_section_empty_snippets_returns_empty() -> None:
+    assert retrieve_for_section("python async", []) == []
+
+
+def test_retrieve_for_section_score_order() -> None:
+    snippets = [
+        make_snippet("a", "python async await event loop coroutine", offset=0),
+        make_snippet("b", "database transactions and indexing", offset=1),
+        make_snippet("c", "frontend css layout animation", offset=2),
+        make_snippet("d", "python packaging guide", offset=3),
+        make_snippet("e", "message queues and workers", offset=4),
+    ]
+
+    ranked = retrieve_for_section("python async", snippets, top_k=5)
+
+    assert ranked[0].evidence_id == "a"
+
+
+def test_retrieve_for_section_single_snippet_no_crash() -> None:
+    snippet = make_snippet("only", "python async guide")
+
+    assert retrieve_for_section("python async", [snippet]) == [snippet]
+
+
+def test_retrieve_for_section_cjk_query() -> None:
+    snippets = [
+        make_snippet("async", "Python异步编程使用协程和事件循环"),
+        make_snippet("db", "数据库索引优化和事务隔离"),
+        make_snippet("ui", "前端布局与动画设计"),
+    ]
+
+    ranked = retrieve_for_section("异步编程协程", snippets, top_k=3)
+
+    assert ranked[0].evidence_id == "async"
+
+
+def test_retrieve_for_section_top_k_zero_returns_all() -> None:
+    snippets = [
+        make_snippet("a", "python async guide", offset=0),
+        make_snippet("b", "database indexing guide", offset=1),
+        make_snippet("c", "css animation guide", offset=2),
+    ]
+
+    ranked = retrieve_for_section("guide", snippets, top_k=0)
+
+    assert len(ranked) == len(snippets)
+
+
+def test_split_all_evidence_flattens() -> None:
+    evidences = [
+        make_evidence(
+            url=f"https://example.com/{index}",
+            title=f"Evidence {index}",
+            content=_words(250, prefix=f"e{index}"),
+        )
+        for index in range(3)
+    ]
+
+    snippets = split_all_evidence(evidences, window_tokens=200, overlap_tokens=0)
+
+    assert len(snippets) == 6
+
+
+def test_evidence_processor_methods_delegate() -> None:
+    processor = EvidenceProcessor()
+    evidence = make_evidence(content=_words(300))
+    module_snippets = split_into_snippets(evidence, window_tokens=200, overlap_tokens=40)
+    method_snippets = processor.split_into_snippets(
+        evidence,
+        window_tokens=200,
+        overlap_tokens=40,
+    )
+
+    assert method_snippets == module_snippets
+    assert processor.retrieve_for_section("word1 word2", module_snippets, top_k=2) == (
+        retrieve_for_section("word1 word2", module_snippets, top_k=2)
+    )

--- a/tests/unit/synthesis/test_citation.py
+++ b/tests/unit/synthesis/test_citation.py
@@ -74,6 +74,22 @@ def test_scrub_handles_content_without_markers() -> None:
     assert scrubbed == content
 
 
+def test_scrub_preserves_bracket_digit_in_fenced_code() -> None:
+    content = "Prose [1] here [99].\n```python\narr[1]\narr[99]\n```\nMore [2]."
+
+    scrubbed = scrub_invalid_inline_citations(content, valid_ids={1, 2})
+
+    assert scrubbed == "Prose [1] here.\n```python\narr[1]\narr[99]\n```\nMore [2]."
+
+
+def test_scrub_preserves_bracket_digit_in_inline_code() -> None:
+    content = "Use `arr[5]` to access [1]."
+
+    scrubbed = scrub_invalid_inline_citations(content, valid_ids={1})
+
+    assert scrubbed == content
+
+
 def test_renumber_by_first_appearance_basic() -> None:
     content, ref_table = renumber_by_first_appearance(
         "[5] text [2] more [5]",
@@ -117,6 +133,26 @@ def test_renumber_empty_content_returns_empty_table() -> None:
 
     assert content == ""
     assert ref_table == {}
+
+
+def test_renumber_preserves_code_blocks() -> None:
+    content, ref_table = renumber_by_first_appearance(
+        "[5] first.\n```\ntest[5]test\n```\n[2] second.",
+        {2: "b", 5: "a"},
+    )
+
+    assert content == "[1] first.\n```\ntest[5]test\n```\n[2] second."
+    assert ref_table == {1: "a", 2: "b"}
+
+
+def test_renumber_preserves_inline_code() -> None:
+    content, ref_table = renumber_by_first_appearance(
+        "See [5] and `x[5]`.",
+        {5: "a"},
+    )
+
+    assert content == "See [1] and `x[5]`."
+    assert ref_table == {1: "a"}
 
 
 def test_renderer_scrubs_before_remap() -> None:

--- a/tests/unit/synthesis/test_citation.py
+++ b/tests/unit/synthesis/test_citation.py
@@ -1,0 +1,144 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import datetime
+
+from autosearch.core.models import Evidence, Section
+from autosearch.synthesis.citation import (
+    CitationRenderer,
+    renumber_by_first_appearance,
+    scrub_invalid_inline_citations,
+)
+
+NOW = datetime(2026, 4, 20, 12, 0, 0)
+
+
+def make_evidence(url: str, title: str, source_channel: str) -> Evidence:
+    return Evidence(
+        url=url,
+        title=title,
+        content="Detailed evidence body for synthesis.",
+        source_channel=source_channel,
+        fetched_at=NOW,
+    )
+
+
+def test_scrub_removes_unknown_markers() -> None:
+    content = "Foo [1] bar [99] baz [2]"
+
+    scrubbed = scrub_invalid_inline_citations(content, valid_ids={1, 2})
+
+    assert scrubbed == "Foo [1] bar baz [2]"
+
+
+def test_scrub_preserves_known_markers() -> None:
+    content = "[1] [2] [3]"
+
+    scrubbed = scrub_invalid_inline_citations(content, valid_ids={1, 2, 3})
+
+    assert scrubbed == content
+
+
+def test_scrub_collapses_double_spaces_after_deletion() -> None:
+    scrubbed = scrub_invalid_inline_citations("a [99] b", valid_ids={1, 2})
+
+    assert scrubbed == "a b"
+
+
+def test_scrub_empty_valid_ids_removes_all() -> None:
+    scrubbed = scrub_invalid_inline_citations("a [1] b [2]", valid_ids=set())
+
+    assert scrubbed == "a b"
+
+
+def test_scrub_preserves_newlines() -> None:
+    scrubbed = scrub_invalid_inline_citations("a\n[99]\nb", valid_ids=set())
+
+    assert scrubbed == "a\n\nb"
+
+
+def test_scrub_multi_digit_ids() -> None:
+    assert scrub_invalid_inline_citations("[12]", valid_ids={12}) == "[12]"
+    assert scrub_invalid_inline_citations("[12]", valid_ids={1, 2}) == ""
+
+
+def test_scrub_handles_adjacent_markers() -> None:
+    scrubbed = scrub_invalid_inline_citations("[1][99][2]", valid_ids={1, 2})
+
+    assert scrubbed == "[1][2]"
+
+
+def test_scrub_handles_content_without_markers() -> None:
+    content = "plain text"
+
+    scrubbed = scrub_invalid_inline_citations(content, valid_ids={1, 2, 3})
+
+    assert scrubbed == content
+
+
+def test_renumber_by_first_appearance_basic() -> None:
+    content, ref_table = renumber_by_first_appearance(
+        "[5] text [2] more [5]",
+        {2: "ref2", 5: "ref5", 7: "ref7"},
+    )
+
+    assert content == "[1] text [2] more [1]"
+    assert ref_table == {1: "ref5", 2: "ref2"}
+
+
+def test_renumber_preserves_unused_refs_absence() -> None:
+    content, ref_table = renumber_by_first_appearance(
+        "Only [2] is cited.",
+        {2: "ref2", 5: "ref5"},
+    )
+
+    assert content == "Only [1] is cited."
+    assert ref_table == {1: "ref2"}
+
+
+def test_renumber_stable_across_reorder() -> None:
+    once_content, once_ref_table = renumber_by_first_appearance(
+        "[5] text [2] more [5]",
+        {2: "ref2", 5: "ref5"},
+    )
+
+    twice_content, twice_ref_table = renumber_by_first_appearance(
+        once_content,
+        once_ref_table,
+    )
+
+    assert twice_content == once_content
+    assert twice_ref_table == once_ref_table
+
+
+def test_renumber_empty_content_returns_empty_table() -> None:
+    content, ref_table = renumber_by_first_appearance(
+        "",
+        {2: "ref2", 5: "ref5"},
+    )
+
+    assert content == ""
+    assert ref_table == {}
+
+
+def test_renderer_scrubs_before_remap() -> None:
+    renderer = CitationRenderer()
+    evidences = [
+        make_evidence("https://example.com/shared", "Shared source", "web"),
+        make_evidence("https://example.com/unique", "Unique source", "web"),
+        make_evidence("https://example.com/shared", "Shared source duplicate", "web"),
+    ]
+    sections = [
+        Section(heading="Findings", content="Alpha [3] extra [99] text.", ref_ids=[3]),
+        Section(heading="Background", content="Beta [2][42].", ref_ids=[2]),
+    ]
+
+    remapped_sections, remapped_evidences = renderer.remap_citations(sections, evidences)
+
+    assert sections[0].content == "Alpha [3] extra [99] text."
+    assert [evidence.url for evidence in remapped_evidences] == [
+        "https://example.com/shared",
+        "https://example.com/unique",
+    ]
+    assert remapped_sections[0].content == "Alpha [1] extra text."
+    assert remapped_sections[0].ref_ids == [1]
+    assert remapped_sections[1].content == "Beta [2]."
+    assert remapped_sections[1].ref_ids == [2]

--- a/tests/unit/synthesis/test_outline.py
+++ b/tests/unit/synthesis/test_outline.py
@@ -1,0 +1,138 @@
+# Self-written, plan v2.3 § W3 F302
+from pydantic import BaseModel
+
+from autosearch.core.models import OutlineNode, ResearchTurn
+from autosearch.synthesis.outline import OutlineResponse, draft_outline, refine_outline
+
+
+class FakeLLMClient:
+    def __init__(self, payloads: list[dict[str, object]]) -> None:
+        self.payloads = list(payloads)
+        self.calls = 0
+        self.prompts: list[str] = []
+        self.response_models: list[type[BaseModel]] = []
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        self.prompts.append(prompt)
+        self.response_models.append(response_model)
+        payload = self.payloads[self.calls]
+        self.calls += 1
+        return response_model.model_validate(payload)
+
+
+async def test_draft_outline_returns_tree_from_query() -> None:
+    client = FakeLLMClient([OutlineResponse(markdown="# A\n## A1\n# B").model_dump(mode="json")])
+
+    outline = await draft_outline("search tooling", client)
+
+    assert outline.heading == ""
+    assert outline.level == 0
+    assert [child.heading for child in outline.children] == ["A", "B"]
+    assert [child.heading for child in outline.children[0].children] == ["A1"]
+    assert client.response_models == [OutlineResponse]
+
+
+async def test_draft_outline_fallback_on_parse_failure() -> None:
+    client = FakeLLMClient([{"markdown": "garbage", "headings": []}])
+
+    outline = await draft_outline("search tooling", client)
+
+    assert outline == OutlineNode(heading="search tooling", level=1)
+
+
+async def test_refine_outline_accepts_dict_research_trace() -> None:
+    client = FakeLLMClient(
+        [OutlineResponse(markdown="# Final\n## Evidence").model_dump(mode="json")]
+    )
+    draft = OutlineNode(
+        heading="",
+        level=0,
+        children=[OutlineNode(heading="Draft", level=1)],
+    )
+    research_trace = [
+        {
+            "iteration": 1,
+            "batch_index": 0,
+            "subqueries": ["pricing comparison", "latency comparison"],
+            "gaps": [{"topic": "regional support", "reason": "coverage still missing"}],
+            "digest_id_if_any": 42,
+        }
+    ]
+
+    outline = await refine_outline("compare providers", draft, research_trace, client)
+
+    assert outline.heading == "Final"
+    assert [child.heading for child in outline.children] == ["Evidence"]
+    assert "Turn 1 (iteration 1, batch 0):" in client.prompts[0]
+    assert "Q: pricing comparison; latency comparison" in client.prompts[0]
+    assert "A: Observed gaps: regional support (coverage still missing)" in client.prompts[0]
+    assert "Searched: pricing comparison; latency comparison" in client.prompts[0]
+
+
+async def test_refine_outline_accepts_typed_research_trace() -> None:
+    client = FakeLLMClient(
+        [OutlineResponse(markdown="# Final\n## Coverage").model_dump(mode="json")]
+    )
+    draft = OutlineNode(heading="Draft", level=1)
+    research_trace = [
+        ResearchTurn(
+            iteration=2,
+            batch_index=1,
+            question="Which providers had current benchmarks?",
+            answer="Two providers had 2026 benchmark notes.",
+            search_queries=["provider benchmark 2026", "provider latency note"],
+            evidence_ids=["e-1", "e-2"],
+        )
+    ]
+
+    outline = await refine_outline("compare providers", draft, research_trace, client)
+
+    assert outline.heading == "Final"
+    assert [child.heading for child in outline.children] == ["Coverage"]
+    assert "Turn 1 (iteration 2, batch 1):" in client.prompts[0]
+    assert "Q: Which providers had current benchmarks?" in client.prompts[0]
+    assert "A: Two providers had 2026 benchmark notes." in client.prompts[0]
+    assert "Searched: provider benchmark 2026; provider latency note" in client.prompts[0]
+
+
+async def test_refine_outline_truncates_large_trace() -> None:
+    client = FakeLLMClient([OutlineResponse(markdown="# Final").model_dump(mode="json")])
+    draft = OutlineNode(heading="Draft", level=1)
+    research_trace = [
+        ResearchTurn(
+            iteration=index,
+            batch_index=index % 3,
+            question=f"Question {index} " + ("x" * 120),
+            answer=f"Answer {index} " + ("y" * 180),
+            search_queries=[f"query {index} " + ("z" * 80)],
+            evidence_ids=[f"e-{index}"],
+        )
+        for index in range(1, 101)
+    ]
+
+    outline = await refine_outline("compare providers", draft, research_trace, client)
+
+    assert outline.heading == "Final"
+    assert len(client.prompts[0]) < 9800
+    assert "Turn 100" in client.prompts[0]
+    assert "Turn 1 (iteration 1, batch 1):" not in client.prompts[0]
+
+
+async def test_refine_outline_preserves_draft_when_trace_empty() -> None:
+    client = FakeLLMClient([])
+    draft = OutlineNode(
+        heading="",
+        level=0,
+        children=[
+            OutlineNode(
+                heading="Overview",
+                level=1,
+                children=[OutlineNode(heading="History", level=2)],
+            )
+        ],
+    )
+
+    refined = await refine_outline("compare providers", draft, [], client)
+
+    assert refined == draft
+    assert client.prompts == []

--- a/tests/unit/synthesis/test_section.py
+++ b/tests/unit/synthesis/test_section.py
@@ -1,0 +1,161 @@
+# Self-written, plan v2.3 § 13.5
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from autosearch.core.models import Evidence, EvidenceSnippet, OutlineNode
+from autosearch.synthesis.section import SectionWriter
+
+NOW = datetime(2026, 4, 20, 12, 0, 0)
+
+
+class FakeLLMClient:
+    def __init__(
+        self,
+        *,
+        content: str = "Generated section [1].",
+        ref_ids: list[int] | None = None,
+    ) -> None:
+        self.calls = 0
+        self.prompts: list[str] = []
+        self.content = content
+        self.ref_ids = ref_ids or []
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        self.calls += 1
+        self.prompts.append(prompt)
+        payload = {"content": self.content}
+        if "ref_ids" in response_model.model_fields:
+            payload["ref_ids"] = self.ref_ids
+        return response_model.model_validate(payload)
+
+
+def make_snippet(index: int, text: str | None = None) -> EvidenceSnippet:
+    return EvidenceSnippet(
+        evidence_id=f"ev-{index}",
+        text=text or f"Snippet text {index}",
+        offset=0,
+        source_url=f"https://example.com/{index}",
+        source_title=f"Source {index}",
+    )
+
+
+def make_evidence(index: int) -> Evidence:
+    return Evidence(
+        url=f"https://example.com/evidence/{index}",
+        title=f"Evidence {index}",
+        content=f"Evidence body {index}",
+        source_channel="web",
+        fetched_at=NOW,
+    )
+
+
+async def test_write_section_from_snippets_basic() -> None:
+    client = FakeLLMClient(
+        content="Python async is cool [1]. BM25 is a ranking function [3].",
+    )
+    node = OutlineNode(heading="Overview", level=2)
+    snippets = [make_snippet(1), make_snippet(2), make_snippet(3)]
+
+    section = await SectionWriter().write_section_from_snippets(
+        node=node,
+        snippets=snippets,
+        topic="Compare search tooling",
+        client=client,
+    )
+
+    assert section.heading == "Overview"
+    assert section.content == "Python async is cool [1]. BM25 is a ranking function [3]."
+    assert section.ref_ids == [1, 3]
+
+
+async def test_write_section_from_snippets_passes_outline_to_prompt() -> None:
+    client = FakeLLMClient()
+    node = OutlineNode(
+        heading="Approach",
+        level=2,
+        children=[
+            OutlineNode(heading="Retrieval", level=3),
+            OutlineNode(heading="Synthesis", level=3),
+        ],
+    )
+
+    await SectionWriter().write_section_from_snippets(
+        node=node,
+        snippets=[make_snippet(1)],
+        topic="Compare search tooling",
+        client=client,
+    )
+
+    prompt = client.prompts[0]
+    assert "Approach" in prompt
+    assert "Approach > Retrieval" in prompt
+    assert "Approach > Synthesis" in prompt
+
+
+async def test_write_section_from_snippets_caps_snippet_count() -> None:
+    client = FakeLLMClient()
+    snippets = [make_snippet(index) for index in range(1, 21)]
+
+    await SectionWriter().write_section_from_snippets(
+        node=OutlineNode(heading="Overview", level=2),
+        snippets=snippets,
+        topic="Compare search tooling",
+        client=client,
+    )
+
+    prompt = client.prompts[0]
+    assert "[12]" in prompt
+    assert "[13]" not in prompt
+    assert "https://example.com/12" in prompt
+    assert "https://example.com/13" not in prompt
+
+
+async def test_write_section_from_snippets_truncates_long_snippet_text() -> None:
+    client = FakeLLMClient()
+    long_text = "x" * 5000
+
+    await SectionWriter().write_section_from_snippets(
+        node=OutlineNode(heading="Overview", level=2),
+        snippets=[make_snippet(1, text=long_text)],
+        topic="Compare search tooling",
+        client=client,
+    )
+
+    prompt = client.prompts[0]
+    assert f'"{"x" * 600}..."' in prompt
+    assert f'"{"x" * 601}' not in prompt
+
+
+async def test_write_section_from_snippets_handles_empty_snippets() -> None:
+    client = FakeLLMClient()
+
+    section = await SectionWriter().write_section_from_snippets(
+        node=OutlineNode(heading="Overview", level=2),
+        snippets=[],
+        topic="Compare search tooling",
+        client=client,
+    )
+
+    assert section.heading == "Overview"
+    assert section.content == ""
+    assert section.ref_ids == []
+    assert client.calls == 0
+
+
+async def test_write_section_preserves_old_signature_still_works() -> None:
+    client = FakeLLMClient(
+        content="## Background\nLegacy section body [1].",
+        ref_ids=[1],
+    )
+
+    section = await SectionWriter().write_section(
+        heading="Background",
+        evidences=[make_evidence(1)],
+        client=client,
+    )
+
+    assert section.heading == "Background"
+    assert section.content == "Legacy section body [1]."
+    assert section.ref_ids == [1]
+    assert client.calls == 1

--- a/tests/unit/test_evidence_snippet.py
+++ b/tests/unit/test_evidence_snippet.py
@@ -1,0 +1,41 @@
+# Self-written, plan v2.3 § 13.5 F301
+import pytest
+from pydantic import ValidationError
+
+from autosearch.core.models import EvidenceSnippet
+
+
+def test_evidence_snippet_roundtrip() -> None:
+    snippet = EvidenceSnippet(
+        evidence_id="session-evidence-1",
+        text="Chunked evidence body.",
+        offset=128,
+        source_url="https://example.com/source",
+        source_title="Example Source",
+    )
+
+    payload = snippet.model_dump_json()
+    restored = EvidenceSnippet.model_validate_json(payload)
+
+    assert restored == snippet
+
+
+def test_evidence_snippet_offset_non_negative() -> None:
+    with pytest.raises(ValidationError):
+        EvidenceSnippet(
+            evidence_id="session-evidence-1",
+            text="Chunked evidence body.",
+            offset=-1,
+            source_url="https://example.com/source",
+        )
+
+
+def test_evidence_snippet_default_source_title_empty() -> None:
+    snippet = EvidenceSnippet(
+        evidence_id="session-evidence-2",
+        text="Chunked evidence body.",
+        offset=0,
+        source_url="https://example.com/source",
+    )
+
+    assert snippet.source_title == ""

--- a/tests/unit/test_outline_node.py
+++ b/tests/unit/test_outline_node.py
@@ -1,0 +1,162 @@
+# Self-written, plan v2.3 § 13.5 F301
+from autosearch.core.models import OutlineNode, parse_markdown_outline
+
+
+def make_outline_tree() -> OutlineNode:
+    return OutlineNode(
+        heading="Parent",
+        level=1,
+        children=[
+            OutlineNode(
+                heading="Child A",
+                level=2,
+                children=[
+                    OutlineNode(
+                        heading="Grandchild A1",
+                        level=3,
+                    )
+                ],
+            ),
+            OutlineNode(
+                heading="Child B",
+                level=2,
+                children=[
+                    OutlineNode(
+                        heading="Grandchild B1",
+                        level=3,
+                    )
+                ],
+            ),
+        ],
+    )
+
+
+def test_outline_node_basic_roundtrip() -> None:
+    node = OutlineNode(heading="Overview", level=1)
+
+    payload = node.model_dump_json()
+    restored = OutlineNode.model_validate_json(payload)
+
+    assert restored == node
+    assert restored.children == []
+    assert restored.section_query is None
+
+
+def test_outline_node_nested_roundtrip() -> None:
+    node = OutlineNode(
+        heading="Overview",
+        level=1,
+        children=[
+            OutlineNode(
+                heading="Background",
+                level=2,
+                children=[OutlineNode(heading="Timeline", level=3)],
+            )
+        ],
+    )
+
+    payload = node.model_dump_json()
+    restored = OutlineNode.model_validate_json(payload)
+
+    assert restored == node
+    assert restored.children[0].children[0].heading == "Timeline"
+
+
+def test_get_subtree_headings_flat() -> None:
+    node = OutlineNode(heading="Overview", level=1)
+
+    assert node.get_subtree_headings() == ["Overview"]
+
+
+def test_get_subtree_headings_nested() -> None:
+    node = make_outline_tree()
+
+    assert node.get_subtree_headings() == [
+        "Parent",
+        "Parent > Child A",
+        "Parent > Child A > Grandchild A1",
+        "Parent > Child B",
+        "Parent > Child B > Grandchild B1",
+    ]
+
+
+def test_get_subtree_headings_with_root_name() -> None:
+    node = OutlineNode(
+        heading="Overview",
+        level=1,
+        children=[OutlineNode(heading="History", level=2)],
+    )
+
+    assert node.get_subtree_headings(root_name="Topic") == [
+        "Topic > Overview",
+        "Topic > Overview > History",
+    ]
+
+
+def test_walk_leaves() -> None:
+    node = make_outline_tree()
+
+    assert [leaf.heading for leaf in node.walk_leaves()] == [
+        "Grandchild A1",
+        "Grandchild B1",
+    ]
+
+
+def test_walk_depth_first() -> None:
+    node = make_outline_tree()
+
+    assert [current.heading for current in node.walk_depth_first()] == [
+        "Parent",
+        "Child A",
+        "Grandchild A1",
+        "Child B",
+        "Grandchild B1",
+    ]
+
+
+def test_parse_markdown_outline_single_level() -> None:
+    outline = parse_markdown_outline("# A\n# B")
+
+    assert outline.heading == ""
+    assert outline.level == 0
+    assert [child.heading for child in outline.children] == ["A", "B"]
+
+
+def test_parse_markdown_outline_nested() -> None:
+    outline = parse_markdown_outline("# A\n## A1\n## A2\n# B")
+
+    assert outline.heading == ""
+    assert outline.level == 0
+    assert [child.heading for child in outline.children] == ["A", "B"]
+    assert [child.heading for child in outline.children[0].children] == ["A1", "A2"]
+    assert outline.children[1].children == []
+
+
+def test_parse_markdown_outline_no_hash_fallback() -> None:
+    outline = parse_markdown_outline("Alpha\n\nBeta\nGamma")
+
+    assert outline.heading == ""
+    assert outline.level == 0
+    assert [child.heading for child in outline.children] == ["Alpha", "Beta", "Gamma"]
+    assert all(child.level == 1 for child in outline.children)
+
+
+def test_parse_markdown_outline_empty() -> None:
+    outline = parse_markdown_outline("")
+
+    assert outline == OutlineNode(heading="", level=0, children=[])
+
+
+def test_parse_markdown_outline_handles_mixed_whitespace_and_blank_lines() -> None:
+    outline = parse_markdown_outline("   # A   \n\n\n  ## A1  ")
+
+    assert outline.heading == "A"
+    assert outline.level == 1
+    assert [child.heading for child in outline.children] == ["A1"]
+
+
+def test_parse_markdown_outline_skips_non_heading_lines() -> None:
+    outline = parse_markdown_outline("# A\nparagraph\n## A1")
+
+    assert outline.heading == "A"
+    assert [child.heading for child in outline.children] == ["A1"]

--- a/tests/unit/test_pipeline_channel_error.py
+++ b/tests/unit/test_pipeline_channel_error.py
@@ -85,6 +85,7 @@ async def test_pipeline_continues_after_channel_error_and_emits_error_event() ->
             },
             {"gaps": []},
             {"headings": ["Overview"]},
+            {"headings": ["Overview"]},
             {"content": "Working evidence supports the answer [1].", "ref_ids": [1]},
             {"grade": "pass", "follow_up_gaps": []},
         ]

--- a/tests/unit/test_pipeline_channel_scope.py
+++ b/tests/unit/test_pipeline_channel_scope.py
@@ -66,6 +66,7 @@ def _pipeline_payloads() -> list[dict[str, object]]:
         },
         {"gaps": []},
         {"headings": ["Overview"]},
+        {"headings": ["Overview"]},
         {"content": "Scoped channels returned evidence [1].", "ref_ids": [1]},
         {"grade": "pass", "follow_up_gaps": []},
     ]

--- a/tests/unit/test_pipeline_events.py
+++ b/tests/unit/test_pipeline_events.py
@@ -91,6 +91,7 @@ def make_pipeline(on_event=None) -> Pipeline:
             },
             {"gaps": []},
             {"headings": ["Overview"]},
+            {"headings": ["Overview"]},
             {"content": "Streaming is available through the callback path [1].", "ref_ids": [1]},
             {"grade": "pass", "follow_up_gaps": []},
         ]
@@ -169,7 +170,7 @@ async def test_pipeline_result_includes_channel_empty_calls() -> None:
             },
             {"gaps": []},
             {"headings": ["Overview"]},
-            {"content": "The channel produced no evidence in this run.", "ref_ids": []},
+            {"headings": ["Overview"]},
             {"grade": "pass", "follow_up_gaps": []},
         ]
     )

--- a/tests/unit/test_pipeline_tokens.py
+++ b/tests/unit/test_pipeline_tokens.py
@@ -118,6 +118,12 @@ async def test_pipeline_populates_token_counts_from_cost_tracker_breakdown() -> 
                 ),
             ),
             CompletionStep(
+                response_model=OutlineResponse,
+                payload=OutlineResponse(headings=["Overview", "Practical Takeaways"]).model_dump(
+                    mode="json"
+                ),
+            ),
+            CompletionStep(
                 response_model=_SectionWriteResponse,
                 payload=_SectionWriteResponse(
                     content=(

--- a/tests/unit/test_research_turn.py
+++ b/tests/unit/test_research_turn.py
@@ -1,0 +1,44 @@
+# Self-written, plan v2.3 § 13.5 F301
+from autosearch.core.models import ResearchTurn
+
+
+def test_research_turn_minimum_fields() -> None:
+    turn = ResearchTurn(
+        iteration=1,
+        question="What changed in the API?",
+        answer="The release adds a new endpoint and updates auth guidance.",
+    )
+
+    assert turn.batch_index == 0
+    assert turn.perspective is None
+    assert turn.search_queries == []
+    assert turn.evidence_ids == []
+    assert turn.digest_trace_id is None
+
+
+def test_research_turn_full_fields() -> None:
+    turn = ResearchTurn(
+        iteration=2,
+        batch_index=1,
+        perspective="security reviewer",
+        question="Are there migration risks?",
+        answer="The docs mention a deprecation window and fallback path.",
+        search_queries=["api migration risks", "deprecation window"],
+        evidence_ids=["https://example.com/guide", "session-evidence-2"],
+        digest_trace_id=42,
+    )
+
+    payload = turn.model_dump_json()
+    restored = ResearchTurn.model_validate_json(payload)
+
+    assert restored == turn
+
+
+def test_research_turn_perspective_default_none() -> None:
+    turn = ResearchTurn(
+        iteration=3,
+        question="What does the changelog say?",
+        answer="The changelog confirms the feature is GA.",
+    )
+
+    assert turn.perspective is None

--- a/tests/unit/test_synthesis.py
+++ b/tests/unit/test_synthesis.py
@@ -49,12 +49,15 @@ async def test_report_synthesizer_outputs_sections_references_and_sources() -> N
         client,
     )
 
-    assert "## Overview" in report
-    assert "## References" in report
-    assert re.search(r"\[1\].*https://example.com/one", report)
-    assert "## Sources" in report
-    assert "| Platform | Count |" in report
-    assert "| web | 1 |" in report
+    assert report.title == "Compare search tooling"
+    assert report.content.startswith("## Overview")
+    assert "## Overview" in report.markdown
+    assert "## References" in report.markdown
+    assert re.search(r"\[1\].*https://example.com/one", report.markdown)
+    assert "## Sources" in report.markdown
+    assert "| Platform | Count |" in report.markdown
+    assert "| web | 1 |" in report.markdown
+    assert report.ref_table[1].url == "https://example.com/one"
 
 
 def test_remap_citations_collapses_duplicate_urls_and_renumbers_refs() -> None:


### PR DESCRIPTION
## Summary

W3 of plan `autosearch-0420-steal-3-patterns.md` — borrow STORM's synthesis ideas without vendoring DSPy / sentence-transformers / Co-STORM. Zero new frameworks; zero new deps.

- **OutlineNode tree** + `ResearchTurn` + `EvidenceSnippet` (pydantic v2) — replaces `list[str]` flat outline
- **Two-stage outline**: `draft_outline(query)` → `refine_outline(query, draft, research_trace)` using W2 research_trace as dialogue context
- **Snippet-level BM25 retrieval**: `split_into_snippets()` + `retrieve_for_section()` — CJK character-window fallback; uses existing rank-bm25
- **write_section_from_snippets()** — each section only sees its own retrieved snippets (not flat evidence)
- **Citation hardening**: invalid inline `[N]` markers scrubbed per-section, final article renumbered by first-appearance order; code blocks + inline code protected
- **ReportSynthesizer.synthesize()** rewired: walk outline tree → per-section retrieve → per-section write → global citation rewrite → scrub+remap → renumber

## Commits (7)

1. feat(models): outline node tree research turn and evidence snippet for storm-style synthesis
2. feat(synthesis): two-stage outline draft then refine from research trace
3. feat(core): snippet-level bm25 retrieval for per-section synthesis
4. fix(synthesis): scrub invalid inline citations and renumber by first appearance
5. refactor(synthesis): write section from per-section snippets with outline context
6. refactor(synthesis): report walks outline tree with per-section retrieval and citation renumber
7. fix(synthesis): citation scrub and renumber skip fenced and inline code blocks (review-response)

## Test plan

- [x] 71 new unit+integration tests (19 models + 6 outline + 17 snippet + 13 citation scrub + 6 section writer + 5 report integration + 5 code-block fix)
- [x] Full suite: **581 passed / 18 deselected / 0 failed** (baseline 510 after W2)
- [x] ruff + ruff format clean
- [x] pr-review-toolkit:code-reviewer pass: no blocking issues, 1 P1 (code-block regex) folded into commit 7

## Gotchas for reviewer

- `Report.outline` is now `OutlineNode` tree, not `list[str]`. Pre-1.0 breaking change per plan.
- `ReportSynthesizer.synthesize()` gains `research_trace` parameter (optional, backward-compat via None).
- Backward-compat: `OutlineGenerator.outline()` class kept alive (though no remaining caller in production); `write_section(heading, evidences, client)` legacy function kept.
- Prompts renamed: `m7_section_write_v2.md` (new); existing m4/m5/m7 prompts unchanged.
- Section-local `[N]` markers are rewritten to global `[sid:N]` internally before renumber; code blocks + inline code are protected from the regex.
- Depends on **W1 + W2 merged** (both already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced evidence retrieval with per-section snippet matching for more targeted, relevant source selection
  * Improved outline generation using a two-stage draft-and-refine approach for better-structured reports
  * Better support for non-English text including CJK character handling
  * Structured report output with complete citation tracking and reference tables

* **Bug Fixes**
  * Fixed citation handling to prevent broken references in code blocks
  * Improved citation accuracy and deduplication across report sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->