### PR TITLE
chore(nightly): local launchd/systemd runner for Gate 13 evidence

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -31,8 +31,8 @@ keywords = [".ts.net", ".local"]
   regexes = ['''\$HOME/\.local/bin/uv''']
 
   [[rules.allowlists]]
-  description = "SKILL.md prose references .local paths (Linux XDG, not a Tailscale domain)"
-  paths = ['''skills/.*/SKILL\.md$''']
+  description = "SKILL.md + ops docs reference .local paths (Linux XDG, not a Tailscale domain)"
+  paths = ['''skills/.*/SKILL\.md$''', '''docs/.*\.md$''']
   regexes = ['''\.local/''']
 
 # ── Public-repo-only rules ───────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - docs(mcp): add per-client MCP config guide for Claude Code / Cursor / Zed / Continue; document `research` + `health` tools and the full input schema.
 - chore(ci): port E2B validation orchestrator (`run_validation.py`, `bench_channels.py`, `bench_variance.py`, `lib/`) into repo `scripts/e2b/` so nightly/weekly CI workflows stop short-circuiting. Also fixes bench bugs — host-only E2B_API_KEY, null-safe variance summarize, docstring/CLI alignment.
 - fix(ci): pin e2b nightly/weekly workflow `content-filepath` to a concrete date (was a glob peter-evans-create-issue-from-file silently ignored) + add a fallback "failure summary" step so auto-issues always have real content, even when the orchestrator crashed before writing summary.md.
+- chore(nightly): add `scripts/nightly-local.sh` + macOS launchd / Linux systemd recipes in `docs/local-nightly.md` so Gate 13 observation-period evidence can be collected without GitHub Actions secrets.

--- a/docs/local-nightly.md
+++ b/docs/local-nightly.md
@@ -1,6 +1,6 @@
 ---
 title: "Local Nightly Runner"
-description: "Schedule the F101 baseline regression on your own machine via macOS launchd, cron, or manual invocation"
+description: "Schedule the F101 baseline regression on your own machine via macOS launchd, Linux systemd, or manual invocation"
 ---
 
 # Local Nightly Runner
@@ -133,7 +133,7 @@ They're not mutually exclusive — you can run both.
 |---|---|---|
 | `error: no orchestrator venv found` | `scripts/e2b/` venv never created and shared `~/.claude/scripts/e2b/.venv` is missing | `uv venv scripts/e2b/.venv --python 3.12 && uv pip install --python scripts/e2b/.venv/bin/python e2b e2b-code-interpreter rich pyyaml` |
 | `error: secrets file not readable` | `~/.config/ai-secrets.env` missing or wrong perms | Create the file with `chmod 600`; populate with `E2B_API_KEY=...`, `ANTHROPIC_API_KEY=...` lines |
-| launchd starts but exits 78 / 126 | `PATH` inside launchd is minimal by default | Keep the `EnvironmentVariables.PATH` stanza above; adjust for your own `uv` install location if needed |
+| Script exits 2 with `error: no orchestrator venv found` when launchd fires | `PATH` inside launchd is minimal, so `uv` / `python` from `~/.local/bin` or `/opt/homebrew/bin` is out of reach | Keep the `EnvironmentVariables.PATH` stanza above; adjust for your own `uv` install location if needed |
 | No reports produced, no error | Scheduler fired while machine asleep | launchd uses `StartCalendarInterval`; wake-on-LAN or `caffeinate` around the hour if you suspend the machine at night |
 
 ## Where to go next

--- a/docs/local-nightly.md
+++ b/docs/local-nightly.md
@@ -1,0 +1,143 @@
+---
+title: "Local Nightly Runner"
+description: "Schedule the F101 baseline regression on your own machine via macOS launchd, cron, or manual invocation"
+---
+
+# Local Nightly Runner
+
+`scripts/nightly-local.sh` drives the same F101 baseline regression that `.github/workflows/e2b-nightly.yml` runs, but locally — without uploading any keys to GitHub Actions secrets. It reads your LLM / E2B keys directly from `~/.config/ai-secrets.env`.
+
+Use this when you want Gate 13 observation-period evidence (3 consecutive nightly greens) but don't want a GitHub Actions footprint.
+
+## One-off manual run
+
+```bash
+./scripts/nightly-local.sh
+```
+
+Outputs land in `reports/nightly-$(date -u +%Y-%m-%d)/`. The `summary.md` in that directory is what the release gate observation period evaluates.
+
+Override defaults via env vars:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AUTOSEARCH_PARALLEL` | `15` | Sandbox pool size (cap is 15 per `~/.config/ai-secrets.env` quota) |
+| `AUTOSEARCH_SECRETS_FILE` | `~/.config/ai-secrets.env` | Where the orchestrator reads API keys |
+
+## macOS launchd (daily schedule)
+
+Drop this plist at `~/Library/LaunchAgents/com.autosearch.nightly.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.autosearch.nightly</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>cd ~/Projects/autosearch && ./scripts/nightly-local.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key><integer>3</integer>
+        <key>Minute</key><integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/autosearch-nightly.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/autosearch-nightly.stderr.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>
+```
+
+Adjust the repo path (`cd ~/Projects/autosearch`) if you cloned elsewhere. Then:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.autosearch.nightly.plist
+launchctl start com.autosearch.nightly      # immediate smoke run
+```
+
+To unload later: `launchctl unload ~/Library/LaunchAgents/com.autosearch.nightly.plist`.
+
+Check run logs:
+
+```bash
+tail -f /tmp/autosearch-nightly.stderr.log     # orchestrator progress
+ls -lt reports/nightly-*/                       # produced reports
+```
+
+## Linux systemd (optional)
+
+For a Linux box (personal workstation, not CI runner), drop a unit + timer in `~/.config/systemd/user/`:
+
+```ini
+# ~/.config/systemd/user/autosearch-nightly.service
+[Unit]
+Description=AutoSearch F101 nightly regression
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/Projects/autosearch
+ExecStart=%h/Projects/autosearch/scripts/nightly-local.sh
+StandardOutput=append:/tmp/autosearch-nightly.stdout.log
+StandardError=append:/tmp/autosearch-nightly.stderr.log
+```
+
+```ini
+# ~/.config/systemd/user/autosearch-nightly.timer
+[Unit]
+Description=Run AutoSearch F101 nightly regression daily
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Activate:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now autosearch-nightly.timer
+systemctl --user list-timers autosearch-nightly.timer
+```
+
+## Comparison with the GitHub Actions workflow
+
+| Concern | Local (launchd / systemd) | GitHub Actions (`e2b-nightly.yml`) |
+|---|---|---|
+| Secret sync | Reads `~/.config/ai-secrets.env` in place | Requires `gh secret set` for each key |
+| Keeps running if your machine is off | No — scheduler fires only when the machine is on | Yes — runs on GitHub's runners |
+| Failure notification | stderr log file | Auto-opens a GitHub issue via `peter-evans/create-issue-from-file` |
+| Cost | Just E2B sandbox minutes + LLM calls | Same + GH Actions minutes (free within quota) |
+| Good fit | Solo maintainer, always-on workstation | Team, intermittent developer availability |
+
+They're not mutually exclusive — you can run both.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `error: no orchestrator venv found` | `scripts/e2b/` venv never created and shared `~/.claude/scripts/e2b/.venv` is missing | `uv venv scripts/e2b/.venv --python 3.12 && uv pip install --python scripts/e2b/.venv/bin/python e2b e2b-code-interpreter rich pyyaml` |
+| `error: secrets file not readable` | `~/.config/ai-secrets.env` missing or wrong perms | Create the file with `chmod 600`; populate with `E2B_API_KEY=...`, `ANTHROPIC_API_KEY=...` lines |
+| launchd starts but exits 78 / 126 | `PATH` inside launchd is minimal by default | Keep the `EnvironmentVariables.PATH` stanza above; adjust for your own `uv` install location if needed |
+| No reports produced, no error | Scheduler fired while machine asleep | launchd uses `StartCalendarInterval`; wake-on-LAN or `caffeinate` around the hour if you suspend the machine at night |
+
+## Where to go next
+
+- F101 matrix definition: [`tests/e2b/matrix.yaml`](../tests/e2b/matrix.yaml)
+- Release gate definitions: `../RELEASE-READINESS.md` (per-run, under `reports/`)
+- Orchestrator internals: [`scripts/e2b/README.md`](../scripts/e2b/README.md) (post PR #196)

--- a/scripts/nightly-local.sh
+++ b/scripts/nightly-local.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# nightly-local.sh — F101 baseline regression, driven locally.
+#
+# Meant for macOS launchd or cron scheduling when GitHub Actions is not the
+# desired driver (no GH Actions secrets required — orchestrator reads keys
+# directly from ~/.config/ai-secrets.env).
+#
+# Produces the same reports/nightly-YYYY-MM-DD/ layout as the CI workflow, so
+# "3 consecutive nightly greens" evidence is identical regardless of scheduler.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Orchestrator location — prefer the shared venv; repo-local fallback for when
+# scripts/e2b/ has its own venv installed.
+if [ -x "${REPO_ROOT}/scripts/e2b/.venv/bin/python" ]; then
+  PY="${REPO_ROOT}/scripts/e2b/.venv/bin/python"
+elif [ -x "${HOME}/.claude/scripts/e2b/.venv/bin/python" ]; then
+  PY="${HOME}/.claude/scripts/e2b/.venv/bin/python"
+else
+  echo "error: no orchestrator venv found" >&2
+  echo "  tried: ${REPO_ROOT}/scripts/e2b/.venv/bin/python" >&2
+  echo "  tried: ${HOME}/.claude/scripts/e2b/.venv/bin/python" >&2
+  echo "  hint:  uv venv scripts/e2b/.venv --python 3.12 && uv pip install --python scripts/e2b/.venv/bin/python e2b e2b-code-interpreter rich pyyaml" >&2
+  exit 2
+fi
+
+ORCHESTRATOR="${REPO_ROOT}/scripts/e2b/run_validation.py"
+if [ ! -f "${ORCHESTRATOR}" ]; then
+  # Scripts still living outside the repo (pre PR #196 merge).
+  ORCHESTRATOR="${HOME}/.claude/scripts/e2b/run_validation.py"
+fi
+if [ ! -f "${ORCHESTRATOR}" ]; then
+  echo "error: run_validation.py not found in repo or ~/.claude/scripts/e2b/" >&2
+  exit 2
+fi
+
+SECRETS_FILE="${AUTOSEARCH_SECRETS_FILE:-${HOME}/.config/ai-secrets.env}"
+if [ ! -r "${SECRETS_FILE}" ]; then
+  echo "error: secrets file not readable: ${SECRETS_FILE}" >&2
+  exit 2
+fi
+
+DATE="$(date -u +%Y-%m-%d)"
+REPORT_DIR="reports/nightly-${DATE}"
+mkdir -p "${REPORT_DIR}"
+
+TARBALL="/tmp/autosearch-src-nightly.tar.gz"
+tar --exclude='.git' --exclude='node_modules' --exclude='.venv' \
+    --exclude='__pycache__' --exclude='.pytest_cache' \
+    --exclude='*.egg-info' --exclude='reports' --exclude='build' \
+    --exclude='.ruff_cache' --exclude='.orchestrator' \
+    -czf "${TARBALL}" .
+
+PARALLEL="${AUTOSEARCH_PARALLEL:-15}"
+
+echo "[$(date -u +%FT%TZ)] nightly start | orchestrator=${ORCHESTRATOR} | report=${REPORT_DIR} | parallel=${PARALLEL}"
+
+"${PY}" "${ORCHESTRATOR}" \
+  --project autosearch \
+  --matrix tests/e2b/matrix.yaml \
+  --secrets "${SECRETS_FILE}" \
+  --output "${REPORT_DIR}" \
+  --parallel "${PARALLEL}" \
+  --tarball "${TARBALL}"
+
+echo "[$(date -u +%FT%TZ)] nightly done | summary=${REPORT_DIR}/summary.md"

--- a/scripts/nightly-local.sh
+++ b/scripts/nightly-local.sh
@@ -13,8 +13,9 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "${REPO_ROOT}"
 
-# Orchestrator location — prefer the shared venv; repo-local fallback for when
-# scripts/e2b/ has its own venv installed.
+# Orchestrator Python: prefer a repo-local venv (post PR #196 layout) so the
+# runner stays self-contained; fall back to the shared venv when the repo
+# doesn't yet carry one.
 if [ -x "${REPO_ROOT}/scripts/e2b/.venv/bin/python" ]; then
   PY="${REPO_ROOT}/scripts/e2b/.venv/bin/python"
 elif [ -x "${HOME}/.claude/scripts/e2b/.venv/bin/python" ]; then
@@ -47,7 +48,9 @@ DATE="$(date -u +%Y-%m-%d)"
 REPORT_DIR="reports/nightly-${DATE}"
 mkdir -p "${REPORT_DIR}"
 
-TARBALL="/tmp/autosearch-src-nightly.tar.gz"
+# Matrix upload steps in tests/e2b/matrix.yaml hardcode /tmp/autosearch-src.tar.gz
+# as the source path, so the file on disk has to match that exact name.
+TARBALL="/tmp/autosearch-src.tar.gz"
 tar --exclude='.git' --exclude='node_modules' --exclude='.venv' \
     --exclude='__pycache__' --exclude='.pytest_cache' \
     --exclude='*.egg-info' --exclude='reports' --exclude='build' \

--- a/tests/unit/test_nightly_local_shape.py
+++ b/tests/unit/test_nightly_local_shape.py
@@ -1,0 +1,45 @@
+"""Guard that `scripts/nightly-local.sh` keeps the invariants callers rely on:
+executable bit set, `set -euo pipefail`, tarball path matches the
+`tests/e2b/matrix.yaml` hardcoded upload path, and the secrets file is read
+from `~/.config/ai-secrets.env` (overridable via `AUTOSEARCH_SECRETS_FILE`).
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "nightly-local.sh"
+
+
+def test_script_exists_and_is_executable():
+    assert SCRIPT.is_file(), f"{SCRIPT} missing"
+    mode = SCRIPT.stat().st_mode
+    assert mode & stat.S_IXUSR, "nightly-local.sh must be executable (+x for owner)"
+
+
+def test_script_sets_strict_bash_flags():
+    body = SCRIPT.read_text(encoding="utf-8")
+    assert "set -euo pipefail" in body, (
+        "nightly-local.sh must fail fast — unset vars, command errors, pipe failures"
+    )
+
+
+def test_tarball_path_matches_matrix_upload():
+    body = SCRIPT.read_text(encoding="utf-8")
+    matrix = (REPO_ROOT / "tests" / "e2b" / "matrix.yaml").read_text(encoding="utf-8")
+    assert "/tmp/autosearch-src.tar.gz" in body, (
+        "nightly-local.sh must pack to /tmp/autosearch-src.tar.gz"
+    )
+    assert "/tmp/autosearch-src.tar.gz" in matrix, (
+        "matrix.yaml must agree on the tarball path the runner ships"
+    )
+
+
+def test_script_reads_secrets_file_path_from_env():
+    body = SCRIPT.read_text(encoding="utf-8")
+    assert "AUTOSEARCH_SECRETS_FILE" in body, (
+        "nightly-local.sh must allow overriding secrets file location via env"
+    )


### PR DESCRIPTION
## Summary
- Adds `scripts/nightly-local.sh` — drives the same F101 baseline regression as `e2b-nightly.yml`, locally. Reads keys from `~/.config/ai-secrets.env`; no GitHub Actions secrets required.
- Adds `docs/local-nightly.md` — one-off / macOS launchd / Linux systemd recipes plus a comparison table vs the CI workflow.
- Unblocks Gate 13 (3-nightly-green observation) without needing the boss to sync secrets to GitHub.

## Why this path
Gate 13 in the 0420 production-validation plan requires "3 consecutive nightly greens" as observation-period evidence. The plan did not hardcode GitHub Actions as the only driver. This PR makes the non-CI path first-class so:

- The scheduler can be local (launchd / systemd) when the maintainer is always-on and wants zero GH Actions footprint.
- The scheduler can be GH Actions when team coverage matters more than secret-sync overhead.
- Both produce the same `reports/nightly-YYYY-MM-DD/summary.md` shape, so gate evaluators don't care which one fired.

## Runner behaviour
- Resolves orchestrator Python interpreter in a clear order: repo-local `scripts/e2b/.venv/bin/python` → shared `~/.claude/scripts/e2b/.venv/bin/python` → hard error with remediation hint.
- Resolves `run_validation.py` from the repo first (post PR #196) and falls back to the shared location so the script works before and after PR #196 lands.
- Packs the same source tarball (same exclusion set as the CI workflow), writes report to `reports/nightly-YYYY-MM-DD/`, hands control to orchestrator with `--parallel ${AUTOSEARCH_PARALLEL:-15}`.
- Two env-var escape hatches: `AUTOSEARCH_SECRETS_FILE` and `AUTOSEARCH_PARALLEL`.
- Exits non-zero with a specific, actionable error message when prereqs are missing.

## Doc shape
- 1-line manual run example.
- macOS launchd plist sample with `bash -lc "cd ~/Projects/autosearch && ..."` so users don't have to hardcode an absolute path (and so this PR doesn't trip the `/Users/[a-zA-Z]` PII scanner).
- Linux systemd unit + timer sample.
- Side-by-side comparison table with the CI workflow — makes the "when to pick which" decision easy.
- Troubleshooting table keyed to the four realistic failure modes (no venv, no secrets file, launchd PATH, machine sleep).

## Test plan
- [x] `scripts/nightly-local.sh` is executable
- [x] `bash -n scripts/nightly-local.sh` parses clean
- [x] `grep -n /Users /home/\[a-z\]` → no hits in either file (hook clean)
- [x] `.husky/pre-commit` hook passes
- [ ] CI green (hygiene / gitleaks / lint / PR Lint / Mintlify)
- [ ] Manual smoke post-merge: run `./scripts/nightly-local.sh` once locally with real E2B quota, confirm `reports/nightly-YYYY-MM-DD/summary.md` drops.

## Interaction with other open PRs
- Independent of PR #196 (orchestrator port) — the runner prefers repo-local location, falls back to shared one. Works before and after PR #196 merges.
- Independent of PR #197 (MCP client doc) and PR #198 (workflow auto-issue fix) entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)