### PR TITLE
fix: handle simhash uint8 overflow in evidence dedup (F111 P0 root cause)

### DIFF
--- a/autosearch/core/evidence.py
+++ b/autosearch/core/evidence.py
@@ -30,7 +30,15 @@ class EvidenceProcessor:
         kept_hashes: list[Simhash] = []
         for evidence in evs:
             text = _simhash_text(evidence)
-            fingerprint = Simhash(text)
+            try:
+                fingerprint = Simhash(text)
+            except OverflowError:
+                # simhash 2.x has a numpy uint8 overflow when any feature weight
+                # exceeds 255 (triggered on long / repetitive text). Fall back to
+                # keeping the evidence without near-duplicate suppression rather
+                # than silently dropping channel output.
+                kept.append(evidence)
+                continue
             if any(fingerprint.distance(existing) <= threshold for existing in kept_hashes):
                 continue
             kept.append(evidence)

--- a/tests/unit/test_evidence_simhash_overflow.py
+++ b/tests/unit/test_evidence_simhash_overflow.py
@@ -1,0 +1,57 @@
+"""Regression test for simhash OverflowError path in EvidenceProcessor."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from autosearch.core.evidence import EvidenceProcessor
+from autosearch.core.models import Evidence
+
+
+def _make_evidence(url: str, content: str) -> Evidence:
+    return Evidence(
+        url=url,
+        title="Test",
+        snippet=content[:200],
+        content=content,
+        source_channel="test",
+        fetched_at=datetime.now(timezone.utc),
+    )
+
+
+def test_dedup_simhash_handles_overflow_without_crashing() -> None:
+    """simhash 2.x raises OverflowError when a feature weight overflows uint8.
+
+    Reproduction: a repetitive long text causes one feature to accumulate a
+    weight > 255, and simhash's numpy path tries to store it in uint8. The
+    dedup path must not let this crash the pipeline — evidence should still
+    be kept, just without near-duplicate suppression for the offending item.
+    """
+    processor = EvidenceProcessor()
+
+    pathological = "bm25 " * 600 + "retrieval ranking " * 400
+    normal = "Short text about information retrieval."
+
+    evs = [
+        _make_evidence("https://example.com/1", pathological),
+        _make_evidence("https://example.com/2", normal),
+    ]
+
+    kept = processor.dedup_simhash(evs)
+
+    assert len(kept) == 2
+    assert {e.url for e in kept} == {"https://example.com/1", "https://example.com/2"}
+
+
+def test_dedup_simhash_deduplicates_identical_short_text() -> None:
+    """Baseline — identical short text should still be deduped normally."""
+    processor = EvidenceProcessor()
+    text = "Same content about BM25 retrieval ranking algorithm."
+    evs = [
+        _make_evidence("https://example.com/a", text),
+        _make_evidence("https://example.com/b", text),
+    ]
+
+    kept = processor.dedup_simhash(evs)
+
+    assert len(kept) == 1


### PR DESCRIPTION
## Summary

F111 E2B channel validation surfaced **14 of 31 channels returning zero evidence** on every seed query. Direct reproduction showed reddit's `channel.search()` actually returns 20+ evidence items — the pipeline crashes downstream at `dedup_simhash`:

```
File \"autosearch/core/evidence.py\", line 33, in dedup_simhash
  fingerprint = Simhash(text)
File \"simhash/__init__.py\", line 136, in build_by_features
  sums.append(self._bitarray_from_bytes(h) * w)
OverflowError: Python integer 258 out of bounds for uint8
```

`simhash` 2.1.2 uses numpy's `uint8` bitarray internally. When any feature weight exceeds 255 (easy on Reddit-style long/repetitive evidence text), multiplication overflows and crashes `Pipeline._dedup_accumulated_evidence`.

## Fix

Catch `OverflowError` in `dedup_simhash` and keep the evidence without near-duplicate suppression, rather than letting the whole iteration return zero evidence.

Near-duplicate suppression is best-effort. Dropping it for one pathological evidence is strictly better than silently losing an entire channel's output.

## Verification

Before fix (main `d4d3c2e`):
```json
{\"channel\": \"reddit\", \"status\": \"exception\", \"error\": \"OverflowError: Python integer 258 out of bounds for uint8\"}
```

After fix:
```json
{\"channel\": \"reddit\", \"evidence_count\": 20, \"avg_content_len\": 19175.6, \"markdown_len\": 10210, \"iterations\": 6, \"status\": \"ok\"}
```

Expected impact: most of the 14 \"Tier 4 zero-evidence\" channels in `reports/2026-04-20-prod-val/channels/channel-leaderboard.md` should revive to Tier 2 / Tier 3.

## Test plan
- [x] `pytest -x -q tests/unit/` green (448 tests)
- [x] Added regression tests in `tests/unit/test_evidence_simhash_overflow.py` (pathological + baseline dedup)
- [x] Local bench: reddit channel goes from 0 → 20 evidence
- [ ] F111 channel matrix rerun on merge will validate unblocking across all channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)