### PR TITLE
fix: CLI exits non-zero on provider/query failures (F114 findings)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -1,10 +1,12 @@
 # Source: gpt-researcher/cli.py:L28-L216 (adapted)
 import asyncio
+import contextlib
 import json
 import sys
 from typing import Annotated
 
 import click
+import httpx
 import typer
 import uvicorn
 from pydantic import ValidationError
@@ -31,7 +33,13 @@ from autosearch.init.channel_status import (
     default_channels_root,
 )
 from autosearch.init_runner import InitError, InitRunner
-from autosearch.llm.client import LLMClient
+from autosearch.llm.client import AllProvidersFailedError, LLMClient
+
+_NO_PROVIDER_MESSAGE = (
+    "No LLM provider available; set ANTHROPIC_API_KEY, OPENAI_API_KEY, "
+    "GOOGLE_API_KEY, or install the `claude` CLI."
+)
+_AUTH_FAILURE_MESSAGE = "LLM authentication failed"
 
 
 class _DefaultQueryGroup(typer.core.TyperGroup):
@@ -141,6 +149,10 @@ def query(
     if mode is not None and depth is not None:
         typer.echo("--mode ignored because --depth was also provided", err=True)
 
+    normalized_query = query.strip()
+    if not normalized_query:
+        _exit_query_failure("Query must not be empty.", exit_code=2, json_output=json_output)
+
     provided: dict[str, object] = {}
     if channel_scope is not None:
         provided["channel_scope"] = channel_scope
@@ -160,17 +172,23 @@ def query(
     resolved_mode = depth_to_mode(scope.depth)
     stream_callback = _stderr_event_writer if stream and not json_output else None
     try:
-        result = asyncio.run(
-            Pipeline(
-                llm=LLMClient(),
-                channels=_build_channels(),
-                top_k_evidence=top_k,
-                on_event=stream_callback,
-            ).run(query, mode_hint=resolved_mode, scope=scope)
-        )
+        with contextlib.ExitStack() as exit_stack:
+            if json_output:
+                exit_stack.enter_context(contextlib.redirect_stdout(sys.stderr))
+            result = asyncio.run(
+                Pipeline(
+                    llm=LLMClient(),
+                    channels=_build_channels(),
+                    top_k_evidence=top_k,
+                    on_event=stream_callback,
+                ).run(normalized_query, mode_hint=resolved_mode, scope=scope)
+            )
     except Exception as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1) from exc
+        _exit_query_failure(
+            _friendly_query_error_message(exc),
+            exit_code=1,
+            json_output=json_output,
+        )
 
     if result.delivery_status == "needs_clarification":
         typer.echo(result.clarification.question or "More detail is required.", err=True)
@@ -179,12 +197,15 @@ def query(
     try:
         rendered_output = _render_output(
             markdown_text=result.markdown or "",
-            title=query,
+            title=normalized_query,
             output_format=scope.output_format,
         )
     except Exception as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1) from exc
+        _exit_query_failure(
+            _friendly_query_error_message(exc),
+            exit_code=1,
+            json_output=json_output,
+        )
 
     if json_output:
         typer.echo(
@@ -340,6 +361,59 @@ def serve(
 def _stderr_event_writer(event: dict[str, object]) -> None:
     sys.stderr.write(json.dumps(event, ensure_ascii=False) + "\n")
     sys.stderr.flush()
+
+
+def _friendly_query_error_message(error: Exception) -> str:
+    if _is_authentication_error(error):
+        return _AUTH_FAILURE_MESSAGE
+    if _is_no_provider_configured_error(error):
+        return _NO_PROVIDER_MESSAGE
+    if isinstance(error, AllProvidersFailedError):
+        return "No LLM provider available; all configured providers failed."
+    return str(error)
+
+
+def _is_no_provider_configured_error(error: Exception) -> bool:
+    return isinstance(error, RuntimeError) and "No LLM provider configured" in str(error)
+
+
+def _is_authentication_error(error: Exception) -> bool:
+    if isinstance(error, AllProvidersFailedError):
+        provider_errors = list(error.provider_errors.values())
+        return bool(provider_errors) and all(
+            _is_authentication_error(provider_error) for provider_error in provider_errors
+        )
+    if isinstance(error, httpx.HTTPStatusError):
+        return error.response.status_code in {401, 403}
+
+    message = str(error).lower()
+    return any(
+        marker in message
+        for marker in (
+            "authentication failed",
+            "invalid api key",
+            "api key is invalid",
+            "unauthorized",
+            "forbidden",
+            "invalid x-api-key",
+        )
+    )
+
+
+def _exit_query_failure(message: str, *, exit_code: int, json_output: bool) -> None:
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "delivery_status": "error",
+                    "error": message,
+                    "exit_code": exit_code,
+                }
+            )
+        )
+    else:
+        typer.echo(message, err=True)
+    raise typer.Exit(code=exit_code)
 
 
 def _resolve_scope(

--- a/autosearch/core/pipeline.py
+++ b/autosearch/core/pipeline.py
@@ -5,6 +5,7 @@ import re
 import uuid
 from typing import Any
 
+import httpx
 import structlog
 
 from autosearch.channels.base import Channel
@@ -25,7 +26,7 @@ from autosearch.core.models import (
 )
 from autosearch.core.search_scope import SearchScope, filter_channels_by_scope
 from autosearch.core.strategy import QueryStrategist
-from autosearch.llm.client import LLMClient
+from autosearch.llm.client import AllProvidersFailedError, LLMClient
 from autosearch.observability.cost import CostTracker
 from autosearch.persistence.session_store import SessionStore
 from autosearch.quality.gate import QualityGate
@@ -371,11 +372,18 @@ class Pipeline:
                 completion_tokens=completion_tokens,
             )
         except Exception as exc:
-            self.logger.exception(
-                "pipeline_run_failed",
-                phase=current_phase,
-                error=str(exc),
-            )
+            if _should_log_pipeline_traceback(exc):
+                self.logger.exception(
+                    "pipeline_run_failed",
+                    phase=current_phase,
+                    error=str(exc),
+                )
+            else:
+                self.logger.warning(
+                    "pipeline_run_failed",
+                    phase=current_phase,
+                    error=str(exc),
+                )
             await self._emit_event(
                 {
                     "type": "error",
@@ -652,6 +660,14 @@ def _subqueries_from_gaps(gaps: list[Gap]) -> list[SubQuery]:
         seen.add(key)
         subqueries.append(SubQuery(text=text, rationale=gap.reason.strip() or text))
     return subqueries
+
+
+def _should_log_pipeline_traceback(error: Exception) -> bool:
+    if isinstance(error, AllProvidersFailedError):
+        return False
+    if isinstance(error, httpx.HTTPStatusError):
+        return error.response.status_code not in {400, 401, 403}
+    return not (isinstance(error, RuntimeError) and "No LLM provider configured" in str(error))
 
 
 def _extract_first_section(markdown: str) -> Section:

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -1,0 +1,70 @@
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from autosearch.cli import main as cli_main
+import autosearch.llm.client as client_module
+
+runner = CliRunner()
+
+
+def _auth_error() -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(401, request=request)
+    return httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+
+
+def test_cli_exits_nonzero_without_any_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env_var in (
+        "AUTOSEARCH_LLM_MODE",
+        "AUTOSEARCH_LLM_PROVIDER",
+        "AUTOSEARCH_PROVIDER_CHAIN",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "CLAUDE_API_KEY",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(
+        client_module.ClaudeCodeProvider,
+        "is_available",
+        staticmethod(lambda: False),
+    )
+
+    result = runner.invoke(cli_main.app, ["query", "test", "--no-stream"])
+
+    assert result.exit_code != 0
+    assert "No LLM provider available" in result.stderr
+
+
+def test_cli_exits_nonzero_with_invalid_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-invalid-fake-xxx")
+    monkeypatch.setattr(cli_main, "_build_channels", lambda: [])
+    monkeypatch.setattr(cli_main.LLMClient, "complete", _raise_auth_error)
+
+    result = runner.invoke(cli_main.app, ["query", "test", "--no-stream"])
+
+    assert result.exit_code != 0
+    assert "LLM authentication failed" in result.stderr
+
+
+def test_cli_rejects_empty_query() -> None:
+    result = runner.invoke(cli_main.app, ["query", ""])
+
+    assert result.exit_code == 2
+    assert result.stderr == "Query must not be empty.\n"
+
+
+async def _raise_auth_error(
+    self: cli_main.LLMClient,
+    prompt: str,
+    response_model: type[object],
+) -> object:
+    _ = self
+    _ = prompt
+    _ = response_model
+    raise _auth_error()


### PR DESCRIPTION
## Summary

E2B production validation (`F114_failure_paths`) surfaced three silent-failure bugs where `autosearch query` exited **0** when it should have exited non-zero:

| Case | Repro | Before | After |
|---|---|---|---|
| Zero LLM key | `unset ANTHROPIC_API_KEY ...; autosearch query "test"` | exit 0 | exit 1 + stderr friendly msg |
| Invalid key (401) | `ANTHROPIC_API_KEY=sk-ant-fake autosearch query "test"` | exit 0 | exit 1 + "LLM authentication failed" |
| Empty query | `autosearch query ""` | exit 0 | exit 2 (bad usage) |

## Why this matters

CI/shell scripts that wire `autosearch` by checking `$?` currently get false-positive success when provider config is broken. Release gate "zero-key graceful degradation" requires non-zero exit with friendly message — this PR delivers it.

## Changes

- `autosearch/cli/main.py` — catch `AllProvidersFailedError` / auth errors, print one-line stderr, exit 1. Empty query rejected at Typer layer with exit 2. `--json` output stays valid JSON on error paths.
- `autosearch/core/pipeline.py` — suppress stack trace on expected provider failures.
- `tests/unit/test_cli_main.py` — 3 regression tests covering all three paths.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest -x -q -m "not real_llm and not perf and not slow and not network"` green
- [x] Repro each of 3 bugs post-fix: exit 1 / exit 1 / exit 2 as expected
- [ ] E2B `F114_failure_paths` phase re-runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query input validation now provides clear feedback when queries are empty.
  * Error messages improved with context-aware guidance for authentication and missing provider configuration issues.
  * Error handling refined to deliver clearer, friendlier feedback during execution failures.
  * Error output formatting improvements for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->