### PR TITLE
fix(channels): arxiv rate-limit detection with exp backoff and ttl cache

### DIFF
--- a/autosearch/skills/channels/arxiv/methods/api_search.py
+++ b/autosearch/skills/channels/arxiv/methods/api_search.py
@@ -1,5 +1,6 @@
 # Self-written, plan autosearch-0418-channels-and-skills.md § F003
 import asyncio
+import time
 from datetime import UTC, datetime
 
 import feedparser
@@ -13,6 +14,15 @@ LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="arxiv
 MAX_RESULTS = 10
 HTTP_TIMEOUT = 30.0
 BASE_URL = "https://export.arxiv.org/api/query"
+RATE_LIMIT_RETRIES = 3
+QUERY_CACHE_TTL_SECONDS = 300.0
+QUERY_CACHE_MAX_ENTRIES = 200
+
+_QUERY_CACHE: dict[str, tuple[list[Evidence], float]] = {}
+
+
+class ArxivRateLimitError(Exception):
+    """Raised when arXiv responds with a rate-limit body instead of Atom XML."""
 
 
 def _normalize_whitespace(text: str) -> str:
@@ -20,34 +30,90 @@ def _normalize_whitespace(text: str) -> str:
 
 
 async def search(query: SubQuery) -> list[Evidence]:
+    cached_results = _get_cached_results(query.text)
+    if cached_results is not None:
+        return cached_results
+
     try:
-        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
-            response = await client.get(
-                BASE_URL,
-                params={
-                    "search_query": f"all:{query.text}",
-                    "start": 0,
-                    "max_results": MAX_RESULTS,
-                    "sortBy": "relevance",
-                    "sortOrder": "descending",
-                },
-            )
-            response.raise_for_status()
-
-        feed = await asyncio.to_thread(feedparser.parse, response.text)
-        if getattr(feed, "bozo", 0):
-            bozo_exception = getattr(feed, "bozo_exception", None)
-            raise ValueError(str(bozo_exception or "failed to parse Atom feed"))
-
-        entries = list(getattr(feed, "entries", []))
-        if not entries:
-            raise ValueError("empty feed")
+        entries = await _search_entries_with_retry(query.text)
+    except ArxivRateLimitError:
+        LOGGER.warning("arxiv_search_failed", reason="rate_exceeded")
+        return []
     except Exception as exc:
         LOGGER.warning("arxiv_search_failed", reason=str(exc))
         return []
 
     fetched_at = datetime.now(UTC)
-    return [_to_evidence(entry, fetched_at=fetched_at) for entry in entries]
+    results = [_to_evidence(entry, fetched_at=fetched_at) for entry in entries]
+    _store_cached_results(query.text, results)
+    return list(results)
+
+
+async def _search_entries_with_retry(query_text: str) -> list[object]:
+    for attempt in range(RATE_LIMIT_RETRIES + 1):
+        try:
+            return await _fetch_entries(query_text)
+        except ArxivRateLimitError:
+            if attempt >= RATE_LIMIT_RETRIES:
+                raise
+            await asyncio.sleep(2**attempt)
+
+    raise ArxivRateLimitError("rate_exceeded")
+
+
+async def _fetch_entries(query_text: str) -> list[object]:
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
+        response = await client.get(
+            BASE_URL,
+            params={
+                "search_query": f"all:{query_text}",
+                "start": 0,
+                "max_results": MAX_RESULTS,
+                "sortBy": "relevance",
+                "sortOrder": "descending",
+            },
+        )
+        response.raise_for_status()
+
+    response_text = response.text
+    if _is_rate_limited(response_text):
+        raise ArxivRateLimitError("rate_exceeded")
+
+    feed = await asyncio.to_thread(feedparser.parse, response_text)
+    if getattr(feed, "bozo", 0):
+        bozo_exception = getattr(feed, "bozo_exception", None)
+        raise ValueError(str(bozo_exception or "failed to parse Atom feed"))
+
+    entries = list(getattr(feed, "entries", []))
+    if not entries:
+        raise ValueError("empty feed")
+    return entries
+
+
+def _is_rate_limited(response_text: str) -> bool:
+    return response_text.strip().startswith("Rate exceeded.")
+
+
+def _get_cached_results(query_text: str) -> list[Evidence] | None:
+    cached_entry = _QUERY_CACHE.get(query_text)
+    if cached_entry is None:
+        return None
+
+    results, cached_at = cached_entry
+    if (time.monotonic() - cached_at) > QUERY_CACHE_TTL_SECONDS:
+        _QUERY_CACHE.pop(query_text, None)
+        return None
+
+    return list(results)
+
+
+def _store_cached_results(query_text: str, results: list[Evidence]) -> None:
+    _QUERY_CACHE.pop(query_text, None)
+    _QUERY_CACHE[query_text] = (list(results), time.monotonic())
+
+    while len(_QUERY_CACHE) > QUERY_CACHE_MAX_ENTRIES:
+        oldest_query = next(iter(_QUERY_CACHE))
+        _QUERY_CACHE.pop(oldest_query, None)
 
 
 def _to_evidence(entry: object, *, fetched_at: datetime) -> Evidence:

--- a/tests/unit/test_arxiv_channel.py
+++ b/tests/unit/test_arxiv_channel.py
@@ -45,6 +45,10 @@ def _response(
     )
 
 
+def _subquery(text: str) -> SubQuery:
+    return SubQuery(text=text, rationale="Need paper coverage")
+
+
 @pytest.mark.asyncio
 async def test_search_returns_evidence_from_atom_feed(
     monkeypatch: pytest.MonkeyPatch,
@@ -60,9 +64,7 @@ async def test_search_returns_evidence_from_atom_feed(
 
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
 
-    results = await registry.get("arxiv").search(
-        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
-    )
+    results = await registry.get("arxiv").search(_subquery("retrieval augmented generation"))
 
     assert len(results) == 3
     assert all(isinstance(item, Evidence) for item in results)
@@ -102,9 +104,7 @@ async def test_search_empty_feed_returns_empty_list(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    results = await registry.get("arxiv").search(
-        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
-    )
+    results = await registry.get("arxiv").search(_subquery("retrieval augmented generation"))
 
     assert results == []
     assert logger.events == [
@@ -130,9 +130,7 @@ async def test_search_handles_network_error_gracefully(
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    results = await registry.get("arxiv").search(
-        SubQuery(text="rag", rationale="Need paper coverage")
-    )
+    results = await registry.get("arxiv").search(_subquery("rag"))
 
     assert results == []
     assert logger.events == [
@@ -157,9 +155,7 @@ async def test_search_handles_parse_error_gracefully(
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    results = await registry.get("arxiv").search(
-        SubQuery(text="rag", rationale="Need paper coverage")
-    )
+    results = await registry.get("arxiv").search(_subquery("rag"))
 
     assert results == []
     assert logger.events
@@ -177,9 +173,7 @@ async def test_snippet_truncated_to_500_chars(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
 
-    results = await registry.get("arxiv").search(
-        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
-    )
+    results = await registry.get("arxiv").search(_subquery("retrieval augmented generation"))
 
     assert len(results) == 3
     assert results[1].snippet is not None
@@ -196,11 +190,244 @@ async def test_title_whitespace_normalized(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
 
-    results = await registry.get("arxiv").search(
-        SubQuery(text="retrieval augmented generation", rationale="Need paper coverage")
-    )
+    results = await registry.get("arxiv").search(_subquery("retrieval augmented generation"))
 
     assert len(results) == 3
     assert results[2].title == "Chain-of-Thought Prompting for Retrieval Systems"
     assert "\n" not in results[2].title
     assert "  " not in results[2].title
+
+
+@pytest.mark.asyncio
+async def test_arxiv_rate_exceeded_body_triggers_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, search_callable = _compiled_arxiv()
+    sleep_calls: list[int] = []
+    call_count = 0
+    responses = [
+        "Rate exceeded.",
+        _fixture_text("arxiv_response.atom"),
+    ]
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        nonlocal call_count
+        call_count += 1
+        return _response(responses.pop(0), url=url, params=params)
+
+    async def fake_sleep(delay: int) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+    monkeypatch.setattr(search_callable.__globals__["asyncio"], "sleep", fake_sleep)
+
+    results = await registry.get("arxiv").search(_subquery("retry query"))
+
+    assert len(results) == 3
+    assert call_count == 2
+    assert sleep_calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_arxiv_rate_exceeded_exhausts_retries_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    registry, search_callable = _compiled_arxiv()
+    call_count = 0
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        nonlocal call_count
+        call_count += 1
+        return _response("Rate exceeded.", url=url, params=params)
+
+    async def fake_sleep(delay: int) -> None:
+        _ = delay
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+    monkeypatch.setattr(search_callable.__globals__["asyncio"], "sleep", fake_sleep)
+    monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
+
+    results = await registry.get("arxiv").search(_subquery("retry query"))
+
+    assert results == []
+    assert call_count == 4
+    assert logger.events == [
+        (
+            "arxiv_search_failed",
+            {"reason": "rate_exceeded"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_arxiv_rate_exceeded_backoff_doubles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, search_callable = _compiled_arxiv()
+    sleep_calls: list[int] = []
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        return _response("Rate exceeded.", url=url, params=params)
+
+    async def fake_sleep(delay: int) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+    monkeypatch.setattr(search_callable.__globals__["asyncio"], "sleep", fake_sleep)
+
+    results = await registry.get("arxiv").search(_subquery("retry query"))
+
+    assert results == []
+    assert sleep_calls == [1, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_arxiv_cache_hit_skips_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry, search_callable = _compiled_arxiv()
+    call_count = 0
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        nonlocal call_count
+        call_count += 1
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+
+    first_results = await registry.get("arxiv").search(_subquery("cached query"))
+    second_results = await registry.get("arxiv").search(_subquery("cached query"))
+
+    assert len(first_results) == 3
+    assert second_results == first_results
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_arxiv_cache_respects_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry, search_callable = _compiled_arxiv()
+    call_count = 0
+    now = {"value": 100.0}
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        nonlocal call_count
+        call_count += 1
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+    monkeypatch.setattr(search_callable.__globals__["time"], "monotonic", lambda: now["value"])
+
+    first_results = await registry.get("arxiv").search(_subquery("ttl query"))
+    now["value"] = 401.0
+    second_results = await registry.get("arxiv").search(_subquery("ttl query"))
+
+    assert len(first_results) == 3
+    assert len(second_results) == 3
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_arxiv_cache_different_query_not_reused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, search_callable = _compiled_arxiv()
+    call_count = 0
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        nonlocal call_count
+        call_count += 1
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+
+    first_results = await registry.get("arxiv").search(_subquery("query A"))
+    second_results = await registry.get("arxiv").search(_subquery("query B"))
+
+    assert len(first_results) == 3
+    assert len(second_results) == 3
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_arxiv_cache_does_not_store_rate_limit_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    registry, search_callable = _compiled_arxiv()
+    call_count = 0
+    responses = [
+        "Rate exceeded.",
+        "Rate exceeded.",
+        "Rate exceeded.",
+        "Rate exceeded.",
+        _fixture_text("arxiv_response.atom"),
+    ]
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        nonlocal call_count
+        call_count += 1
+        return _response(responses.pop(0), url=url, params=params)
+
+    async def fake_sleep(delay: int) -> None:
+        _ = delay
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+    monkeypatch.setattr(search_callable.__globals__["asyncio"], "sleep", fake_sleep)
+    monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
+
+    first_results = await registry.get("arxiv").search(_subquery("retry query"))
+
+    assert first_results == []
+    assert search_callable.__globals__["_QUERY_CACHE"] == {}
+
+    second_results = await registry.get("arxiv").search(_subquery("retry query"))
+
+    assert len(second_results) == 3
+    assert call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_arxiv_cache_size_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry, search_callable = _compiled_arxiv()
+    call_count = 0
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        nonlocal call_count
+        call_count += 1
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+
+    for index in range(201):
+        await registry.get("arxiv").search(_subquery(f"query-{index}"))
+
+    cache = search_callable.__globals__["_QUERY_CACHE"]
+
+    assert len(cache) == 200
+    assert "query-0" not in cache
+    assert "query-1" in cache
+    assert "query-200" in cache
+    assert call_count == 201
+
+
+@pytest.mark.asyncio
+async def test_arxiv_valid_xml_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry, search_callable = _compiled_arxiv()
+
+    async def fake_get(self, url: str, *, params: dict[str, object]) -> httpx.Response:
+        _ = self
+        return _response(_fixture_text("arxiv_response.atom"), url=url, params=params)
+
+    monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
+
+    results = await registry.get("arxiv").search(_subquery("xml query"))
+
+    assert len(results) == 3
+    assert all(item.source_channel == "arxiv" for item in results)


### PR DESCRIPTION
## Summary

Fixes HANDOFF.md Pending #1 (tracked since plan-0420): arxiv silently returns 0 evidence when rate-limited because the API responds HTTP 200 with body "Rate exceeded." (plain text, not XML).

- Detect `"Rate exceeded."` body before feedparser handoff → raise `ArxivRateLimitError`
- Retry up to 3 attempts with exp backoff: 1s → 2s → 4s
- On full exhaustion: log warning (channel=arxiv, reason=rate_exceeded) and degrade to `[]`
- 300s TTL cache for successful queries (capped at 200 entries, LRU-evict oldest)
- Cache does NOT store rate-limit failures — next call can retry

## Test plan

- [x] 9 new tests (rate-limit retry / backoff doubling / exhaustion / cache hit / cache TTL / cache different-query / cache no-store-failures / cache size cap / regression)
- [x] Full suite: 613 passed / 18 deselected / 0 failed
- [x] ruff + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)