### PR TITLE
chore(release): bump-version.sh + e2b-weekly workflow

### DIFF
--- a/.github/workflows/e2b-weekly.yml
+++ b/.github/workflows/e2b-weekly.yml
@@ -1,0 +1,89 @@
+name: E2B Weekly Validation (quality benchmark subset)
+
+on:
+  schedule:
+    # Sundays 12:00 UTC
+    - cron: '0 12 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  weekly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install orchestrator deps
+        run: |
+          uv venv --python 3.12 .orchestrator
+          uv pip install --python .orchestrator/bin/python \
+            e2b e2b-code-interpreter rich pyyaml
+          uv pip install --python .orchestrator/bin/python -e .
+
+      - name: Pack source tarball
+        run: |
+          tar --exclude='.git' --exclude='node_modules' --exclude='.venv' \
+              --exclude='__pycache__' --exclude='.pytest_cache' \
+              --exclude='*.egg-info' --exclude='reports' --exclude='build' \
+              --exclude='.ruff_cache' --exclude='.orchestrator' \
+              -czf /tmp/autosearch-src.tar.gz -C $GITHUB_WORKSPACE .
+
+      - name: Run channel smoke matrix (F111)
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TIKHUB_API_KEY: ${{ secrets.TIKHUB_API_KEY }}
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+        run: |
+          if [ ! -f scripts/e2b/bench_channels.py ]; then
+            echo "::warning::bench_channels.py not ported to repo yet; skipping"
+            exit 0
+          fi
+          mkdir -p reports/weekly-$(date -u +%Y-%m-%d)
+          .orchestrator/bin/python scripts/e2b/bench_channels.py \
+            --tarball /tmp/autosearch-src.tar.gz \
+            --output reports/weekly-$(date -u +%Y-%m-%d)/channels \
+            --parallel 15 --mode fast
+
+      - name: Run variance benchmark subset (F203, K=3, 5 topics)
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ ! -f scripts/e2b/bench_variance.py ]; then
+            echo "::warning::bench_variance.py not ported to repo yet; skipping"
+            exit 0
+          fi
+          mkdir -p reports/weekly-$(date -u +%Y-%m-%d)/variance
+          .orchestrator/bin/python scripts/e2b/bench_variance.py \
+            --tarball /tmp/autosearch-src.tar.gz \
+            --output reports/weekly-$(date -u +%Y-%m-%d)/variance \
+            --parallel 15 --runs-per-topic 3 --mode fast
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2b-weekly-report
+          path: reports/weekly-*/**
+          retention-days: 30
+
+      - name: Open issue on failure
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "E2B weekly validation failed ${{ github.run_number }}"
+          content-filepath: reports/weekly-*/variance/variance-summary.md
+          labels: ci,weekly-fail

--- a/.github/workflows/e2b-weekly.yml
+++ b/.github/workflows/e2b-weekly.yml
@@ -38,7 +38,7 @@ jobs:
               --exclude='__pycache__' --exclude='.pytest_cache' \
               --exclude='*.egg-info' --exclude='reports' --exclude='build' \
               --exclude='.ruff_cache' --exclude='.orchestrator' \
-              -czf /tmp/autosearch-src.tar.gz -C $GITHUB_WORKSPACE .
+              -czf /tmp/autosearch-src.tar.gz -C "$GITHUB_WORKSPACE" .
 
       - name: Run channel smoke matrix (F111)
         env:
@@ -51,10 +51,11 @@ jobs:
             echo "::warning::bench_channels.py not ported to repo yet; skipping"
             exit 0
           fi
-          mkdir -p reports/weekly-$(date -u +%Y-%m-%d)
+          report_root="reports/weekly-$(date -u +%Y-%m-%d)"
+          mkdir -p "${report_root}"
           .orchestrator/bin/python scripts/e2b/bench_channels.py \
             --tarball /tmp/autosearch-src.tar.gz \
-            --output reports/weekly-$(date -u +%Y-%m-%d)/channels \
+            --output "${report_root}/channels" \
             --parallel 15 --mode fast
 
       - name: Run variance benchmark subset (F203, K=3, 5 topics)
@@ -66,10 +67,11 @@ jobs:
             echo "::warning::bench_variance.py not ported to repo yet; skipping"
             exit 0
           fi
-          mkdir -p reports/weekly-$(date -u +%Y-%m-%d)/variance
+          report_root="reports/weekly-$(date -u +%Y-%m-%d)"
+          mkdir -p "${report_root}/variance"
           .orchestrator/bin/python scripts/e2b/bench_variance.py \
             --tarball /tmp/autosearch-src.tar.gz \
-            --output reports/weekly-$(date -u +%Y-%m-%d)/variance \
+            --output "${report_root}/variance" \
             --parallel 15 --runs-per-topic 3 --mode fast
 
       - name: Upload report artifacts

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/bump-version.sh — bump autosearch version across files
+#
+# Version scheme: CalVer YYYY.MM.DD.N (e.g. 2026.04.21.1).
+#   - N is the daily sequence number (1, 2, 3...) within the same calendar day.
+#   - Auto-computed if not passed as argument.
+#
+# Updates (when files exist):
+#   - pyproject.toml         (version = "...")
+#   - .claude-plugin/plugin.json         (JSON "version")
+#   - .claude-plugin/marketplace.json    (JSON "version")
+#   - CHANGELOG.md                        (prepend empty entry if missing)
+#
+# Usage:
+#   scripts/bump-version.sh                      # auto-bump to today's version
+#   scripts/bump-version.sh 2026.04.21.1         # explicit version
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+today="$(date -u +%Y.%m.%d)"
+
+if [ -n "${1:-}" ]; then
+  new_version="$1"
+else
+  current=""
+  if [ -f pyproject.toml ]; then
+    current=$(grep -E '^version\s*=\s*"' pyproject.toml | head -1 | sed -E 's/.*"(.*)".*/\1/')
+  fi
+  next_seq=1
+  if [[ "$current" =~ ^${today}\.([0-9]+)$ ]]; then
+    next_seq=$((${BASH_REMATCH[1]} + 1))
+  fi
+  new_version="${today}.${next_seq}"
+fi
+
+echo "Bumping to $new_version"
+
+update_pyproject() {
+  [ -f pyproject.toml ] || return 0
+  python3 - "$new_version" <<'PY'
+import re, sys
+new_version = sys.argv[1]
+path = 'pyproject.toml'
+content = open(path).read()
+content = re.sub(r'^(version\s*=\s*)"[^"]*"', rf'\1"{new_version}"', content, count=1, flags=re.M)
+open(path, 'w').write(content)
+PY
+  echo "  updated pyproject.toml"
+}
+
+update_json_version() {
+  local path="$1"
+  [ -f "$path" ] || return 0
+  python3 - "$path" "$new_version" <<'PY'
+import json, sys
+path, new_version = sys.argv[1], sys.argv[2]
+with open(path) as f: d = json.load(f)
+d['version'] = new_version
+with open(path, 'w') as f: json.dump(d, f, indent=2); f.write('\n')
+PY
+  echo "  updated $path"
+}
+
+ensure_changelog_entry() {
+  [ -f CHANGELOG.md ] || { echo "# Changelog" > CHANGELOG.md; echo "" >> CHANGELOG.md; }
+  if ! grep -q "## $new_version" CHANGELOG.md; then
+    python3 - "$new_version" <<'PY'
+from datetime import date
+import sys
+new_version = sys.argv[1]
+path = 'CHANGELOG.md'
+content = open(path).read()
+banner = content.split('\n', 1)[0] if content.startswith('# ') else '# Changelog'
+rest = content[len(banner)+1:] if content.startswith('# ') else content
+entry = f'\n## {new_version} — {date.today().isoformat()}\n\n- \n'
+open(path, 'w').write(banner + '\n' + entry + rest)
+PY
+    echo "  prepended CHANGELOG.md entry (fill in the bullet)"
+  fi
+}
+
+update_pyproject
+update_json_version .claude-plugin/plugin.json
+update_json_version .claude-plugin/marketplace.json
+ensure_changelog_entry
+
+echo "Done. Review diff before committing:"
+echo "  git diff pyproject.toml .claude-plugin/ CHANGELOG.md"


### PR DESCRIPTION
F306 release-workflow dry-run surfaced that CLAUDE.md references scripts/bump-version.sh but the file was missing. Adds the script plus the Sun 12:00 UTC weekly workflow that pairs with nightly. Standalone scope from PR #185 (validation infra) and PR #188 (PruningCleaner fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added weekly automated validation and benchmarking workflow to ensure ongoing code quality.
  * Added version management script to streamline version updates across project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->