### PR TITLE
chore(perf): bless channel wall-time baseline after W1+arxiv fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ tests/integration/reports/
 tests/integration/tmp/
 tests/integration/sessions/
 tests/perf/channel_wall_time_last.json
-tests/perf/channel_wall_time_baseline.json
 
 # E2B per-run artifacts (transient per-task stdout/stderr logs); master reports live in docs/validation/
 reports/

--- a/tests/perf/channel_wall_time_baseline.json
+++ b/tests/perf/channel_wall_time_baseline.json
@@ -1,0 +1,8 @@
+{
+  "arxiv": 0.06,
+  "devto": 0.041,
+  "hackernews": 0.494,
+  "stackoverflow": 0.333,
+  "wikidata": 0.329,
+  "wikipedia": 0.5
+}


### PR DESCRIPTION
## Summary

Fixes HANDOFF Pending #3. Runs `pytest -m "perf and network" tests/perf/test_channel_wall_time.py -s` with `AUTOSEARCH_PERF_WRITE_BASELINE=1`, writes the 6-channel baseline, removes the file from `.gitignore`, commits as the regression reference.

Baseline (all 6 T0 channels returning 10 evidence):
- arxiv: 0.06s (post-W1 HTTP→HTTPS redirect fix + post-arxiv-rate-limit commit)
- devto: 0.041s (post-W1 tag→search param fix)
- hackernews: 0.494s
- stackoverflow: 0.333s
- wikidata: 0.329s
- wikipedia: 0.5s

Future runs without `WRITE_BASELINE=1` will fail if any channel exceeds `REGRESSION_FACTOR × baseline`.

## Test plan

- [x] perf test ran successfully, all channels evidence=10 / error=null
- [x] baseline JSON committed, `last.json` stays gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)