### PR TITLE
refactor(mcp): replace ResearchResponse str-subclass with pydantic envelope

### DIFF
--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, ConfigDict, Field
 
 from autosearch.core.channel_bootstrap import _build_channels
 from autosearch.core.pipeline import Pipeline
@@ -10,22 +11,16 @@ from autosearch.core.search_scope import SearchScope, depth_to_mode
 from autosearch.llm.client import LLMClient
 
 
-class ResearchResponse(str):
-    def __new__(
-        cls,
-        content: str,
-        *,
-        channel_empty_calls: dict[str, int],
-        routing_trace: dict[str, object],
-        delivery_status: str,
-        scope: SearchScope,
-    ) -> "ResearchResponse":
-        instance = str.__new__(cls, content)
-        instance.channel_empty_calls = dict(channel_empty_calls)
-        instance.routing_trace = dict(routing_trace)
-        instance.delivery_status = delivery_status
-        instance.scope = scope.model_dump()
-        return instance
+class ResearchResponse(BaseModel):
+    """Structured MCP tool response for the research tool."""
+
+    content: str
+    delivery_status: str
+    channel_empty_calls: dict[str, int] = Field(default_factory=dict)
+    routing_trace: dict[str, object] = Field(default_factory=dict)
+    scope: dict[str, object]
+
+    model_config = ConfigDict(extra="forbid")
 
 
 def _default_pipeline_factory() -> Pipeline:
@@ -49,8 +44,8 @@ def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> Fas
         languages: Literal["all", "en_only", "zh_only", "mixed"] | None = None,
         depth: Literal["fast", "deep", "comprehensive"] | None = None,
         output_format: Literal["md", "html"] | None = None,
-    ) -> str:
-        """Run an AutoSearch research query and return the report text."""
+    ) -> ResearchResponse:
+        """Run an AutoSearch research query and return a structured response envelope."""
         scope = SearchScope(
             channel_scope=languages or "all",
             depth=depth or mode,
@@ -63,21 +58,21 @@ def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> Fas
             result = await factory().run(query, mode_hint=mode_hint, scope=scope)
         except Exception as exc:
             return ResearchResponse(
-                f"[error] {exc}",
+                content=f"[error] {exc}",
                 channel_empty_calls={},
                 routing_trace={},
                 delivery_status="error",
-                scope=scope,
+                scope=scope.model_dump(),
             )
 
         if result.delivery_status == "needs_clarification":
             question = result.clarification.question or "More detail is required."
             return ResearchResponse(
-                f"[clarification needed] {question}",
+                content=f"[clarification needed] {question}",
                 channel_empty_calls=result.channel_empty_calls,
                 routing_trace=result.routing_trace,
                 delivery_status=result.delivery_status,
-                scope=scope,
+                scope=scope.model_dump(),
             )
 
         banner = _scope_banner(scope)
@@ -86,7 +81,7 @@ def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> Fas
             markdown_text = f"{banner}\n\n{markdown_text}" if markdown_text else banner
 
         return ResearchResponse(
-            _render_output(
+            content=_render_output(
                 markdown_text=markdown_text,
                 title=query,
                 output_format=scope.output_format,
@@ -94,7 +89,7 @@ def create_server(pipeline_factory: Callable[[], Pipeline] | None = None) -> Fas
             channel_empty_calls=result.channel_empty_calls,
             routing_trace=result.routing_trace,
             delivery_status=result.delivery_status,
-            scope=scope,
+            scope=scope.model_dump(),
         )
 
     @server.tool()

--- a/tests/unit/test_mcp_research_scope.py
+++ b/tests/unit/test_mcp_research_scope.py
@@ -68,7 +68,11 @@ async def test_research_accepts_scope_params_with_defaults(
     research_tool = server._tool_manager.get_tool("research")
 
     assert research_tool is not None
-    assert await research_tool.run({"query": "test query"}) == "# Test\n\nBody"
+    result = await research_tool.run({"query": "test query"})
+    assert isinstance(result, mcp_server.ResearchResponse)
+    assert result.content == "# Test\n\nBody"
+    assert result.delivery_status == "ok"
+    assert result.scope == SearchScope().model_dump()
     assert pipeline.calls == [("test query", SearchMode.FAST, SearchScope())]
 
 
@@ -116,7 +120,7 @@ async def test_research_emits_scope_banner_for_nondefault_scope(
 
     assert research_tool is not None
     result = await research_tool.run({"query": "test query", "languages": "zh_only"})
-    assert result.startswith("[scope] languages=zh_only")
+    assert result.content.startswith("[scope] languages=zh_only")
 
 
 @pytest.mark.asyncio
@@ -130,7 +134,8 @@ async def test_research_no_banner_for_default_scope(
     research_tool = server._tool_manager.get_tool("research")
 
     assert research_tool is not None
-    assert await research_tool.run({"query": "test query"}) == "# Test\n\nBody"
+    result = await research_tool.run({"query": "test query"})
+    assert result.content == "# Test\n\nBody"
 
 
 @pytest.mark.asyncio
@@ -145,7 +150,7 @@ async def test_research_html_format_wraps_markdown(
 
     assert research_tool is not None
     result = await research_tool.run({"query": "test query", "output_format": "html"})
-    assert result.startswith("<!doctype html>")
+    assert result.content.startswith("<!doctype html>")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -87,10 +87,19 @@ async def test_create_server_registers_research_tool() -> None:
     tools = await server.list_tools()
 
     assert {tool.name for tool in tools} >= {"research", "health"}
+    research = next(tool for tool in tools if tool.name == "research")
+    assert research.outputSchema is not None
+    assert set(research.outputSchema["properties"]) >= {
+        "content",
+        "delivery_status",
+        "channel_empty_calls",
+        "routing_trace",
+        "scope",
+    }
 
 
 @pytest.mark.asyncio
-async def test_research_tool_returns_markdown_for_ok_result(
+async def test_research_tool_returns_structured_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pipeline = _StubPipeline(result=_ok_result())
@@ -100,12 +109,39 @@ async def test_research_tool_returns_markdown_for_ok_result(
     research_tool = server._tool_manager.get_tool("research")
 
     assert research_tool is not None
-    assert await research_tool.run({"query": "test query", "mode": "fast"}) == "# Test\n\nBody"
+    result = await research_tool.run({"query": "test query", "mode": "fast"})
+    assert isinstance(result, mcp_server.ResearchResponse)
+    assert result.content == "# Test\n\nBody"
+    assert result.delivery_status == "ok"
+    assert result.channel_empty_calls == {}
+    assert result.routing_trace == {}
+    assert result.scope == {
+        "domain_followups": [],
+        "channel_scope": "all",
+        "depth": "fast",
+        "output_format": "md",
+    }
     assert pipeline.calls == [("test query", SearchMode.FAST)]
 
 
 @pytest.mark.asyncio
-async def test_research_tool_returns_clarification_prompt(
+async def test_research_tool_success_path_content_is_markdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _StubPipeline(result=_ok_result())
+    _install_default_factory(monkeypatch, pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+    result = await research_tool.run({"query": "test query", "mode": "fast"})
+    assert result.content == "# Test\n\nBody"
+    assert result.delivery_status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_research_tool_clarification_path_flagged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pipeline = _StubPipeline(result=_clarification_result())
@@ -116,12 +152,14 @@ async def test_research_tool_returns_clarification_prompt(
 
     assert research_tool is not None
     result = await research_tool.run({"query": "test query", "mode": "deep"})
-    assert result.startswith("[clarification needed]")
+    assert isinstance(result, mcp_server.ResearchResponse)
+    assert result.content == "[clarification needed] Which deployment target matters most?"
+    assert result.delivery_status == "needs_clarification"
     assert pipeline.calls == [("test query", SearchMode.DEEP)]
 
 
 @pytest.mark.asyncio
-async def test_research_tool_returns_error_prefix_on_exception(
+async def test_research_tool_error_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pipeline = _StubPipeline(exc=RuntimeError("boom"))
@@ -131,8 +169,33 @@ async def test_research_tool_returns_error_prefix_on_exception(
     research_tool = server._tool_manager.get_tool("research")
 
     assert research_tool is not None
-    assert await research_tool.run({"query": "test query", "mode": "fast"}) == "[error] boom"
+    result = await research_tool.run({"query": "test query", "mode": "fast"})
+    assert isinstance(result, mcp_server.ResearchResponse)
+    assert result.content.startswith("[error]")
+    assert result.content == "[error] boom"
+    assert result.delivery_status == "error"
     assert pipeline.calls == [("test query", SearchMode.FAST)]
+
+
+@pytest.mark.asyncio
+async def test_research_response_serializable_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pipeline = _StubPipeline(result=_ok_result())
+    _install_default_factory(monkeypatch, pipeline)
+    server = mcp_server.create_server()
+
+    research_tool = server._tool_manager.get_tool("research")
+
+    assert research_tool is not None
+    result = await research_tool.run({"query": "test query", "mode": "fast"})
+    payload = result.model_dump()
+    encoded = result.model_dump_json()
+    decoded = mcp_server.ResearchResponse.model_validate_json(encoded)
+
+    assert payload["content"] == "# Test\n\nBody"
+    assert payload["delivery_status"] == "ok"
+    assert decoded == result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes HANDOFF Pending #8: MCP `research` tool used a `class ResearchResponse(str)` hack — subclassed str to smuggle metadata via instance attributes. Replace with proper pydantic v2 envelope that FastMCP exposes as structured output with a real `outputSchema`.

Before: tool returned a str with hidden attributes.
After: tool returns `ResearchResponse` pydantic model with explicit `content` / `delivery_status` / `channel_empty_calls` / `routing_trace` / `scope` fields.

MCP clients now get structured data instead of having to introspect a str subclass.

## Test plan

- [x] 10 MCP test cases updated to assert pydantic model fields
- [x] Full suite: 615 passed / 18 deselected / 0 failed
- [x] ruff + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Research tool responses now return structured data containing delivery status, routing trace, channel call metrics, and request scope information.

* **Improvements**
  * Enhanced response validation prevents invalid data and ensures consistency across all API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->