### PR TITLE
feat(lib): playwright browser fetcher scaffold (optional extra)

### DIFF
--- a/autosearch/lib/browser_fetcher.py
+++ b/autosearch/lib/browser_fetcher.py
@@ -1,0 +1,105 @@
+"""Optional Playwright-backed browser fetcher for JS-rendered pages.
+Install with: `pip install "autosearch[browser]" && playwright install chromium`.
+Usage: `from autosearch.lib.browser_fetcher import fetch_page_with_js`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import structlog
+
+from autosearch.core.models import FetchedPage
+
+LOGGER = structlog.get_logger(__name__).bind(component="browser_fetcher")
+DEFAULT_TIMEOUT_MS = 30_000
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+class BrowserNotInstalledError(RuntimeError):
+    """Raised when Playwright or Chromium is not available."""
+
+
+@dataclass(frozen=True)
+class BrowserFetchConfig:
+    headless: bool = True
+    timeout_ms: int = DEFAULT_TIMEOUT_MS
+    user_agent: str = DEFAULT_USER_AGENT
+    wait_for_selector: str | None = None
+    wait_until: str = "networkidle"
+    extra_http_headers: dict[str, str] | None = None
+
+
+async def fetch_page_with_js(
+    url: str,
+    *,
+    config: BrowserFetchConfig | None = None,
+    run_prune: bool = True,
+) -> FetchedPage:
+    """Navigate to a URL with Chromium, then return the shared FetchedPage shape."""
+    cfg = config or BrowserFetchConfig()
+
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError as exc:
+        raise BrowserNotInstalledError(
+            "Playwright is not installed. To use browser fetch: "
+            'pip install "autosearch[browser]" && playwright install chromium'
+        ) from exc
+
+    LOGGER.debug(
+        "browser_fetch_start",
+        url=url,
+        headless=cfg.headless,
+        wait_until=cfg.wait_until,
+        wait_for_selector=cfg.wait_for_selector,
+    )
+
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(headless=cfg.headless)
+        except Exception as exc:
+            raise BrowserNotInstalledError(
+                "Chromium binary not found. Run: playwright install chromium"
+            ) from exc
+
+        context = None
+        try:
+            context = await browser.new_context(
+                user_agent=cfg.user_agent,
+                extra_http_headers=cfg.extra_http_headers or {},
+            )
+            page = await context.new_page()
+            response = await page.goto(
+                url,
+                timeout=cfg.timeout_ms,
+                wait_until=cfg.wait_until,
+            )
+            if cfg.wait_for_selector:
+                await page.wait_for_selector(
+                    cfg.wait_for_selector,
+                    timeout=cfg.timeout_ms,
+                )
+            html = await page.content()
+            status_code = response.status if response is not None else 0
+        finally:
+            try:
+                if context is not None:
+                    await context.close()
+            finally:
+                await browser.close()
+
+    LOGGER.debug("browser_fetch_complete", url=url, status_code=status_code)
+
+    # Import locally so the optional Playwright feature stays decoupled from the static path.
+    from autosearch.lib.html_scraper import _parse_html_into_page
+
+    return _parse_html_into_page(
+        url=url,
+        html=html,
+        status_code=status_code,
+        run_prune=run_prune,
+    )

--- a/autosearch/lib/html_scraper.py
+++ b/autosearch/lib/html_scraper.py
@@ -74,8 +74,23 @@ async def fetch_page(
     # TODO: fetch_html only returns the response body today; return response metadata to preserve
     # the real status code here instead of assuming 200 on success.
     status_code = 200
-    soup = BeautifulSoup(raw_html, "html.parser")
-    cleaned_html = PruningCleaner().clean(raw_html) if run_prune else raw_html
+    return _parse_html_into_page(
+        url=url,
+        html=raw_html,
+        status_code=status_code,
+        run_prune=run_prune,
+    )
+
+
+def _parse_html_into_page(
+    *,
+    url: str,
+    html: str,
+    status_code: int,
+    run_prune: bool = True,
+) -> FetchedPage:
+    soup = BeautifulSoup(html, "html.parser")
+    cleaned_html = PruningCleaner().clean(html) if run_prune else html
     markdown = markdownify(
         cleaned_html,
         heading_style="ATX",
@@ -85,7 +100,7 @@ async def fetch_page(
     return FetchedPage(
         url=url,
         status_code=status_code,
-        html=raw_html,
+        html=html,
         cleaned_html=cleaned_html,
         markdown=markdown,
         links=_extract_links(soup, base_url=url),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ dependencies = [
   "uvicorn",
 ]
 
+[project.optional-dependencies]
+browser = [
+  "playwright>=1.40",
+]
+
 [project.scripts]
 autosearch = "autosearch.cli.main:app"
 autosearch-mcp = "autosearch.mcp.cli:main"

--- a/tests/unit/lib/test_browser_fetcher.py
+++ b/tests/unit/lib/test_browser_fetcher.py
@@ -1,0 +1,203 @@
+import builtins
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from autosearch.lib.browser_fetcher import (
+    DEFAULT_TIMEOUT_MS,
+    DEFAULT_USER_AGENT,
+    BrowserFetchConfig,
+    BrowserNotInstalledError,
+    fetch_page_with_js,
+)
+from autosearch.lib.html_scraper import fetch_page
+
+
+def _clear_playwright_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(sys.modules, "playwright", raising=False)
+    monkeypatch.delitem(sys.modules, "playwright.async_api", raising=False)
+
+
+def _install_fake_playwright(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    page_html: str,
+    response_status: int = 200,
+    launch_side_effect: Exception | None = None,
+) -> dict[str, object]:
+    _clear_playwright_modules(monkeypatch)
+
+    response = Mock(status=response_status)
+
+    page = Mock()
+    page.goto = AsyncMock(return_value=response)
+    page.content = AsyncMock(return_value=page_html)
+    page.wait_for_selector = AsyncMock()
+
+    context = Mock()
+    context.new_page = AsyncMock(return_value=page)
+    context.close = AsyncMock()
+
+    browser = Mock()
+    browser.new_context = AsyncMock(return_value=context)
+    browser.close = AsyncMock()
+
+    chromium = Mock()
+    if launch_side_effect is None:
+        chromium.launch = AsyncMock(return_value=browser)
+    else:
+        chromium.launch = AsyncMock(side_effect=launch_side_effect)
+
+    playwright = Mock(chromium=chromium)
+    playwright_context = AsyncMock()
+    playwright_context.__aenter__.return_value = playwright
+    playwright_context.__aexit__.return_value = False
+
+    async_playwright = Mock(return_value=playwright_context)
+
+    playwright_package = ModuleType("playwright")
+    playwright_package.__path__ = []
+    async_api_module = ModuleType("playwright.async_api")
+    async_api_module.async_playwright = async_playwright
+
+    monkeypatch.setitem(sys.modules, "playwright", playwright_package)
+    monkeypatch.setitem(sys.modules, "playwright.async_api", async_api_module)
+
+    return {
+        "async_playwright": async_playwright,
+        "browser": browser,
+        "chromium": chromium,
+        "context": context,
+        "page": page,
+    }
+
+
+@pytest.mark.asyncio
+async def test_browser_fetcher_raises_when_playwright_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_playwright_modules(monkeypatch)
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "playwright.async_api":
+            raise ImportError("No module named 'playwright.async_api'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(BrowserNotInstalledError) as exc_info:
+        await fetch_page_with_js("https://example.com/post")
+
+    assert 'pip install "autosearch[browser]"' in str(exc_info.value)
+    assert "playwright install chromium" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_browser_fetcher_raises_when_chromium_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_playwright(
+        monkeypatch,
+        page_html="<html></html>",
+        launch_side_effect=RuntimeError("Executable doesn't exist"),
+    )
+
+    with pytest.raises(BrowserNotInstalledError) as exc_info:
+        await fetch_page_with_js("https://example.com/post")
+
+    assert "Chromium binary not found" in str(exc_info.value)
+    assert "playwright install chromium" in str(exc_info.value)
+
+
+def test_browser_fetch_config_defaults() -> None:
+    config = BrowserFetchConfig()
+
+    assert config.headless is True
+    assert config.timeout_ms == DEFAULT_TIMEOUT_MS
+    assert config.user_agent == DEFAULT_USER_AGENT
+    assert config.wait_for_selector is None
+    assert config.wait_until == "networkidle"
+    assert config.extra_http_headers is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_with_js_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    mocks = _install_fake_playwright(
+        monkeypatch,
+        page_html="""
+        <html>
+          <head><title>Browser Title</title></head>
+          <body>
+            <article>
+              <p>Loaded via JS.</p>
+              <a href="/about">About</a>
+            </article>
+          </body>
+        </html>
+        """,
+        response_status=206,
+    )
+
+    page = await fetch_page_with_js("https://example.com/post", run_prune=False)
+
+    assert page.status_code == 206
+    assert page.metadata["title"] == "Browser Title"
+    assert "# Browser Title" not in page.markdown
+    assert "Loaded via JS." in page.markdown
+    assert page.links[0].href == "https://example.com/about"
+    assert mocks["page"].goto.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_with_js_wait_for_selector_called(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocks = _install_fake_playwright(
+        monkeypatch,
+        page_html="<html><body><article>Ready</article></body></html>",
+    )
+    config = BrowserFetchConfig(wait_for_selector="article", timeout_ms=12_345)
+
+    await fetch_page_with_js("https://example.com/post", config=config)
+
+    mocks["page"].wait_for_selector.assert_awaited_once_with(
+        "article",
+        timeout=12_345,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_with_js_reuses_html_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    html = """
+    <html>
+      <head>
+        <title>Shared Parser</title>
+        <meta property="og:description" content="Same output" />
+      </head>
+      <body>
+        <article>
+          <p>Rendered content.</p>
+          <a href="/story">Story</a>
+          <img src="/image.png" alt="Hero" />
+        </article>
+      </body>
+    </html>
+    """
+
+    async def fake_fetch_html(*args: object, **kwargs: object) -> str:
+        return html
+
+    monkeypatch.setattr("autosearch.lib.html_scraper.fetch_html", fake_fetch_html)
+    _install_fake_playwright(monkeypatch, page_html=html)
+
+    static_page = await fetch_page("https://example.com/post", run_prune=False)
+    browser_page = await fetch_page_with_js("https://example.com/post", run_prune=False)
+
+    assert browser_page.model_dump(exclude={"fetched_at"}) == static_page.model_dump(
+        exclude={"fetched_at"}
+    )


### PR DESCRIPTION
## Summary

W5 minimal scaffold from plan `autosearch-0420-steal-3-patterns.md`. Adds Playwright-backed JS-rendered page fetch as **optional** — not installed by default, not wired to any channel yet. Foundation for future JS-heavy channels (xiaohongshu登录后页面, douyin 评论区, 小红书 SPA, etc.) to opt in.

- `pyproject.toml` new optional extra `browser = ["playwright>=1.40"]`. Install: `pip install "autosearch[browser]" && playwright install chromium`
- `autosearch/lib/browser_fetcher.py` — `fetch_page_with_js(url, config)` returns same `FetchedPage` shape as static `fetch_page`
- `BrowserNotInstalledError` with install-hint when Playwright/Chromium missing
- `BrowserFetchConfig` with headless / timeout / user_agent / wait_for_selector / wait_until / extra_http_headers
- `html_scraper.py` refactored: extracted `_parse_html_into_page(url, html, status_code, run_prune)` shared by both fetchers for consistency

## Test plan

- [x] 6 new tests (missing Playwright / missing Chromium / config defaults / happy path with mocked Playwright / wait_for_selector / parser consistency with static fetcher)
- [x] Full suite: 634 passed / 18 deselected / 0 failed (baseline 622)
- [x] ruff + ruff format clean
- [x] `fetch_page` behavior unchanged post-refactor

## Gotchas for reviewer

- Base `pip install autosearch` unchanged — **no Playwright in default deps**, no Chromium binary download
- No channel is using `fetch_page_with_js` yet — future PRs will opt in specific channels
- Refactor to shared `_parse_html_into_page` is the one non-additive change; `fetch_page` tests still pass verifying backward-compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)