### PR TITLE
fix(ci): pin e2b workflow auto-issue content-filepath + add fallback summary

### DIFF
--- a/.github/workflows/e2b-nightly.yml
+++ b/.github/workflows/e2b-nightly.yml
@@ -32,6 +32,10 @@ jobs:
             e2b e2b-code-interpreter rich pyyaml
           uv pip install --python .orchestrator/bin/python -e .
 
+      - name: Capture run date
+        id: date
+        run: echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Pack source tarball
         run: |
           tar --exclude='.git' --exclude='node_modules' --exclude='.venv' \
@@ -42,6 +46,7 @@ jobs:
 
       - name: Run E2B nightly matrix (Track A core)
         env:
+          REPORT_DIR: reports/nightly-${{ steps.date.outputs.today }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -62,14 +67,29 @@ jobs:
             echo "::warning::nightly orchestrator not yet ported to repo; skipping"
             exit 0
           fi
-          report_dir="reports/nightly-$(date -u +%Y-%m-%d)"
+          mkdir -p "${REPORT_DIR}"
           .orchestrator/bin/python scripts/e2b/run_validation.py \
             --project autosearch \
             --matrix tests/e2b/matrix.yaml \
             --secrets /tmp/nightly-secrets.env \
-            --output "${report_dir}" \
+            --output "${REPORT_DIR}" \
             --parallel 15 \
             --tarball /tmp/autosearch-src.tar.gz
+
+      - name: Ensure failure summary exists
+        if: failure()
+        env:
+          REPORT_DIR: reports/nightly-${{ steps.date.outputs.today }}
+        run: |
+          mkdir -p "${REPORT_DIR}"
+          if [ ! -s "${REPORT_DIR}/summary.md" ]; then
+            cat > "${REPORT_DIR}/summary.md" <<EOF
+          # Nightly E2B validation failed early
+
+          Run: ${{ github.run_number }}
+          The orchestrator did not produce a full summary. See the Actions run logs linked from the issue body for root-cause analysis.
+          EOF
+          fi
 
       - name: Upload report artifacts
         if: always()
@@ -84,5 +104,5 @@ jobs:
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "E2B nightly validation failed ${{ github.run_number }}"
-          content-filepath: reports/nightly-*/summary.md
+          content-filepath: reports/nightly-${{ steps.date.outputs.today }}/summary.md
           labels: ci,nightly-fail

--- a/.github/workflows/e2b-weekly.yml
+++ b/.github/workflows/e2b-weekly.yml
@@ -32,6 +32,10 @@ jobs:
             e2b e2b-code-interpreter rich pyyaml
           uv pip install --python .orchestrator/bin/python -e .
 
+      - name: Capture run date
+        id: date
+        run: echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Pack source tarball
         run: |
           tar --exclude='.git' --exclude='node_modules' --exclude='.venv' \
@@ -42,6 +46,7 @@ jobs:
 
       - name: Run channel smoke matrix (F111)
         env:
+          REPORT_ROOT: reports/weekly-${{ steps.date.outputs.today }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TIKHUB_API_KEY: ${{ secrets.TIKHUB_API_KEY }}
@@ -51,15 +56,15 @@ jobs:
             echo "::warning::bench_channels.py not ported to repo yet; skipping"
             exit 0
           fi
-          report_root="reports/weekly-$(date -u +%Y-%m-%d)"
-          mkdir -p "${report_root}"
+          mkdir -p "${REPORT_ROOT}"
           .orchestrator/bin/python scripts/e2b/bench_channels.py \
             --tarball /tmp/autosearch-src.tar.gz \
-            --output "${report_root}/channels" \
+            --output "${REPORT_ROOT}/channels" \
             --parallel 15 --mode fast
 
       - name: Run variance benchmark subset (F203, K=3, 5 topics)
         env:
+          REPORT_ROOT: reports/weekly-${{ steps.date.outputs.today }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
@@ -67,12 +72,26 @@ jobs:
             echo "::warning::bench_variance.py not ported to repo yet; skipping"
             exit 0
           fi
-          report_root="reports/weekly-$(date -u +%Y-%m-%d)"
-          mkdir -p "${report_root}/variance"
+          mkdir -p "${REPORT_ROOT}/variance"
           .orchestrator/bin/python scripts/e2b/bench_variance.py \
             --tarball /tmp/autosearch-src.tar.gz \
-            --output "${report_root}/variance" \
+            --output "${REPORT_ROOT}/variance" \
             --parallel 15 --runs-per-topic 3 --mode fast
+
+      - name: Ensure failure summary exists
+        if: failure()
+        env:
+          REPORT_ROOT: reports/weekly-${{ steps.date.outputs.today }}
+        run: |
+          mkdir -p "${REPORT_ROOT}/variance"
+          if [ ! -s "${REPORT_ROOT}/variance/variance-summary.md" ]; then
+            cat > "${REPORT_ROOT}/variance/variance-summary.md" <<EOF
+          # Weekly E2B validation failed early
+
+          Run: ${{ github.run_number }}
+          The bench suite did not produce a variance summary. See the Actions run logs linked from the issue body for root-cause analysis.
+          EOF
+          fi
 
       - name: Upload report artifacts
         if: always()
@@ -87,5 +106,5 @@ jobs:
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "E2B weekly validation failed ${{ github.run_number }}"
-          content-filepath: reports/weekly-*/variance/variance-summary.md
+          content-filepath: reports/weekly-${{ steps.date.outputs.today }}/variance/variance-summary.md
           labels: ci,weekly-fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - feat(ci): bootstrap AI-native dev environment from sync pack v1.4 (Closes #203)
 - docs(mcp): add per-client MCP config guide for Claude Code / Cursor / Zed / Continue; document `research` + `health` tools and the full input schema.
 - chore(ci): port E2B validation orchestrator (`run_validation.py`, `bench_channels.py`, `bench_variance.py`, `lib/`) into repo `scripts/e2b/` so nightly/weekly CI workflows stop short-circuiting. Also fixes bench bugs — host-only E2B_API_KEY, null-safe variance summarize, docstring/CLI alignment.
+- fix(ci): pin e2b nightly/weekly workflow `content-filepath` to a concrete date (was a glob peter-evans-create-issue-from-file silently ignored) + add a fallback "failure summary" step so auto-issues always have real content, even when the orchestrator crashed before writing summary.md.

--- a/tests/unit/test_e2b_workflow_auto_issue.py
+++ b/tests/unit/test_e2b_workflow_auto_issue.py
@@ -1,0 +1,44 @@
+"""Guard that the two e2b CI workflow YAMLs keep the `content-filepath`
+pinned to a concrete date expression instead of a shell glob. Prior bug:
+`peter-evans/create-issue-from-file@v5` does not expand globs, so a
+`reports/nightly-*/summary.md` path silently mis-fired on failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _yaml_body(name: str) -> str:
+    return (REPO_ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def test_nightly_content_filepath_is_dated_not_globbed():
+    body = _yaml_body("e2b-nightly.yml")
+    assert "reports/nightly-*/summary.md" not in body, (
+        "nightly auto-issue must not point at a glob path"
+    )
+    assert "reports/nightly-${{ steps.date.outputs.today }}/summary.md" in body, (
+        "nightly auto-issue must interpolate the date step output"
+    )
+
+
+def test_weekly_content_filepath_is_dated_not_globbed():
+    body = _yaml_body("e2b-weekly.yml")
+    assert "reports/weekly-*/variance/variance-summary.md" not in body, (
+        "weekly auto-issue must not point at a glob path"
+    )
+    assert "reports/weekly-${{ steps.date.outputs.today }}/variance/variance-summary.md" in body, (
+        "weekly auto-issue must interpolate the date step output"
+    )
+
+
+def test_both_workflows_include_fallback_summary_step():
+    for name in ("e2b-nightly.yml", "e2b-weekly.yml"):
+        body = _yaml_body(name)
+        assert "Ensure failure summary exists" in body, (
+            f"{name} must keep the fallback step that creates a placeholder summary on failure"
+        )


### PR DESCRIPTION
## Summary
- `peter-evans/create-issue-from-file` does **not** expand glob patterns — `reports/nightly-*/summary.md` and `reports/weekly-*/variance/variance-summary.md` silently mis-fired on failure.
- Pin the content-filepath to a concrete date via a `steps.date.outputs.today` step output.
- Add a "fallback summary" step that runs only on `failure()` and fills in a minimal placeholder summary if the orchestrator crashed before writing one, so the auto-issue always has real content.
- Closes the F404 (auto-issue) side of F401 S4 in the 0420 production-validation plan.

## Why this matters
Gate 13 (3-nightly-green observation period) depends on nightly CI running to completion **and** failures opening issues automatically. Without the fix, a crash before summary.md is written + a glob-only content-filepath = a silently-missed failure. Fixing this is prerequisite to trusting "3 consecutive greens" as evidence.

## Diff shape
- `.github/workflows/e2b-nightly.yml`: add `Capture run date` step (id=date), thread `REPORT_DIR=reports/nightly-${{ steps.date.outputs.today }}` into orchestrator + fallback + issue steps.
- `.github/workflows/e2b-weekly.yml`: same pattern with `REPORT_ROOT=reports/weekly-...`, plus the fallback points at `variance/variance-summary.md` (the path `bench_variance.py` writes to).

## Test plan
- [x] YAML parses (GitHub Actions editor)
- [x] Fallback heredoc writes valid Markdown (no bash expansion landmines — run_number is quoted, no nested EOF)
- [ ] CI green on this PR (hygiene / gitleaks / lint / PR Lint)
- [ ] Post-merge manual test once GH Actions secrets are populated: `workflow_dispatch` the nightly workflow with a deliberately broken matrix file and confirm the auto-issue gets created with real content

## Dependency ordering
Independent of PR #196 (orchestrator port) and PR #197 (MCP client doc). Can merge in any order; all three need to land before nightly CI is truly end-to-end operable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)