### PR TITLE
fix(cleaner): PruningCleaner over-prune fallback (F105 P1)

### DIFF
--- a/autosearch/cleaners/pruning_cleaner.py
+++ b/autosearch/cleaners/pruning_cleaner.py
@@ -54,6 +54,12 @@ class PruningCleaner(Cleaner):
         "cookie",
     }
 
+    # If pruning removes more than this fraction of the original text, treat it as
+    # over-pruning (e.g. SPA-heavy sites where content sits in generic divs the
+    # cleaner cannot score positively) and fall back to the unpruned HTML.
+    MIN_RETAIN_RATIO = 0.05
+    MIN_RETAIN_CHARS = 200
+
     def __init__(self, threshold: float = 0.48, min_word_count: int = 2):
         self.threshold = threshold
         self.min_word_count = min_word_count
@@ -73,8 +79,23 @@ class PruningCleaner(Cleaner):
         if body is None:
             return ""
 
+        original_text_len = len(body.get_text(" ", strip=True))
         self._prune_node(body, is_root=True)
-        return body.decode_contents().strip()
+        cleaned = body.decode_contents().strip()
+
+        cleaned_text_len = len(BeautifulSoup(cleaned, "html.parser").get_text(" ", strip=True))
+        if original_text_len >= self.MIN_RETAIN_CHARS and cleaned_text_len < max(
+            self.MIN_RETAIN_CHARS, int(original_text_len * self.MIN_RETAIN_RATIO)
+        ):
+            # Over-prune fallback: restore unpruned body (with always-drop tags already removed).
+            fresh = BeautifulSoup(html, "html.parser")
+            if fresh.body is None:
+                fresh = BeautifulSoup(f"<body>{html}</body>", "html.parser")
+            self._remove_comments(fresh)
+            self._remove_always_drop_tags(fresh)
+            return fresh.body.decode_contents().strip() if fresh.body else cleaned
+
+        return cleaned
 
     def _remove_comments(self, soup: BeautifulSoup) -> None:
         for node in soup(string=lambda value: isinstance(value, Comment)):

--- a/tests/unit/test_pruning_overprune_fallback.py
+++ b/tests/unit/test_pruning_overprune_fallback.py
@@ -1,0 +1,54 @@
+"""Regression test for PruningCleaner over-prune fallback (F105 finding)."""
+
+from __future__ import annotations
+
+from autosearch.cleaners.pruning_cleaner import PruningCleaner
+
+
+def test_over_prune_fallback_returns_minimally_cleaned_html() -> None:
+    """When the heuristic scorer wipes most of the content (SPA-heavy sites),
+    the cleaner must fall back to minimally-processed HTML rather than return
+    empty. Simulates a dev.to-style layout where content sits in generic divs
+    the tag-weight table cannot score positively.
+    """
+    cleaner = PruningCleaner()
+    html = """<html><body>
+        <div class="wrapper">
+          <div class="col">
+            <div>Paragraph one about BM25 ranking algorithm and how it works.</div>
+            <div>Paragraph two with more specific details on term frequency saturation.</div>
+            <div>Paragraph three about inverse document frequency weighting.</div>
+            <div>Paragraph four about length normalization and the b parameter.</div>
+          </div>
+        </div>
+    </body></html>"""
+
+    cleaned = cleaner.clean(html)
+
+    # Content should survive even though container divs have neutral tag weights.
+    assert "BM25 ranking algorithm" in cleaned
+    assert "length normalization" in cleaned
+
+
+def test_normal_article_is_pruned_cleanly() -> None:
+    """Baseline — articles with <article>/<main>/<nav>/<footer> must still have
+    their negative parts removed by the primary path, not triggering fallback.
+    """
+    cleaner = PruningCleaner()
+    html = """<html><body>
+        <nav class="site-nav">Home About Contact</nav>
+        <header>Site Header</header>
+        <article>
+          <p>BM25 is a ranking function used in information retrieval systems.</p>
+          <p>It builds on TF-IDF with term frequency saturation and length normalization.</p>
+        </article>
+        <aside class="sidebar">Ads here</aside>
+        <footer>Site Footer</footer>
+    </body></html>"""
+
+    cleaned = cleaner.clean(html)
+
+    assert "BM25 is a ranking function" in cleaned
+    assert "Site Header" not in cleaned
+    assert "Home About Contact" not in cleaned
+    assert "Ads here" not in cleaned


### PR DESCRIPTION
## Summary

F105 E2B W1 validation hit `PruningCleaner` over-prune on 4/5 seed URLs. All returned HTTP 200 with valid HTML but `cleaned_html=0`.

| URL | Before | After |
|---|---|---|
| en.wikipedia.org | 4400 | 4400 (unchanged; primary path) |
| dev.to/search?q=bm25 | **0** | **21392** |
| arxiv.org/abs/1712.05055 | **0** | **32991** |
| stackoverflow (HTTP 403 block, unrelated) | — | — |

## Root cause

SPA-heavy / generic-div layouts have no positive tag signals for `<article>/<main>/<p>`. Every container scores below threshold and gets recursively decomposed bottom-up, leaving an empty body.

## Fix

After primary pruning, if the result retains less than 5% of the original text (or under 200 chars), fall back to a minimally-cleaned body (only script/style/noscript/template + comments removed). Preserves channel output on sites the heuristic cannot score.

## Test plan
- [x] `pytest -x tests/unit/` (450+ green)
- [x] 2 regression tests in `tests/unit/test_pruning_overprune_fallback.py`:
  - SPA-style generic-div layout survives (fallback path)
  - Normal article layout still pruned cleanly via primary path
- [x] Real network verify: dev.to + arxiv now produce content; wikipedia unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)