### PR TITLE
feat(core): per-iteration routing history in routing_trace

### DIFF
--- a/autosearch/core/iteration.py
+++ b/autosearch/core/iteration.py
@@ -1,5 +1,6 @@
 # Source: open_deep_research/src/legacy/graph.py:L235-L354 (adapted)
 import asyncio
+import inspect
 from dataclasses import dataclass
 
 import structlog
@@ -135,6 +136,10 @@ class IterationController:
             else None,
         )
         batch_size = max(1, budget.subquery_batch_size)
+        search_supports_iteration_trace = _callable_accepts_keyword(
+            self._search,
+            "iteration_trace",
+        )
 
         for iteration in range(1, budget.max_iterations + 1):
             if not active_queries:
@@ -149,6 +154,10 @@ class IterationController:
 
             collected_batch_gaps: list[Gap] = []
             subquery_batches = _partition_subqueries(active_queries, batch_size)
+            iteration_routing_trace = _initial_iteration_routing_entry(
+                iteration,
+                batch_count=len(subquery_batches),
+            )
             round_evidence_count = 0
             self.logger.info(
                 "iteration_phase_started",
@@ -169,12 +178,17 @@ class IterationController:
                     subqueries=len(batch_subqueries),
                     channels=len(channels),
                 )
+                search_kwargs: dict[str, object] = {
+                    "priority_channels": effective_priority,
+                    "skip_channels": effective_skip,
+                }
+                if search_supports_iteration_trace:
+                    search_kwargs["iteration_trace"] = iteration_routing_trace
                 batch_evidence = await self._search(
                     batch_subqueries,
                     channels,
                     iteration,
-                    priority_channels=effective_priority,
-                    skip_channels=effective_skip,
+                    **search_kwargs,
                 )
                 round_evidence_count += len(batch_evidence)
                 accumulated_evidence = self._dedup_accumulated_evidence(
@@ -299,6 +313,7 @@ class IterationController:
 
             all_gaps = _dedup_gaps(gaps + collected_batch_gaps)
 
+            should_continue = False
             if iteration >= budget.max_iterations or not all_gaps:
                 self.logger.info(
                     "iteration_phase_completed",
@@ -311,39 +326,43 @@ class IterationController:
                         else "no_remaining_gaps"
                     ),
                 )
-                break
-
-            self.logger.info("iteration_phase_started", phase="followup", iteration=iteration)
-            active_queries = await self._follow_up(
-                query=query,
-                gaps=all_gaps,
-                evidences=accumulated_evidence,
-                client=client,
-            )
-            self.logger.info(
-                "iteration_phase_completed",
-                phase="followup",
-                iteration=iteration,
-                subqueries=len(active_queries),
-            )
-
-            if not active_queries:
+            else:
+                self.logger.info("iteration_phase_started", phase="followup", iteration=iteration)
+                active_queries = await self._follow_up(
+                    query=query,
+                    gaps=all_gaps,
+                    evidences=accumulated_evidence,
+                    client=client,
+                )
                 self.logger.info(
                     "iteration_phase_completed",
-                    phase="route",
+                    phase="followup",
                     iteration=iteration,
-                    decision="stop",
-                    reason="no_follow_up_queries",
+                    subqueries=len(active_queries),
                 )
-                break
 
-            self.logger.info(
-                "iteration_phase_completed",
-                phase="route",
-                iteration=iteration,
-                decision="continue",
-                next_iteration=iteration + 1,
-            )
+                if not active_queries:
+                    self.logger.info(
+                        "iteration_phase_completed",
+                        phase="route",
+                        iteration=iteration,
+                        decision="stop",
+                        reason="no_follow_up_queries",
+                    )
+                else:
+                    self.logger.info(
+                        "iteration_phase_completed",
+                        phase="route",
+                        iteration=iteration,
+                        decision="continue",
+                        next_iteration=iteration + 1,
+                    )
+                    should_continue = True
+
+            _append_iteration_routing_entry(self.routing_trace, iteration_routing_trace)
+
+            if not should_continue:
+                break
 
             if budget.per_channel_rate_limit > 0:
                 await asyncio.sleep(budget.per_channel_rate_limit)
@@ -360,6 +379,7 @@ class IterationController:
         iteration: int,
         priority_channels: set[str] | None = None,
         skip_channels: set[str] | None = None,
+        iteration_trace: dict[str, object] | None = None,
     ) -> list[Evidence]:
         effective_priority = set(priority_channels or [])
         effective_skip = set(skip_channels or [])
@@ -372,10 +392,14 @@ class IterationController:
         runnable_channels = [channel for channel in channels if channel.name not in effective_skip]
         skipped_names = [channel.name for channel in channels if channel.name in effective_skip]
         _extend_unique_names(self.routing_trace, "skipped_channels", skipped_names)
+        if iteration_trace is not None:
+            _extend_unique_names(iteration_trace, "skipped", skipped_names)
 
         if not effective_priority:
             rest_names = [channel.name for channel in runnable_channels]
             _extend_unique_names(self.routing_trace, "rest_ran", rest_names)
+            if iteration_trace is not None:
+                _extend_unique_names(iteration_trace, "rest_ran", rest_names)
             return await self._run_channel_batch(subqueries, runnable_channels, iteration)
 
         priority_batch = [
@@ -387,17 +411,28 @@ class IterationController:
 
         priority_names = [channel.name for channel in priority_batch]
         _extend_unique_names(self.routing_trace, "priority_ran", priority_names)
+        if iteration_trace is not None:
+            _extend_unique_names(iteration_trace, "priority_ran", priority_names)
         priority_evidence = await self._run_channel_batch(subqueries, priority_batch, iteration)
-        self.routing_trace["priority_evidence_count"] = int(
-            self.routing_trace.get("priority_evidence_count", 0)
-        ) + len(priority_evidence)
+        priority_evidence_count = len(priority_evidence)
+        self.routing_trace["priority_evidence_count"] = (
+            int(self.routing_trace.get("priority_evidence_count", 0)) + priority_evidence_count
+        )
+        if iteration_trace is not None:
+            iteration_trace["priority_evidence_count"] = (
+                int(iteration_trace.get("priority_evidence_count", 0)) + priority_evidence_count
+            )
 
         if len(priority_evidence) >= FALLBACK_THRESHOLD or not rest_batch:
             return priority_evidence
 
         self.routing_trace["fallback_triggered"] = True
+        if iteration_trace is not None:
+            iteration_trace["fallback_triggered"] = True
         rest_names = [channel.name for channel in rest_batch]
         _extend_unique_names(self.routing_trace, "rest_ran", rest_names)
+        if iteration_trace is not None:
+            _extend_unique_names(iteration_trace, "rest_ran", rest_names)
         rest_evidence = await self._run_channel_batch(subqueries, rest_batch, iteration)
         return priority_evidence + rest_evidence
 
@@ -746,6 +781,23 @@ def _initial_routing_trace(
         "priority_evidence_count": 0,
         "fallback_triggered": False,
         "skipped_channels": list(skipped),
+        "iterations": [],
+    }
+
+
+def _initial_iteration_routing_entry(
+    iteration: int,
+    *,
+    batch_count: int,
+) -> dict[str, object]:
+    return {
+        "iteration": iteration,
+        "priority_ran": [],
+        "rest_ran": [],
+        "skipped": [],
+        "priority_evidence_count": 0,
+        "fallback_triggered": False,
+        "batch_count": batch_count,
     }
 
 
@@ -775,3 +827,26 @@ def _extend_unique_names(trace: dict[str, object], key: str, names: list[str]) -
             continue
         existing.append(name)
         seen.add(name)
+
+
+def _append_iteration_routing_entry(
+    trace: dict[str, object],
+    iteration_trace: dict[str, object],
+) -> None:
+    iterations = trace.get("iterations")
+    if not isinstance(iterations, list):
+        iterations = []
+        trace["iterations"] = iterations
+    iterations.append(iteration_trace)
+
+
+def _callable_accepts_keyword(callable_obj: object, keyword: str) -> bool:
+    try:
+        parameters = inspect.signature(callable_obj).parameters.values()
+    except (TypeError, ValueError):
+        return False
+
+    return any(
+        parameter.name == keyword or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )

--- a/tests/unit/test_iteration_routing.py
+++ b/tests/unit/test_iteration_routing.py
@@ -52,6 +52,21 @@ def make_evidence(url: str, *, source_channel: str) -> Evidence:
     )
 
 
+def aggregate_iteration_names(iterations: list[dict[str, object]], key: str) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for entry in iterations:
+        values = entry.get(key)
+        if not isinstance(values, list):
+            continue
+        for name in values:
+            if not isinstance(name, str) or name in seen:
+                continue
+            seen.add(name)
+            names.append(name)
+    return names
+
+
 async def test_iteration_runs_priority_channels_first() -> None:
     controller = IterationController()
     call_order: list[str] = []
@@ -106,6 +121,170 @@ async def test_iteration_skips_channels_in_skip_list() -> None:
     assert controller.routing_trace["skipped_channels"] == ["B"]
 
 
+async def test_routing_trace_has_iterations_list() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    channel = FakeChannel(
+        "A",
+        [
+            [make_evidence("https://example.com/a-1", source_channel="A")],
+            [make_evidence("https://example.com/a-2", source_channel="A")],
+        ],
+        call_order=call_order,
+    )
+    client = DummyClient(
+        [
+            {"gaps": [{"topic": "follow-up", "reason": "Need one more pass"}]},
+            {"subqueries": [{"text": "follow-up query", "rationale": "continue research"}]},
+            {"gaps": []},
+        ]
+    )
+
+    await controller.run(
+        query="routing trace history",
+        initial_queries=[SubQuery(text="routing trace history", rationale="seed")],
+        channels=[channel],
+        budget=IterationBudget(max_iterations=2, per_channel_rate_limit=0.0),
+        client=client,
+    )
+
+    iterations = controller.routing_trace["iterations"]
+
+    assert len(iterations) == 2
+    assert [entry["iteration"] for entry in iterations] == [1, 2]
+
+
+async def test_iterations_entry_shape() -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        "A",
+        [[make_evidence("https://example.com/a", source_channel="A")]],
+        call_order=[],
+    )
+    client = DummyClient([{"gaps": []}])
+
+    await controller.run(
+        query="routing trace shape",
+        initial_queries=[SubQuery(text="routing trace shape", rationale="seed")],
+        channels=[channel],
+        budget=IterationBudget(max_iterations=1, per_channel_rate_limit=0.0),
+        client=client,
+    )
+
+    iteration_trace = controller.routing_trace["iterations"][0]
+
+    assert set(iteration_trace) == {
+        "iteration",
+        "priority_ran",
+        "rest_ran",
+        "skipped",
+        "priority_evidence_count",
+        "fallback_triggered",
+        "batch_count",
+    }
+    assert iteration_trace["batch_count"] == 1
+
+
+async def test_iterations_priority_ran_matches_actual_channels_this_iteration() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    channels = [
+        FakeChannel(
+            "arxiv",
+            [
+                [
+                    make_evidence(f"https://example.com/arxiv-{index}", source_channel="arxiv")
+                    for index in range(FALLBACK_THRESHOLD)
+                ],
+                [],
+            ],
+            call_order=call_order,
+        ),
+        FakeChannel(
+            "devto",
+            [[make_evidence("https://example.com/devto-2", source_channel="devto")]],
+            call_order=call_order,
+        ),
+    ]
+    client = DummyClient(
+        [
+            {"gaps": [{"topic": "follow-up", "reason": "Need another pass"}]},
+            {"subqueries": [{"text": "follow-up query", "rationale": "continue research"}]},
+            {"gaps": []},
+        ]
+    )
+
+    await controller.run(
+        query="routing tiers",
+        initial_queries=[SubQuery(text="routing tiers", rationale="seed")],
+        channels=channels,
+        budget=IterationBudget(max_iterations=2, per_channel_rate_limit=0.0),
+        client=client,
+        priority_channels={"arxiv"},
+    )
+
+    iterations = controller.routing_trace["iterations"]
+
+    assert call_order == ["arxiv", "arxiv", "devto"]
+    assert iterations[0]["priority_ran"] == ["arxiv"]
+    assert iterations[0]["rest_ran"] == []
+    assert iterations[1]["priority_ran"] == ["arxiv"]
+    assert iterations[1]["rest_ran"] == ["devto"]
+    assert iterations[0]["priority_evidence_count"] == FALLBACK_THRESHOLD
+    assert iterations[1]["priority_evidence_count"] == 0
+
+
+async def test_iterations_preserves_aggregate_view() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    channels = [
+        FakeChannel(
+            "arxiv",
+            [
+                [
+                    make_evidence(f"https://example.com/arxiv-{index}", source_channel="arxiv")
+                    for index in range(FALLBACK_THRESHOLD)
+                ],
+                [],
+            ],
+            call_order=call_order,
+        ),
+        FakeChannel(
+            "devto",
+            [[make_evidence("https://example.com/devto-2", source_channel="devto")]],
+            call_order=call_order,
+        ),
+        FakeChannel("bilibili", [], call_order=call_order),
+    ]
+    client = DummyClient(
+        [
+            {"gaps": [{"topic": "follow-up", "reason": "Need another pass"}]},
+            {"subqueries": [{"text": "follow-up query", "rationale": "continue research"}]},
+            {"gaps": []},
+        ]
+    )
+
+    await controller.run(
+        query="aggregate routing trace",
+        initial_queries=[SubQuery(text="aggregate routing trace", rationale="seed")],
+        channels=channels,
+        budget=IterationBudget(max_iterations=2, per_channel_rate_limit=0.0),
+        client=client,
+        priority_channels={"arxiv"},
+        skip_channels={"bilibili"},
+    )
+
+    iterations = controller.routing_trace["iterations"]
+
+    assert controller.routing_trace["priority_ran"] == aggregate_iteration_names(
+        iterations, "priority_ran"
+    )
+    assert controller.routing_trace["rest_ran"] == aggregate_iteration_names(iterations, "rest_ran")
+    assert controller.routing_trace["skipped_channels"] == aggregate_iteration_names(
+        iterations, "skipped"
+    )
+
+
 async def test_iteration_fallback_triggered_when_priority_empty() -> None:
     controller = IterationController()
     call_order: list[str] = []
@@ -133,6 +312,52 @@ async def test_iteration_fallback_triggered_when_priority_empty() -> None:
     assert controller.routing_trace["priority_evidence_count"] == 0
     assert controller.routing_trace["fallback_triggered"] is True
     assert controller.routing_trace["rest_ran"] == ["B"]
+
+
+async def test_iterations_fallback_triggered_per_iteration() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    channels = [
+        FakeChannel(
+            "arxiv",
+            [
+                [],
+                [
+                    make_evidence(f"https://example.com/arxiv-{index}", source_channel="arxiv")
+                    for index in range(FALLBACK_THRESHOLD)
+                ],
+            ],
+            call_order=call_order,
+        ),
+        FakeChannel(
+            "devto",
+            [[make_evidence("https://example.com/devto-1", source_channel="devto")]],
+            call_order=call_order,
+        ),
+    ]
+    client = DummyClient(
+        [
+            {"gaps": [{"topic": "follow-up", "reason": "Need another pass"}]},
+            {"subqueries": [{"text": "follow-up query", "rationale": "continue research"}]},
+            {"gaps": []},
+        ]
+    )
+
+    await controller.run(
+        query="iteration fallback trace",
+        initial_queries=[SubQuery(text="iteration fallback trace", rationale="seed")],
+        channels=channels,
+        budget=IterationBudget(max_iterations=2, per_channel_rate_limit=0.0),
+        client=client,
+        priority_channels={"arxiv"},
+    )
+
+    iterations = controller.routing_trace["iterations"]
+
+    assert call_order == ["arxiv", "devto", "arxiv"]
+    assert iterations[0]["fallback_triggered"] is True
+    assert iterations[1]["fallback_triggered"] is False
+    assert controller.routing_trace["fallback_triggered"] is True
 
 
 async def test_iteration_fallback_not_triggered_when_priority_sufficient() -> None:
@@ -172,3 +397,60 @@ async def test_iteration_fallback_not_triggered_when_priority_sufficient() -> No
     assert controller.routing_trace["priority_evidence_count"] == FALLBACK_THRESHOLD
     assert controller.routing_trace["fallback_triggered"] is False
     assert controller.routing_trace["rest_ran"] == []
+
+
+async def test_iterations_empty_when_no_iterations_run() -> None:
+    controller = IterationController()
+    channel = FakeChannel(
+        "A",
+        [[make_evidence("https://example.com/a", source_channel="A")]],
+        call_order=[],
+    )
+    client = DummyClient([])
+
+    evidences, research_trace = await controller.run(
+        query="zero budget",
+        initial_queries=[SubQuery(text="zero budget", rationale="seed")],
+        channels=[channel],
+        budget=IterationBudget(max_iterations=0, per_channel_rate_limit=0.0),
+        client=client,
+    )
+
+    assert evidences == []
+    assert research_trace == []
+    assert controller.routing_trace["iterations"] == []
+
+
+async def test_backward_compat_aggregate_fields_unchanged() -> None:
+    controller = IterationController()
+    call_order: list[str] = []
+    channels = [
+        FakeChannel("A", [[]], call_order=call_order),
+        FakeChannel(
+            "B",
+            [[make_evidence("https://example.com/b", source_channel="B")]],
+            call_order=call_order,
+        ),
+        FakeChannel("C", [], call_order=call_order),
+    ]
+    client = DummyClient([{"gaps": []}])
+
+    evidences, _ = await controller.run(
+        query="backward compat routing trace",
+        initial_queries=[SubQuery(text="backward compat routing trace", rationale="seed")],
+        channels=channels,
+        budget=IterationBudget(max_iterations=1, per_channel_rate_limit=0.0),
+        client=client,
+        priority_channels={"A"},
+        skip_channels={"C"},
+    )
+
+    assert [evidence.source_channel for evidence in evidences] == ["B"]
+    assert call_order == ["A", "B"]
+    assert controller.routing_trace["priority"] == ["A"]
+    assert controller.routing_trace["skip"] == ["C"]
+    assert controller.routing_trace["priority_ran"] == ["A"]
+    assert controller.routing_trace["rest_ran"] == ["B"]
+    assert controller.routing_trace["skipped_channels"] == ["C"]
+    assert controller.routing_trace["priority_evidence_count"] == 0
+    assert controller.routing_trace["fallback_triggered"] is True


### PR DESCRIPTION
## Summary

Fixes HANDOFF Pending #7: `routing_trace` kept only aggregate view (union of all iterations' channels ran / skipped / fallback-triggered). Debugging a long run could not tell "which channels ran in iteration 2 vs iteration 5".

Adds `routing_trace["iterations"]: list[dict]` alongside existing aggregate fields (fully backward-compat).

Each entry:
- `iteration`, `priority_ran`, `rest_ran`, `skipped`, `priority_evidence_count`, `fallback_triggered`, `batch_count`

## Test plan

- [x] 7 new tests (per-iteration shape / tier accuracy / fallback per iteration / aggregate consistency / zero-iteration / backward-compat)
- [x] Full suite: 622 passed / 18 deselected / 0 failed
- [x] ruff + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)