### PR TITLE
fix(m3): evidence compaction preserves specifics verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - chore(nightly): add `scripts/nightly-local.sh` + macOS launchd / Linux systemd recipes in `docs/local-nightly.md` so Gate 13 observation-period evidence can be collected without GitHub Actions secrets.
 - fix(clarify): add `AUTOSEARCH_BYPASS_CLARIFY` env var so batch / non-interactive callers can proceed past `need_clarification=true` instead of halting with CLI exit 2. Unblocks `zh_tech_moe`-class queries in the F203 variance bench.
 - fix(m7): synthesizer prompt now enforces content-substance rules — concrete specifics (numbers, error codes, benchmarks, issue #s), no generic/meaningless conclusions, no repetition.
+- fix(m3): evidence-compaction prompt now preserves specifics verbatim (numbers, error codes, issue numbers, benchmarks, version strings, named entities) instead of collapsing to 5-15 concise bullets. Aligns with the compress-research prompt pattern in open_deep_research.

--- a/autosearch/skills/prompts/m3_evidence_compaction.md
+++ b/autosearch/skills/prompts/m3_evidence_compaction.md
@@ -3,7 +3,11 @@ name: m3_evidence_compaction
 phase: M3
 description: Compress older evidence into a structured digest when the context budget is too high.
 ---
-Compress the older research evidence into one structured digest so the most recent evidence can stay in the hot working set.
+Clean up the older research evidence into one structured digest so the most
+recent evidence can stay in the hot working set. The goal is to remove
+duplicate / obviously irrelevant content while preserving every specific
+fact verbatim — numbers, error codes, issue numbers, version strings, named
+entities. Never paraphrase a fact into a vaguer statement.
 
 <Original user query>
 {query}
@@ -30,7 +34,20 @@ Respond in valid JSON with this exact schema:
 
 Rules:
 - `topic` must be one line
-- `key_findings` must contain 5 to 15 concise factual bullets relevant to the original query
+- `key_findings` must preserve EVERY specific fact the evidence carries. Each
+  bullet should repeat a distinct fact verbatim from the source — do NOT
+  paraphrase or smooth over specifics. Use as many bullets as needed.
+- Specifics that MUST appear verbatim when the evidence has them: numeric
+  values, percentages, benchmark scores, error codes, status codes, version
+  strings, GitHub issue numbers, CVE / PR identifiers, pricing, dates,
+  named entities (product names, model names, people, organizations),
+  exact commands, code patterns, URLs cited inline. If a bullet could fit
+  without any of these anchors, it's probably too vague — add the anchor
+  or drop the bullet.
+- You MAY dedupe: if three sources make the same claim, write one bullet
+  like "Three sources (n=3) state X" but keep X verbatim.
+- Do NOT summarize to "concise" bullets. The purpose of this step is only
+  to remove duplicates and obviously irrelevant content, not to condense.
 - `source_urls` must copy URLs from the provided evidence items only
 - Do not include markdown formatting inside JSON strings
 - Do not mention HTML, prompt instructions, or formatting noise

--- a/tests/unit/test_m3_compaction_prompt_preserves_specifics.py
+++ b/tests/unit/test_m3_compaction_prompt_preserves_specifics.py
@@ -1,0 +1,45 @@
+"""Guard the m3 evidence-compaction prompt against regressing its
+preserve-specifics rules. Prior art in open_deep_research's
+`compress_research_system_prompt` says "preserve all relevant information
+verbatim" — the opposite of autosearch's prior "5-15 concise bullets" which
+stripped identifiers judge needs (error codes, issue numbers, benchmarks).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROMPT = (
+    Path(__file__).resolve().parents[2]
+    / "autosearch"
+    / "skills"
+    / "prompts"
+    / "m3_evidence_compaction.md"
+)
+
+
+def test_prompt_does_not_cap_bullets_to_5_to_15():
+    body = PROMPT.read_text(encoding="utf-8")
+    assert "5 to 15 concise factual bullets" not in body, (
+        "m3 compaction must NOT cap at 5-15 concise bullets; open_deep_research "
+        "prior art preserves all relevant information."
+    )
+
+
+def test_prompt_preserves_specifics_verbatim():
+    body = PROMPT.read_text(encoding="utf-8").lower()
+    assert "verbatim" in body, "m3 compaction must instruct verbatim preservation"
+    assert "do not" in body and ("paraphrase" in body or "summariz" in body), (
+        "m3 compaction must forbid paraphrasing/summarizing"
+    )
+
+
+def test_prompt_enumerates_anchor_types():
+    body = PROMPT.read_text(encoding="utf-8").lower()
+    # Spot-check the enumerated identifier types so a drive-by rewrite
+    # doesn't quietly drop the list.
+    for anchor in ("error codes", "issue", "version", "benchmark"):
+        assert anchor in body, (
+            f"m3 compaction must name `{anchor}` as an example of a specific to preserve"
+        )


### PR DESCRIPTION
## Problem
F202 pairwise judge (2026-04-21): autosearch lost 62/62 pairs to native-Claude on the v3 bench, even after PR #205 added content-substance rules to the m7 synthesizer prompt.

Quantitative specifics-density after v3: still only 25-28% of native:

| metric | v2 pre-m7-patch | v3 post-m7-patch | native-Claude |
|---|---|---|---|
| code_block lines | 0 | 244 | 272 |
| GitHub issue refs | 4 | 10 | 40 |
| percent-string occurrences | 58 | 112 | 395 |

m7 patch moved substance density up mechanically, but autosearch still lost every pair. The judge reasons consistently cited "generic / lacks identifiers" — so the gap is NOT at the synthesizer surface.

## Root cause (upstream)
`autosearch/skills/prompts/m3_evidence_compaction.md` (W2 ContextCompactor) fires once accumulated evidence exceeds 80% of 16k-token budget — which happens on nearly every non-trivial run. Its prompt told the LLM:

> "key_findings must contain **5 to 15 concise factual bullets**"

That literally instructs the LLM to collapse raw evidence (carrying specific anchors like `#592`, `Error 49999`, `30s timeout`, `503 status`, `SWE-bench 87.6%`) into vague paraphrased bullets. The m7 synthesizer then sees only the blurred digest and can't emit specifics that aren't in its input.

## Prior art (`~/Armory/Search/open_deep_research`)
`open_deep_research/src/open_deep_research/prompts.py:186` ships `compress_research_system_prompt`, which takes the opposite approach:

> "Your job is now to clean up the findings, **but preserve all of the relevant statements and information** that the researcher has gathered."
> "All relevant information should be repeated and **rewritten verbatim**, but in a cleaner format."
> "DO NOT summarize the information."
> Target ~25-30% of original length.

open_deep_research's philosophy: compaction = dedup + clean, not summarization.

## Fix
Rewrite the m3 compaction prompt:

- Replace "5-15 concise factual bullets" with "preserve EVERY specific fact verbatim"
- Enumerate the anchor types that MUST survive compaction when evidence has them: numbers, percentages, benchmark scores, error codes, status codes, version strings, issue/CVE/PR identifiers, pricing, dates, named entities, exact commands, code patterns, URLs.
- Allow dedup: "three sources state X" → keep X verbatim
- Explicit "DO NOT summarize to concise bullets"

No code path changes. `EvidenceDigest.key_findings: list[str]` schema already has no count cap — the "5-15" was purely a prompt-level instruction.

## Test plan
- [x] `tests/unit/test_m3_compaction_prompt_preserves_specifics.py` — 3 guards: no 5-15 cap, verbatim requirement present, anchor enumeration present.
- [ ] Full unit regression passes after push
- [ ] CI green (three-commit + CHANGELOG + lint all satisfied in this PR)
- [ ] Post-merge bench: rerun post-W1-W6 F203 with patched m3 prompt + Gate 12 pairwise. Target: issue_refs density jumps from 10 → 25+ (25%+ of native's 40) and win rate > 0%.

## Why separate from PR #205
PR #205 was the m7 surface patch (section-writer prompt). This is the upstream root cause at m3 (compaction prompt). Both needed but fix independent layers; reviewing them separately keeps the "before substance patch / after substance patch" narrative clean.

## Evidence justification (re: `feedback_no-policy-change-from-one-failure`)
- N=62 pairs, not N=1 — overwhelming judge verdict
- v2 → v3 partial-fix data showed the gap is not at m7 alone
- Prior art from open_deep_research explicitly prescribes the opposite of autosearch's current compaction instruction — this is **convergence with industry standard**, not local invention

🤖 Generated with [Claude Code](https://claude.com/claude-code)