### PR TITLE
feat: W4 optional — evidence delegator + multi-perspective reflection (steal deepagents + storm)

### DIFF
--- a/autosearch/core/delegation.py
+++ b/autosearch/core/delegation.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import math
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import structlog
+
+from autosearch.core.context_compaction import ContextCompactor
+from autosearch.core.models import Evidence, EvidenceDigest
+
+if TYPE_CHECKING:
+    from autosearch.llm.client import LLMClient
+    from autosearch.persistence.session_store import SessionStore
+
+
+class EvidenceDelegator:
+    """Parallel slice-level digestion."""
+
+    def __init__(
+        self,
+        *,
+        client: LLMClient,
+        slice_size: int = 15,
+        max_workers: int = 4,
+        token_budget_per_slice: int = 6000,
+        store: SessionStore | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        if slice_size <= 0:
+            raise ValueError("slice_size must be greater than 0")
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+        if token_budget_per_slice <= 0:
+            raise ValueError("token_budget_per_slice must be greater than 0")
+
+        self.client = client
+        self.slice_size = slice_size
+        self.max_workers = max_workers
+        self.token_budget_per_slice = token_budget_per_slice
+        self.store = store
+        self.session_id = session_id
+        self.logger = structlog.get_logger(__name__).bind(component="evidence_delegator")
+
+    async def delegate(
+        self,
+        evidence: list[Evidence],
+        query: str,
+    ) -> list[EvidenceDigest]:
+        """Return one digest per slice. Empty evidence produces no digests."""
+
+        if not evidence:
+            return []
+
+        slices = self._partition_evidence(evidence)
+        self.logger.info(
+            "delegation_started",
+            evidence_count=len(evidence),
+            slice_count=len(slices),
+            max_workers=self.max_workers,
+        )
+
+        if len(slices) == 1:
+            digest = await self._digest_slice(slices[0], query)
+            if digest is None:
+                self.logger.warning("slice_failed", slice_index=0, error="no digest returned")
+                return []
+            self.logger.info(
+                "slice_completed", slice_index=0, digest_tokens_after=digest.token_count_after
+            )
+            return [digest]
+
+        results = await asyncio.gather(
+            *(self._digest_slice(slice_evidence, query) for slice_evidence in slices),
+            return_exceptions=True,
+        )
+
+        digests: list[EvidenceDigest] = []
+        for index, result in enumerate(results):
+            if isinstance(result, Exception):
+                self.logger.warning("slice_failed", slice_index=index, error=str(result))
+                continue
+            if result is None:
+                self.logger.warning("slice_failed", slice_index=index, error="no digest returned")
+                continue
+            self.logger.info(
+                "slice_completed",
+                slice_index=index,
+                digest_tokens_after=result.token_count_after,
+            )
+            digests.append(result)
+        return digests
+
+    async def delegate_with_meta(
+        self,
+        evidence: list[Evidence],
+        query: str,
+    ) -> tuple[list[EvidenceDigest], EvidenceDigest | None]:
+        """Return per-slice digests and an optional meta-digest over those digests."""
+
+        digests = await self.delegate(evidence, query)
+        if len(digests) <= 1:
+            return digests, None
+
+        meta_evidence = [
+            self._digest_to_evidence(index, digest) for index, digest in enumerate(digests)
+        ]
+        compactor = self._make_compactor()
+        meta_tokens_before = sum(compactor._count_tokens(item) for item in meta_evidence)
+        prompt = compactor._build_prompt(query, meta_evidence)
+
+        try:
+            llm_digest = await self.client.complete(prompt, EvidenceDigest)
+        except Exception as exc:
+            self.logger.warning("meta_digest_failed", error=str(exc))
+            return digests, None
+
+        meta_digest = compactor._finalize_digest(llm_digest, meta_evidence, meta_tokens_before)
+        meta_digest = meta_digest.model_copy(
+            update={
+                "source_urls": self._collect_digest_source_urls(digests),
+                "evidence_count": sum(digest.evidence_count for digest in digests),
+            }
+        )
+        meta_digest = meta_digest.model_copy(
+            update={"token_count_after": self._count_digest_tokens(meta_digest)}
+        )
+        self.logger.info(
+            "meta_digest_generated",
+            slice_count=len(digests),
+            meta_tokens_after=meta_digest.token_count_after,
+        )
+        return digests, meta_digest
+
+    def _partition_evidence(self, evidence: list[Evidence]) -> list[list[Evidence]]:
+        effective_slice_size = self.slice_size
+        if len(evidence) > self.max_workers * self.slice_size:
+            effective_slice_size = math.ceil(len(evidence) / self.max_workers)
+        return [
+            evidence[index : index + effective_slice_size]
+            for index in range(0, len(evidence), effective_slice_size)
+        ]
+
+    async def _digest_slice(
+        self,
+        slice_evidence: list[Evidence],
+        query: str,
+    ) -> EvidenceDigest | None:
+        if not slice_evidence:
+            return None
+
+        compactor = self._make_compactor()
+        slice_tokens = sum(compactor._count_tokens(item) for item in slice_evidence)
+        threshold = compactor.token_budget * compactor.compact_when_over_pct
+
+        if slice_tokens < threshold:
+            return await self._force_digest(compactor, slice_evidence, query, slice_tokens)
+
+        _, digest = await compactor.compact(slice_evidence, query)
+        return digest
+
+    async def _force_digest(
+        self,
+        compactor: ContextCompactor,
+        evidence: list[Evidence],
+        query: str,
+        token_count_before: int,
+    ) -> EvidenceDigest:
+        prompt = compactor._build_prompt(query, evidence)
+        llm_digest = await self.client.complete(prompt, EvidenceDigest)
+        digest = compactor._finalize_digest(llm_digest, evidence, token_count_before)
+        await compactor._store_artifact_best_effort(
+            kind="compacted_digest",
+            payload=digest,
+        )
+        return digest
+
+    def _make_compactor(self) -> ContextCompactor:
+        return ContextCompactor(
+            token_budget=self.token_budget_per_slice,
+            hot_set_size=0,
+            client=self.client,
+            store=self.store,
+            session_id=self.session_id,
+        )
+
+    def _digest_to_evidence(self, index: int, digest: EvidenceDigest) -> Evidence:
+        return Evidence(
+            url=digest.source_urls[0] if digest.source_urls else f"digest://slice-{index + 1}",
+            title=digest.topic or f"Slice digest {index + 1}",
+            snippet=digest.key_findings[0] if digest.key_findings else None,
+            content=self._render_digest_as_content(digest),
+            source_channel="delegation_digest",
+            fetched_at=digest.compressed_at or datetime.now(UTC),
+        )
+
+    def _render_digest_as_content(self, digest: EvidenceDigest) -> str:
+        lines = [f"Topic: {digest.topic}", "Key findings:"]
+        lines.extend(f"- {finding}" for finding in digest.key_findings)
+        lines.append("Source URLs:")
+        lines.extend(f"- {url}" for url in digest.source_urls)
+        lines.append(f"Evidence count: {digest.evidence_count}")
+        return "\n".join(lines)
+
+    def _collect_digest_source_urls(self, digests: list[EvidenceDigest]) -> list[str]:
+        seen: set[str] = set()
+        urls: list[str] = []
+        for digest in digests:
+            for url in digest.source_urls:
+                if url in seen:
+                    continue
+                seen.add(url)
+                urls.append(url)
+        return urls
+
+    def _count_digest_tokens(self, digest: EvidenceDigest) -> int:
+        return self._make_compactor()._count_tokens(self._digest_to_evidence(0, digest))

--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -20,6 +20,7 @@ SEARCH_REFLECTION_PROMPT = load_prompt("m3_search_reflection")
 FOLLOW_UP_QUERY_PROMPT = load_prompt("m3_follow_up_query")
 FALLBACK_THRESHOLD = 5
 SUBQUERY_BATCH_SIZE = 3
+logger = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -53,7 +54,14 @@ async def generate_perspectives(
 ) -> list[str]:
     """Generate short perspective labels from the query alone."""
 
-    requested_count = max(1, min(num_perspectives, 3))
+    requested_count = num_perspectives
+    if requested_count > 3:
+        logger.warning(
+            "num_perspectives_clamped",
+            requested=requested_count,
+            actual=3,
+        )
+    requested_count = max(1, min(requested_count, 3))
     prompt = PERSPECTIVE_LABELS_PROMPT.format(
         query=query,
         num_perspectives=requested_count,
@@ -113,6 +121,8 @@ class IterationController:
                 num_perspectives=budget.num_perspectives,
             )
         multi_perspective = budget.num_perspectives >= 2 and len(perspectives) >= 2
+        perspective_mode = "multi" if multi_perspective else "single"
+        active_perspective_count = len(perspectives) if multi_perspective else 1
         accumulated_evidence: list[Evidence] = []
         compactor = ContextCompactor(
             token_budget=budget.context_token_budget,
@@ -226,6 +236,8 @@ class IterationController:
                     accumulated=len(accumulated_evidence),
                     gaps=len(batch_gaps),
                     compacted=digest is not None,
+                    perspective_mode=perspective_mode,
+                    num_perspectives=active_perspective_count,
                 )
             self.logger.info(
                 "iteration_phase_completed",
@@ -281,6 +293,8 @@ class IterationController:
                 phase="reflect",
                 iteration=iteration,
                 gaps=len(gaps),
+                perspective_mode=perspective_mode,
+                num_perspectives=active_perspective_count,
             )
 
             all_gaps = _dedup_gaps(gaps + collected_batch_gaps)

--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -14,6 +14,8 @@ from autosearch.persistence.session_store import SessionStore
 from autosearch.skills.prompts import load_prompt
 
 GAP_REFLECTION_PROMPT = load_prompt("m3_gap_reflection")
+GAP_REFLECTION_PERSPECTIVE_PROMPT = load_prompt("m3_gap_reflection_perspective")
+PERSPECTIVE_LABELS_PROMPT = load_prompt("m3_perspective_labels")
 SEARCH_REFLECTION_PROMPT = load_prompt("m3_search_reflection")
 FOLLOW_UP_QUERY_PROMPT = load_prompt("m3_follow_up_query")
 FALLBACK_THRESHOLD = 5
@@ -28,14 +30,41 @@ class IterationBudget:
     context_token_budget: int = 16000
     compact_hot_set_size: int = 10
     compact_trigger_pct: float = 0.8
+    num_perspectives: int = 0
 
 
 class _GapReflectionResponse(BaseModel):
     gaps: list[Gap] = Field(default_factory=list)
 
 
+class _PerspectiveResponse(BaseModel):
+    labels: list[str] = Field(default_factory=list)
+
+
 class _FollowUpQueryResponse(BaseModel):
     subqueries: list[SubQuery] = Field(default_factory=list)
+
+
+async def generate_perspectives(
+    query: str,
+    client: LLMClient,
+    *,
+    num_perspectives: int = 3,
+) -> list[str]:
+    """Generate short perspective labels from the query alone."""
+
+    requested_count = max(1, min(num_perspectives, 3))
+    prompt = PERSPECTIVE_LABELS_PROMPT.format(
+        query=query,
+        num_perspectives=requested_count,
+    )
+    try:
+        response = await client.complete(prompt, _PerspectiveResponse)
+    except Exception:
+        return ["default"]
+
+    labels = _clean_perspective_labels(response.labels, limit=requested_count)
+    return labels or ["default"]
 
 
 class IterationController:
@@ -76,6 +105,14 @@ class IterationController:
             return [], research_trace
 
         active_queries = _dedup_subqueries(initial_queries)
+        perspectives = ["default"]
+        if budget.num_perspectives >= 2:
+            perspectives = await generate_perspectives(
+                query,
+                client,
+                num_perspectives=budget.num_perspectives,
+            )
+        multi_perspective = budget.num_perspectives >= 2 and len(perspectives) >= 2
         accumulated_evidence: list[Evidence] = []
         compactor = ContextCompactor(
             token_budget=budget.context_token_budget,
@@ -135,12 +172,29 @@ class IterationController:
                 )
                 batch_gaps: list[Gap] = []
                 if run_batch_reflection:
-                    batch_gaps = await self._per_search_reflect(
-                        batch_evidence=batch_evidence,
-                        query=query,
-                        client=client,
-                        batch_subqueries=batch_subqueries,
-                    )
+                    if multi_perspective:
+                        batch_gaps = _dedup_gaps(
+                            [
+                                gap
+                                for gaps in (
+                                    await self._per_search_reflect_multi_perspective(
+                                        batch_evidence=batch_evidence,
+                                        query=query,
+                                        client=client,
+                                        batch_subqueries=batch_subqueries,
+                                        perspectives=perspectives,
+                                    )
+                                ).values()
+                                for gap in gaps
+                            ]
+                        )
+                    else:
+                        batch_gaps = await self._per_search_reflect(
+                            batch_evidence=batch_evidence,
+                            query=query,
+                            client=client,
+                            batch_subqueries=batch_subqueries,
+                        )
                     collected_batch_gaps.extend(batch_gaps)
 
                 digest_id: int | str | None = None
@@ -162,6 +216,8 @@ class IterationController:
                         "digest_id_if_any": digest_id,
                     }
                 )
+                if multi_perspective:
+                    research_trace[-1]["perspective"] = list(perspectives)
                 self.logger.info(
                     "iteration_batch_completed",
                     iteration=iteration,
@@ -193,14 +249,33 @@ class IterationController:
             )
 
             self.logger.info("iteration_phase_started", phase="reflect", iteration=iteration)
-            gaps = await self._reflect(
-                query=query,
-                iteration=iteration,
-                max_iterations=budget.max_iterations,
-                subqueries=active_queries,
-                evidences=accumulated_evidence,
-                client=client,
-            )
+            if multi_perspective:
+                gaps = _dedup_gaps(
+                    [
+                        gap
+                        for gaps in (
+                            await self._reflect_multi_perspective(
+                                query=query,
+                                iteration=iteration,
+                                max_iterations=budget.max_iterations,
+                                subqueries=active_queries,
+                                evidences=accumulated_evidence,
+                                perspectives=perspectives,
+                                client=client,
+                            )
+                        ).values()
+                        for gap in gaps
+                    ]
+                )
+            else:
+                gaps = await self._reflect(
+                    query=query,
+                    iteration=iteration,
+                    max_iterations=budget.max_iterations,
+                    subqueries=active_queries,
+                    evidences=accumulated_evidence,
+                    client=client,
+                )
             self.logger.info(
                 "iteration_phase_completed",
                 phase="reflect",
@@ -409,10 +484,62 @@ class IterationController:
         evidences: list[Evidence],
         client: LLMClient,
     ) -> list[Gap]:
-        prompt = GAP_REFLECTION_PROMPT.format(
+        return await self._reflect_for_perspective(
             query=query,
             iteration=iteration,
             max_iterations=max_iterations,
+            subqueries=subqueries,
+            evidences=evidences,
+            perspective=None,
+            client=client,
+        )
+
+    async def _reflect_multi_perspective(
+        self,
+        *,
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        perspectives: list[str],
+        client: LLMClient,
+    ) -> dict[str, list[Gap]]:
+        results = await asyncio.gather(
+            *[
+                self._reflect_for_perspective(
+                    query=query,
+                    iteration=iteration,
+                    max_iterations=max_iterations,
+                    subqueries=subqueries,
+                    evidences=evidences,
+                    perspective=perspective,
+                    client=client,
+                )
+                for perspective in perspectives
+            ]
+        )
+        return dict(zip(perspectives, results, strict=True))
+
+    async def _reflect_for_perspective(
+        self,
+        *,
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        perspective: str | None,
+        client: LLMClient,
+    ) -> list[Gap]:
+        prompt_template = (
+            GAP_REFLECTION_PERSPECTIVE_PROMPT if perspective else GAP_REFLECTION_PROMPT
+        )
+        prompt = prompt_template.format(
+            query=query,
+            iteration=iteration,
+            max_iterations=max_iterations,
+            perspective=perspective or "",
             subqueries=_format_subqueries(subqueries),
             evidence_context=_format_evidence(evidences, max_items=12),
         )
@@ -427,11 +554,53 @@ class IterationController:
         client: LLMClient,
         batch_subqueries: list[SubQuery] | None = None,
     ) -> list[Gap]:
+        return await self._per_search_reflect_for_perspective(
+            batch_evidence=batch_evidence,
+            query=query,
+            client=client,
+            batch_subqueries=batch_subqueries,
+            perspective=None,
+        )
+
+    async def _per_search_reflect_multi_perspective(
+        self,
+        *,
+        batch_evidence: list[Evidence],
+        query: str,
+        client: LLMClient,
+        batch_subqueries: list[SubQuery] | None = None,
+        perspectives: list[str],
+    ) -> dict[str, list[Gap]]:
+        results = await asyncio.gather(
+            *[
+                self._per_search_reflect_for_perspective(
+                    batch_evidence=batch_evidence,
+                    query=query,
+                    client=client,
+                    batch_subqueries=batch_subqueries,
+                    perspective=perspective,
+                )
+                for perspective in perspectives
+            ]
+        )
+        return dict(zip(perspectives, results, strict=True))
+
+    async def _per_search_reflect_for_perspective(
+        self,
+        *,
+        batch_evidence: list[Evidence],
+        query: str,
+        client: LLMClient,
+        batch_subqueries: list[SubQuery] | None = None,
+        perspective: str | None,
+    ) -> list[Gap]:
         prompt = SEARCH_REFLECTION_PROMPT.format(
             query=query,
             batch_subqueries=_format_subqueries(batch_subqueries or []),
             batch_evidence_context=_format_evidence(batch_evidence, max_items=6),
         )
+        if perspective:
+            prompt = _prepend_perspective_block(prompt, perspective)
         response = await client.complete(prompt, _GapReflectionResponse)
         return _dedup_gaps(response.gaps)
 
@@ -485,6 +654,23 @@ def _dedup_gaps(gaps: list[Gap]) -> list[Gap]:
     return deduped
 
 
+def _clean_perspective_labels(labels: list[str], *, limit: int) -> list[str]:
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for label in labels:
+        normalized = " ".join(label.strip().split())
+        if not normalized or len(normalized) > 60:
+            continue
+        dedup_key = normalized.casefold()
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+        cleaned.append(normalized)
+        if len(cleaned) >= limit:
+            break
+    return cleaned
+
+
 def _format_subqueries(subqueries: list[SubQuery]) -> str:
     if not subqueries:
         return "- None"
@@ -520,6 +706,10 @@ def _format_evidence(evidences: list[Evidence], max_items: int) -> str:
         formatted.append(f"... {len(evidences) - max_items} additional evidence items omitted")
 
     return "\n\n".join(formatted)
+
+
+def _prepend_perspective_block(prompt: str, perspective: str) -> str:
+    return f"<Perspective lens>\n{perspective}\n</Perspective lens>\n\n{prompt}"
 
 
 def _initial_routing_trace(

--- a/autosearch/skills/prompts/m3_gap_reflection_perspective.md
+++ b/autosearch/skills/prompts/m3_gap_reflection_perspective.md
@@ -1,0 +1,46 @@
+---
+name: m3_gap_reflection_perspective
+phase: M3
+description: Identify remaining research gaps for a specific perspective.
+---
+Review the current research progress and identify only the most important remaining gaps from the
+specified perspective.
+
+<Perspective lens>
+{perspective}
+</Perspective lens>
+
+<Original user query>
+{query}
+</Original user query>
+
+<Current iteration>
+{iteration} of {max_iterations}
+</Current iteration>
+
+<Queries already executed>
+{subqueries}
+</Queries already executed>
+
+<Collected evidence>
+{evidence_context}
+</Collected evidence>
+
+Respond in valid JSON with this exact schema:
+{{
+  "gaps": [
+    {{
+      "topic": "missing research topic",
+      "reason": "why this missing information matters"
+    }}
+  ]
+}}
+
+Rules:
+- Return at most 3 gaps
+- Return an empty list if the evidence already covers this perspective well enough to draft a report
+- Focus on missing evidence, missing comparisons, missing time-sensitive details, or unanswered
+  sub-questions
+- Keep each topic concrete enough to search directly
+- Do not repeat gaps that are already covered by the collected evidence
+- Stay within the stated perspective while still serving the original query

--- a/autosearch/skills/prompts/m3_perspective_labels.md
+++ b/autosearch/skills/prompts/m3_perspective_labels.md
@@ -1,0 +1,24 @@
+---
+name: m3_perspective_labels
+phase: M3
+description: Generate short perspective labels from the user query.
+---
+Generate {num_perspectives} short perspective labels for the research query below.
+
+<Original user query>
+{query}
+</Original user query>
+
+Respond in valid JSON with this exact schema:
+{{
+  "labels": [
+    "short perspective label"
+  ]
+}}
+
+Rules:
+- Return exactly {num_perspectives} labels when possible
+- Each label must be 2 to 5 words
+- Each label should describe a distinct lens or angle on the query
+- Keep labels concrete and search-useful
+- Do not include numbering, explanations, or prose outside the JSON

--- a/tests/unit/core/test_delegation.py
+++ b/tests/unit/core/test_delegation.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from autosearch.core.delegation import EvidenceDelegator
+from autosearch.core.models import Evidence, EvidenceDigest
+from autosearch.persistence.session_store import SessionStore
+
+NOW = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeLLMClient:
+    def __init__(
+        self,
+        *,
+        delay_seconds: float = 0.0,
+        fail_on_prompt_substrings: set[str] | None = None,
+    ) -> None:
+        self.delay_seconds = delay_seconds
+        self.fail_on_prompt_substrings = fail_on_prompt_substrings or set()
+        self.calls = 0
+        self.prompts: list[str] = []
+        self.max_concurrent_calls = 0
+        self._active_calls = 0
+        self._lock = asyncio.Lock()
+
+    async def complete(self, prompt: str, response_model: type[EvidenceDigest]) -> EvidenceDigest:
+        _ = response_model
+        async with self._lock:
+            self.calls += 1
+            call_number = self.calls
+            self.prompts.append(prompt)
+            self._active_calls += 1
+            self.max_concurrent_calls = max(self.max_concurrent_calls, self._active_calls)
+
+        try:
+            if self.delay_seconds > 0:
+                await asyncio.sleep(self.delay_seconds)
+            for marker in self.fail_on_prompt_substrings:
+                if marker in prompt:
+                    raise RuntimeError(f"forced failure for {marker}")
+            return EvidenceDigest(
+                topic=f"Digest {call_number}",
+                key_findings=[f"Finding {call_number}.1", f"Finding {call_number}.2"],
+                source_urls=[f"https://placeholder.example/{call_number}"],
+                evidence_count=1,
+                compressed_at=NOW,
+                token_count_before=1,
+                token_count_after=1,
+            )
+        finally:
+            async with self._lock:
+                self._active_calls -= 1
+
+
+def make_evidence(index: int) -> Evidence:
+    return Evidence(
+        url=f"https://example.com/{index}",
+        title=f"Evidence {index}",
+        snippet=f"Snippet {index}",
+        content=f"Content {index}",
+        source_channel="web",
+        fetched_at=NOW,
+    )
+
+
+async def test_delegate_empty_evidence_returns_empty() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client)
+
+    digests = await delegator.delegate([], "empty")
+
+    assert digests == []
+    assert client.calls == 0
+
+
+async def test_delegate_below_slice_size_returns_single_digest() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=15)
+
+    digests = await delegator.delegate([make_evidence(index) for index in range(1, 6)], "query")
+
+    assert len(digests) == 1
+    assert digests[0].evidence_count == 5
+    assert client.calls == 1
+
+
+async def test_delegate_splits_into_multiple_slices() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=15, max_workers=4)
+
+    digests = await delegator.delegate([make_evidence(index) for index in range(1, 41)], "query")
+
+    assert len(digests) == 3
+    assert [digest.evidence_count for digest in digests] == [15, 15, 10]
+
+
+async def test_delegate_respects_max_workers_cap() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=15, max_workers=4)
+
+    digests = await delegator.delegate([make_evidence(index) for index in range(1, 101)], "query")
+
+    assert len(digests) == 4
+    assert [digest.evidence_count for digest in digests] == [25, 25, 25, 25]
+
+
+async def test_delegate_runs_concurrently() -> None:
+    client = FakeLLMClient(delay_seconds=0.05)
+    delegator = EvidenceDelegator(client=client, slice_size=10, max_workers=4)
+
+    digests = await delegator.delegate([make_evidence(index) for index in range(1, 41)], "query")
+
+    assert len(digests) == 4
+    assert client.max_concurrent_calls >= 2
+
+
+async def test_delegate_partial_failure_returns_successful() -> None:
+    client = FakeLLMClient(fail_on_prompt_substrings={"https://example.com/11"})
+    delegator = EvidenceDelegator(client=client, slice_size=10, max_workers=4)
+
+    digests = await delegator.delegate([make_evidence(index) for index in range(1, 31)], "query")
+
+    assert len(digests) == 2
+    assert [digest.evidence_count for digest in digests] == [10, 10]
+    assert [digest.source_urls[0] for digest in digests] == [
+        "https://example.com/1",
+        "https://example.com/21",
+    ]
+
+
+async def test_delegate_preserves_source_url_across_digests() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=10, max_workers=4)
+    evidence = [make_evidence(index) for index in range(1, 26)]
+
+    digests = await delegator.delegate(evidence, "query")
+
+    collected_urls = [url for digest in digests for url in digest.source_urls]
+    assert collected_urls == [item.url for item in evidence]
+
+
+async def test_delegate_persists_artifacts_when_store_set(tmp_path) -> None:
+    client = FakeLLMClient()
+    store = await SessionStore.open(tmp_path / "delegation.sqlite")
+
+    try:
+        await store.create_session("session-1", "query", "deep")
+        delegator = EvidenceDelegator(
+            client=client,
+            slice_size=10,
+            max_workers=4,
+            store=store,
+            session_id="session-1",
+        )
+
+        digests = await delegator.delegate(
+            [make_evidence(index) for index in range(1, 41)], "query"
+        )
+        artifacts = await store.load_artifacts(
+            session_id="session-1",
+            kind="compacted_digest",
+        )
+    finally:
+        await store.close()
+
+    assert len(digests) == 4
+    assert len(artifacts) == 4
+    persisted = [
+        EvidenceDigest.model_validate_json(artifact["payload_json"]) for artifact in artifacts
+    ]
+    assert persisted == digests
+
+
+async def test_delegate_with_meta_single_slice_returns_none_meta() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=15)
+
+    digests, meta_digest = await delegator.delegate_with_meta(
+        [make_evidence(index) for index in range(1, 6)],
+        "query",
+    )
+
+    assert len(digests) == 1
+    assert meta_digest is None
+    assert client.calls == 1
+
+
+async def test_delegate_with_meta_multi_slice_returns_meta_digest() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=10, max_workers=4)
+
+    digests, meta_digest = await delegator.delegate_with_meta(
+        [make_evidence(index) for index in range(1, 41)],
+        "query",
+    )
+
+    assert len(digests) == 4
+    assert meta_digest is not None
+    assert meta_digest.evidence_count == sum(digest.evidence_count for digest in digests)
+    assert set(meta_digest.source_urls) == {
+        item.url for item in [make_evidence(index) for index in range(1, 41)]
+    }
+    assert client.calls == 5
+
+
+async def test_delegate_empty_query_still_works() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=10)
+
+    digests = await delegator.delegate([make_evidence(index) for index in range(1, 11)], "")
+
+    assert len(digests) == 1
+    assert digests[0].evidence_count == 10
+
+
+async def test_delegate_hot_set_size_zero_forces_full_compaction() -> None:
+    client = FakeLLMClient()
+    delegator = EvidenceDelegator(client=client, slice_size=15, token_budget_per_slice=6000)
+
+    digests = await delegator.delegate([make_evidence(1)], "query")
+
+    assert len(digests) == 1
+    assert digests[0].evidence_count == 1
+    assert client.calls == 1

--- a/tests/unit/core/test_perspectives.py
+++ b/tests/unit/core/test_perspectives.py
@@ -1,0 +1,90 @@
+# Self-written, plan 0420 W4 F402
+from pydantic import BaseModel
+
+from autosearch.core.iteration import generate_perspectives
+
+
+class FakeLLMClient:
+    def __init__(self, payload: dict[str, object] | Exception) -> None:
+        self.payload = payload
+        self.prompts: list[str] = []
+
+    async def complete(self, prompt: str, response_model: type[BaseModel]) -> BaseModel:
+        self.prompts.append(prompt)
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return response_model.model_validate(self.payload)
+
+
+async def test_generate_perspectives_returns_requested_count() -> None:
+    client = FakeLLMClient(
+        {
+            "labels": [
+                "economic feasibility",
+                "environmental impact",
+                "policy implementation",
+            ]
+        }
+    )
+
+    labels = await generate_perspectives(
+        "renewable energy adoption",
+        client,
+        num_perspectives=3,
+    )
+
+    assert labels == [
+        "economic feasibility",
+        "environmental impact",
+        "policy implementation",
+    ]
+
+
+async def test_generate_perspectives_llm_error_fallback() -> None:
+    client = FakeLLMClient(RuntimeError("llm unavailable"))
+
+    labels = await generate_perspectives(
+        "renewable energy adoption",
+        client,
+        num_perspectives=3,
+    )
+
+    assert labels == ["default"]
+
+
+async def test_generate_perspectives_empty_response_fallback() -> None:
+    client = FakeLLMClient({"labels": []})
+
+    labels = await generate_perspectives(
+        "renewable energy adoption",
+        client,
+        num_perspectives=3,
+    )
+
+    assert labels == ["default"]
+
+
+async def test_generate_perspectives_labels_are_short() -> None:
+    client = FakeLLMClient(
+        {
+            "labels": [
+                "economic feasibility",
+                "this label is intentionally much longer than sixty characters to validate filtering",
+                "environmental impact",
+                "policy implementation",
+            ]
+        }
+    )
+
+    labels = await generate_perspectives(
+        "renewable energy adoption",
+        client,
+        num_perspectives=3,
+    )
+
+    assert labels == [
+        "economic feasibility",
+        "environmental impact",
+        "policy implementation",
+    ]
+    assert all(len(label) <= 60 for label in labels)

--- a/tests/unit/core/test_perspectives.py
+++ b/tests/unit/core/test_perspectives.py
@@ -1,6 +1,7 @@
 # Self-written, plan 0420 W4 F402
 from pydantic import BaseModel
 
+import autosearch.core.iteration as iteration_module
 from autosearch.core.iteration import generate_perspectives
 
 
@@ -14,6 +15,14 @@ class FakeLLMClient:
         if isinstance(self.payload, Exception):
             raise self.payload
         return response_model.model_validate(self.payload)
+
+
+class RecordingLogger:
+    def __init__(self) -> None:
+        self.warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warning_calls.append((event, kwargs))
 
 
 async def test_generate_perspectives_returns_requested_count() -> None:
@@ -88,3 +97,40 @@ async def test_generate_perspectives_labels_are_short() -> None:
         "policy implementation",
     ]
     assert all(len(label) <= 60 for label in labels)
+
+
+async def test_generate_perspectives_clamp_above_3_emits_warning(monkeypatch) -> None:
+    client = FakeLLMClient(
+        {
+            "labels": [
+                "economic feasibility",
+                "environmental impact",
+                "policy implementation",
+                "supply chain resilience",
+                "consumer adoption",
+            ]
+        }
+    )
+    recording_logger = RecordingLogger()
+    monkeypatch.setattr(iteration_module, "logger", recording_logger)
+
+    labels = await generate_perspectives(
+        "renewable energy adoption",
+        client,
+        num_perspectives=5,
+    )
+
+    assert labels == [
+        "economic feasibility",
+        "environmental impact",
+        "policy implementation",
+    ]
+    assert recording_logger.warning_calls == [
+        (
+            "num_perspectives_clamped",
+            {
+                "requested": 5,
+                "actual": 3,
+            },
+        )
+    ]

--- a/tests/unit/test_iteration.py
+++ b/tests/unit/test_iteration.py
@@ -1,4 +1,5 @@
 # Self-written, plan v2.3 § 13.5
+import asyncio
 from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime
 
@@ -6,6 +7,7 @@ import pytest
 from pydantic import BaseModel
 
 from autosearch.core import context_compaction as context_compaction_module
+import autosearch.core.iteration as iteration_module
 from autosearch.core.iteration import IterationBudget, IterationController
 from autosearch.core.models import Evidence, EvidenceDigest, Gap, SubQuery
 from autosearch.persistence.session_store import SessionStore
@@ -585,3 +587,307 @@ def test_iteration_budget_is_frozen() -> None:
 
     with pytest.raises(FrozenInstanceError):
         budget.max_iterations = 2
+
+
+async def test_iteration_single_perspective_backward_compat(monkeypatch) -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        [[make_evidence("https://example.com/one", "Pricing update", "pricing update evidence")]]
+    )
+    client = DummyClient([])
+    generate_calls = 0
+
+    async def fake_generate_perspectives(
+        query: str,
+        client: DummyClient,
+        *,
+        num_perspectives: int = 3,
+    ) -> list[str]:
+        _ = (query, client, num_perspectives)
+        nonlocal generate_calls
+        generate_calls += 1
+        return ["economic feasibility", "environmental impact", "policy implementation"]
+
+    async def fake_reflect(
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        client: DummyClient,
+    ) -> list[Gap]:
+        _ = (query, iteration, max_iterations, subqueries, evidences, client)
+        return []
+
+    monkeypatch.setattr(iteration_module, "generate_perspectives", fake_generate_perspectives)
+    monkeypatch.setattr(controller, "_reflect", fake_reflect)
+
+    _, research_trace = await controller.run(
+        query="pricing update",
+        initial_queries=[SubQuery(text="pricing update", rationale="seed query")],
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            num_perspectives=0,
+        ),
+        client=client,
+    )
+
+    assert generate_calls == 0
+    assert research_trace == [
+        {
+            "iteration": 1,
+            "batch_index": 1,
+            "subqueries": ["pricing update"],
+            "gaps": [],
+            "digest_id_if_any": None,
+        }
+    ]
+
+
+async def test_iteration_multi_perspective_reflects_in_parallel(monkeypatch) -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        [
+            [
+                make_evidence(
+                    "https://example.com/one",
+                    "Perspective update",
+                    "perspective evidence",
+                )
+            ]
+        ]
+    )
+    client = DummyClient([])
+    perspectives = [
+        "economic feasibility",
+        "environmental impact",
+        "policy implementation",
+    ]
+    call_perspectives: list[str] = []
+    active_calls = 0
+    max_active_calls = 0
+
+    async def fake_generate_perspectives(
+        query: str,
+        client: DummyClient,
+        *,
+        num_perspectives: int = 3,
+    ) -> list[str]:
+        _ = (query, client, num_perspectives)
+        return perspectives
+
+    async def fake_reflect_for_perspective(
+        *,
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        perspective: str | None,
+        client: DummyClient,
+    ) -> list[Gap]:
+        _ = (query, iteration, max_iterations, subqueries, evidences, client)
+        assert perspective is not None
+        nonlocal active_calls, max_active_calls
+        call_perspectives.append(perspective)
+        active_calls += 1
+        max_active_calls = max(max_active_calls, active_calls)
+        await asyncio.sleep(0.01)
+        active_calls -= 1
+        return [Gap(topic=f"{perspective} gap", reason="perspective-specific gap")]
+
+    monkeypatch.setattr(iteration_module, "generate_perspectives", fake_generate_perspectives)
+    monkeypatch.setattr(controller, "_reflect_for_perspective", fake_reflect_for_perspective)
+
+    _, research_trace = await controller.run(
+        query="renewable energy adoption",
+        initial_queries=[SubQuery(text="renewable energy adoption", rationale="seed query")],
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            num_perspectives=3,
+        ),
+        client=client,
+    )
+
+    assert set(call_perspectives) == set(perspectives)
+    assert len(call_perspectives) == 3
+    assert max_active_calls >= 2
+    assert research_trace[0]["perspective"] == perspectives
+
+
+async def test_iteration_multi_perspective_gaps_deduplicated(monkeypatch) -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        [[make_evidence("https://example.com/one", "Pricing update", "pricing update evidence")]]
+    )
+    client = DummyClient([])
+    follow_up_gaps: list[Gap] = []
+
+    async def fake_generate_perspectives(
+        query: str,
+        client: DummyClient,
+        *,
+        num_perspectives: int = 3,
+    ) -> list[str]:
+        _ = (query, client, num_perspectives)
+        return ["economic feasibility", "environmental impact"]
+
+    async def fake_reflect_multi_perspective(
+        *,
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        perspectives: list[str],
+        client: DummyClient,
+    ) -> dict[str, list[Gap]]:
+        _ = (query, iteration, max_iterations, subqueries, evidences, perspectives, client)
+        return {
+            "economic feasibility": [Gap(topic="grid costs", reason="Need updated capex numbers")],
+            "environmental impact": [Gap(topic="grid costs", reason="Need updated capex numbers")],
+        }
+
+    async def fake_follow_up(
+        query: str,
+        gaps: list[Gap],
+        evidences: list[Evidence],
+        client: DummyClient,
+    ) -> list[SubQuery]:
+        _ = (query, evidences, client)
+        follow_up_gaps.extend(gaps)
+        return []
+
+    monkeypatch.setattr(iteration_module, "generate_perspectives", fake_generate_perspectives)
+    monkeypatch.setattr(controller, "_reflect_multi_perspective", fake_reflect_multi_perspective)
+    monkeypatch.setattr(controller, "_follow_up", fake_follow_up)
+
+    await controller.run(
+        query="renewable energy adoption",
+        initial_queries=[SubQuery(text="renewable energy adoption", rationale="seed query")],
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=2,
+            per_channel_rate_limit=0.0,
+            num_perspectives=3,
+        ),
+        client=client,
+    )
+
+    assert follow_up_gaps == [Gap(topic="grid costs", reason="Need updated capex numbers")]
+
+
+async def test_iteration_multi_perspective_research_trace_tags_perspective(
+    monkeypatch,
+) -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        [[make_evidence("https://example.com/one", "Pricing update", "pricing update evidence")]]
+    )
+    client = DummyClient([])
+    perspectives = [
+        "economic feasibility",
+        "environmental impact",
+        "policy implementation",
+    ]
+
+    async def fake_generate_perspectives(
+        query: str,
+        client: DummyClient,
+        *,
+        num_perspectives: int = 3,
+    ) -> list[str]:
+        _ = (query, client, num_perspectives)
+        return perspectives
+
+    async def fake_reflect_multi_perspective(**_: object) -> dict[str, list[Gap]]:
+        return {perspective: [] for perspective in perspectives}
+
+    monkeypatch.setattr(iteration_module, "generate_perspectives", fake_generate_perspectives)
+    monkeypatch.setattr(controller, "_reflect_multi_perspective", fake_reflect_multi_perspective)
+
+    _, research_trace = await controller.run(
+        query="renewable energy adoption",
+        initial_queries=[SubQuery(text="renewable energy adoption", rationale="seed query")],
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            num_perspectives=3,
+        ),
+        client=client,
+    )
+
+    assert research_trace == [
+        {
+            "iteration": 1,
+            "batch_index": 1,
+            "subqueries": ["renewable energy adoption"],
+            "gaps": [],
+            "digest_id_if_any": None,
+            "perspective": perspectives,
+        }
+    ]
+
+
+async def test_iteration_perspective_generation_error_fallback_runs_single(
+    monkeypatch,
+) -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        [[make_evidence("https://example.com/one", "Pricing update", "pricing update evidence")]]
+    )
+    client = DummyClient([])
+    single_reflect_calls = 0
+    multi_reflect_calls = 0
+
+    async def fake_generate_perspectives(
+        query: str,
+        client: DummyClient,
+        *,
+        num_perspectives: int = 3,
+    ) -> list[str]:
+        _ = (query, client, num_perspectives)
+        return ["default"]
+
+    async def fake_reflect(
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        client: DummyClient,
+    ) -> list[Gap]:
+        _ = (query, iteration, max_iterations, subqueries, evidences, client)
+        nonlocal single_reflect_calls
+        single_reflect_calls += 1
+        return []
+
+    async def fake_reflect_multi_perspective(**_: object) -> dict[str, list[Gap]]:
+        nonlocal multi_reflect_calls
+        multi_reflect_calls += 1
+        return {"default": []}
+
+    monkeypatch.setattr(iteration_module, "generate_perspectives", fake_generate_perspectives)
+    monkeypatch.setattr(controller, "_reflect", fake_reflect)
+    monkeypatch.setattr(controller, "_reflect_multi_perspective", fake_reflect_multi_perspective)
+
+    _, research_trace = await controller.run(
+        query="renewable energy adoption",
+        initial_queries=[SubQuery(text="renewable energy adoption", rationale="seed query")],
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            num_perspectives=3,
+        ),
+        client=client,
+    )
+
+    assert single_reflect_calls == 1
+    assert multi_reflect_calls == 0
+    assert "perspective" not in research_trace[0]

--- a/tests/unit/test_iteration.py
+++ b/tests/unit/test_iteration.py
@@ -6,8 +6,8 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import BaseModel
 
-from autosearch.core import context_compaction as context_compaction_module
 import autosearch.core.iteration as iteration_module
+from autosearch.core import context_compaction as context_compaction_module
 from autosearch.core.iteration import IterationBudget, IterationController
 from autosearch.core.models import Evidence, EvidenceDigest, Gap, SubQuery
 from autosearch.persistence.session_store import SessionStore
@@ -39,6 +39,18 @@ class FakeChannel:
     async def search(self, query: SubQuery) -> list[Evidence]:
         self.queries.append(query.text)
         return self.responses.pop(0)
+
+
+class RecordingLogger:
+    def __init__(self) -> None:
+        self.info_calls: list[tuple[str, dict[str, object]]] = []
+        self.warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.info_calls.append((event, kwargs))
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warning_calls.append((event, kwargs))
 
 
 class ArtifactStoreWithoutLookup:
@@ -832,6 +844,93 @@ async def test_iteration_multi_perspective_research_trace_tags_perspective(
             "perspective": perspectives,
         }
     ]
+
+
+async def test_iteration_batch_log_includes_perspective_mode(monkeypatch) -> None:
+    controller = IterationController()
+    logger = RecordingLogger()
+    monkeypatch.setattr(controller, "logger", logger)
+    channel = FakeChannel(
+        [
+            [make_evidence("https://example.com/one", "First result", "first evidence")],
+            [make_evidence("https://example.com/two", "Second result", "second evidence")],
+        ]
+    )
+    client = DummyClient([])
+    perspectives = [
+        "economic feasibility",
+        "environmental impact",
+    ]
+
+    async def fake_generate_perspectives(
+        query: str,
+        client: DummyClient,
+        *,
+        num_perspectives: int = 3,
+    ) -> list[str]:
+        _ = (query, client, num_perspectives)
+        return perspectives
+
+    async def fake_per_search_reflect_multi_perspective(
+        *,
+        batch_evidence: list[Evidence],
+        query: str,
+        client: DummyClient,
+        batch_subqueries: list[SubQuery] | None = None,
+        perspectives: list[str],
+    ) -> dict[str, list[Gap]]:
+        _ = (batch_evidence, query, client, batch_subqueries)
+        return {perspective: [] for perspective in perspectives}
+
+    async def fake_reflect_multi_perspective(
+        *,
+        query: str,
+        iteration: int,
+        max_iterations: int,
+        subqueries: list[SubQuery],
+        evidences: list[Evidence],
+        perspectives: list[str],
+        client: DummyClient,
+    ) -> dict[str, list[Gap]]:
+        _ = (query, iteration, max_iterations, subqueries, evidences, client)
+        return {perspective: [] for perspective in perspectives}
+
+    monkeypatch.setattr(iteration_module, "generate_perspectives", fake_generate_perspectives)
+    monkeypatch.setattr(
+        controller,
+        "_per_search_reflect_multi_perspective",
+        fake_per_search_reflect_multi_perspective,
+    )
+    monkeypatch.setattr(controller, "_reflect_multi_perspective", fake_reflect_multi_perspective)
+
+    await controller.run(
+        query="renewable energy adoption",
+        initial_queries=make_subqueries(2),
+        channels=[channel],
+        budget=IterationBudget(
+            max_iterations=1,
+            per_channel_rate_limit=0.0,
+            subquery_batch_size=1,
+            num_perspectives=3,
+        ),
+        client=client,
+    )
+
+    batch_completed_calls = [
+        kwargs for event, kwargs in logger.info_calls if event == "iteration_batch_completed"
+    ]
+    assert len(batch_completed_calls) == 2
+    assert all(call["perspective_mode"] == "multi" for call in batch_completed_calls)
+    assert all(call["num_perspectives"] == 2 for call in batch_completed_calls)
+
+    reflect_completed_calls = [
+        kwargs
+        for event, kwargs in logger.info_calls
+        if event == "iteration_phase_completed" and kwargs.get("phase") == "reflect"
+    ]
+    assert len(reflect_completed_calls) == 1
+    assert reflect_completed_calls[0]["perspective_mode"] == "multi"
+    assert reflect_completed_calls[0]["num_perspectives"] == 2
 
 
 async def test_iteration_perspective_generation_error_fallback_runs_single(


### PR DESCRIPTION
## Summary

W4 of plan `autosearch-0420-steal-3-patterns.md` — the two optional enhancements on top of W1+W2+W3. Zero new deps, zero new frameworks.

- **EvidenceDelegator** — parallel slice-level digestion. Large evidence lists get partitioned (slice_size=15, max_workers=4 by default), each slice runs `ContextCompactor` concurrently, optional meta-digest aggregates them.
- **Multi-perspective reflection** — `generate_perspectives(query, num=3)` produces 2-3 short perspective labels (e.g. "economic feasibility" / "environmental impact" / "policy implementation"), then each iteration's reflection runs once per perspective in parallel. Gaps deduped across perspectives. Default `num_perspectives=0` = single-perspective (full backward-compat).
- **Observability**: log fields `perspective_mode` + `num_perspectives` on batch/iteration reflection events; warning logged when `num_perspectives` clamped above 3.

## Commits (3)

1. feat(core): evidence delegator for parallel slice-level digestion
2. feat(core): lightweight multi-perspective reflection with query-derived labels
3. feat(core): log perspective mode and warn on num_perspectives clamp (review-response)

## Test plan

- [x] 23 new tests (12 delegation + 9 perspectives + 2 observability)
- [x] Full suite: **604 passed / 18 deselected / 0 failed** (baseline 581 after W3)
- [x] ruff + ruff format clean
- [x] pr-review-toolkit:code-reviewer pass: no blockers, 1 observability recommendation folded into commit 3

## Gotchas for reviewer

- `IterationBudget` gains `num_perspectives: int = 0` — **default keeps single-perspective behavior**. Only activates multi-mode when caller opts in.
- Multi-perspective mode is ~3x LLM spend on reflection only (search + synthesis unchanged). Log fields now distinguish modes for cost tracking.
- `generate_perspectives` fails soft: LLM error / empty response → returns `["default"]`, downstream treats as single-perspective.
- `EvidenceDelegator.delegate_with_meta()` reuses `m3_evidence_compaction` prompt for the meta-digest — reviewer noted semantic awkwardness (digest-of-digests vs original-evidence framing). Current behavior "good enough" for optional scope; dedicated prompt can be added if quality proves poor.
- Depends on **W1+W2+W3 merged** (all in main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)