### PR TITLE
ci: fix codex-autofix-dispatch marker mismatch to prevent dispatch loop

### DIFF
--- a/.github/workflows/codex-autofix-dispatch.yml
+++ b/.github/workflows/codex-autofix-dispatch.yml
@@ -107,7 +107,7 @@ jobs:
             });
             // Loop guard: skip if there is already a dispatch marker
             // for this head SHA.
-            const marker = `codex-autofix-dispatch: ${headSha}`;
+            const marker = `copilot-autofix-dispatch: ${headSha}`;
             const already = comments.data.some(c => (c.body || '').includes(marker));
             core.setOutput('skip', already ? 'true' : 'false');
             if (already) core.notice(`already dispatched for head ${headSha}, skipping`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- ci: fix codex-autofix-dispatch marker mismatch — loop-prevention guard searched `codex-autofix-dispatch:` but write-block emitted `copilot-autofix-dispatch:`, so repeat CI failures on the same PR head spammed fresh `@copilot please fix` comments. Unified both to `copilot-autofix-dispatch:`.
 - fix(ci): update 6 sync-pack files to v1.4.1 canonical — shellcheck/actionlint/gitleaks/@copilot/tools[] fixes (Closes #208)
 - feat(ci): bootstrap AI-native dev environment from sync pack v1.4 (Closes #203)
 - docs(mcp): add per-client MCP config guide for Claude Code / Cursor / Zed / Continue; document `research` + `health` tools and the full input schema.


### PR DESCRIPTION
## Summary

The loop-prevention guard in `.github/workflows/codex-autofix-dispatch.yml` never fired because its search-string at line 110 (`codex-autofix-dispatch:`) did not match the write-string at line 138 (`copilot-autofix-dispatch:`). Every repeat `workflow_run` failure on the same PR head therefore produced a fresh `@copilot please fix` comment.

Unified both sites to `copilot-autofix-dispatch:` — matches the doc comment at line 15 and is more descriptive of what the marker guards.

## Test plan

- [ ] CI green
- [ ] `grep 'marker = ' .github/workflows/codex-autofix-dispatch.yml` reports `copilot-autofix-dispatch:`
- [ ] Same fix landed in vibekit (#77) + will land in lazie

Closes #210