### PR TITLE
feat(transcribe): video-to-text-openai skill (paid Whisper fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `fetch-jina` skill: Jina Reader URL-to-Markdown fetcher. Free, no auth, best for articles/docs. First fast-path of v2 fetch layer.
 - `yt-dlp` dependency (>=2026.3.17): audio/video extraction for v2 video-to-text skills (bilibili / youtube / douyin / xiaoyuzhou) and media download utilities.
 - `video-to-text-groq` skill: yt-dlp + Groq Whisper API transcription (free tier). First of the v2 transcription trio; returns raw text + SRT + metadata. Summary is caller's responsibility (tool supplier principle).
+- `video-to-text-openai` skill: yt-dlp + OpenAI Whisper API transcription (paid, ~$0.006/min). Second of the v2 transcription trio; paid fallback when Groq is rate-limited. Same output shape as `video-to-text-groq`.
 
 ### Changed
 

--- a/autosearch/skills/tools/video-to-text-openai/SKILL.md
+++ b/autosearch/skills/tools/video-to-text-openai/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: video-to-text-openai
+description: Transcribe video/audio URL or local file to text + SRT using yt-dlp + OpenAI Whisper API. Paid fallback for v2 transcription when Groq is rate-limited or unavailable. Returns raw text and segments; summary is caller's responsibility.
+version: 0.1.0
+layer: leaf
+domains: [video-audio, transcription]
+scenarios: [video-to-text, subtitle-extraction, podcast-transcription]
+trigger_keywords: [转文字, 字幕, 转录, transcribe, whisper, video to text, 播客字幕]
+model_tier: Fast
+auth_required: true
+auth_env: OPENAI_API_KEY
+cost: paid
+experience_digest: experience.md
+---
+
+Transcribe video or audio into raw text and SRT subtitles through a reliable paid path: `yt-dlp` audio extraction plus OpenAI Whisper. Use this when `video-to-text-groq` is unavailable or quota-exceeded.
+
+## Input Fit
+
+- YouTube URLs.
+- Bilibili URLs.
+- Douyin URLs.
+- Xiaoyuzhou podcast URLs.
+- Local audio files such as MP3, M4A, WAV, AAC, FLAC, OGG, and OPUS.
+- Local video files such as MP4, MOV, MKV, AVI, WEBM, FLV, and M4V.
+
+## Invocation
+
+Call `transcribe.py`'s sync `transcribe(url_or_path: str)` function with the original URL or local file path:
+
+```python
+result = transcribe("https://www.youtube.com/watch?v=example")
+```
+
+Successful calls return:
+
+```python
+{
+    "ok": True,
+    "raw_txt": "...",
+    "subtitle_srt": "1\n00:00:00,000 --> 00:00:03,100\n...\n",
+    "meta": {
+        "language": "en",
+        "duration_sec": 123.4,
+        "model": "whisper-1",
+        "backend": "openai",
+    },
+    "audio_path": "/tmp/autosearch-video-to-text-openai-.../audio.mp3",
+    "source": "https://www.youtube.com/watch?v=example",
+}
+```
+
+## Failure Modes
+
+- Missing `OPENAI_API_KEY` returns `reason: missing_api_key`.
+- Unsupported URLs, network failures, and non-zero `yt-dlp` exits return `reason: yt_dlp_failed`.
+- Missing local `ffmpeg` for video conversion returns `reason: ffmpeg_missing`.
+- OpenAI rate limits return `reason: rate_limited`.
+- Other OpenAI API 4xx or 5xx responses return `reason: openai_api_error`.
+- Audio larger than 25 MB returns `reason: audio_too_large`.
+
+Downgrade chain: use `video-to-text-local` on Apple Silicon with LM Studio when cloud transcription is unavailable or unsuitable. When possible, prefer `video-to-text-groq` (free tier) first and fall back to this skill for quality or quota reasons.
+
+## Limits
+
+- Requires a paid OpenAI API key in `OPENAI_API_KEY` (pay-as-you-go, approximately $0.006/min for whisper-1).
+- OpenAI rate limits and tier quotas can throttle bursts or long files.
+- The upload cap is 25 MB per request; slice long media or use local transcription.
+- URL extraction depends on `yt-dlp` support for the target platform and current site behavior.
+
+This tool does **not** produce a summary. It returns `raw_txt` and subtitles so the runtime AI can decide how to process, summarize, quote, or cite the transcript.

--- a/autosearch/skills/tools/video-to-text-openai/__init__.py
+++ b/autosearch/skills/tools/video-to-text-openai/__init__.py
@@ -1,0 +1,1 @@
+"""video-to-text-openai skill package marker."""

--- a/autosearch/skills/tools/video-to-text-openai/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-openai/transcribe.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+
+LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="video-to-text-openai")
+
+DEFAULT_TIMEOUT_SECONDS = 120.0
+OPENAI_TRANSCRIPTIONS_URL = "https://api.openai.com/v1/audio/transcriptions"
+OPENAI_MODEL = "whisper-1"
+OPENAI_BACKEND = "openai"
+MAX_AUDIO_BYTES = 25 * 1024 * 1024
+
+AUDIO_EXTENSIONS = {
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".wma",
+}
+VIDEO_EXTENSIONS = {
+    ".avi",
+    ".flv",
+    ".m4v",
+    ".mkv",
+    ".mov",
+    ".mp4",
+    ".mpeg",
+    ".mpg",
+    ".ts",
+    ".webm",
+}
+
+VideoToTextOpenAIResult = dict[str, object]
+
+
+class YtDlpError(RuntimeError):
+    def __init__(self, stderr_tail: str) -> None:
+        super().__init__(stderr_tail)
+        self.stderr_tail = stderr_tail
+
+
+class FFmpegMissingError(RuntimeError):
+    pass
+
+
+class FFmpegFailedError(RuntimeError):
+    def __init__(self, stderr_tail: str) -> None:
+        super().__init__(stderr_tail)
+        self.stderr_tail = stderr_tail
+
+
+def transcribe(
+    url_or_path: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    http_client: httpx.Client | None = None,
+) -> VideoToTextOpenAIResult:
+    """Transcribe a video/audio URL or local file through OpenAI Whisper."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        return _failure(
+            source=url_or_path,
+            reason="missing_api_key",
+            suggest="配置 OPENAI_API_KEY env var（付费 $0.006/min，https://platform.openai.com/api-keys）",
+        )
+
+    try:
+        audio_path = _prepare_audio(url_or_path)
+        size_bytes = Path(audio_path).stat().st_size
+        if size_bytes > MAX_AUDIO_BYTES:
+            return _failure(
+                source=url_or_path,
+                reason="audio_too_large",
+                size_mb=round(size_bytes / 1024 / 1024, 2),
+                suggest="切片或本地转录",
+            )
+
+        response = _post_transcription(
+            audio_path=audio_path,
+            api_key=api_key,
+            timeout_seconds=timeout_seconds,
+            http_client=http_client,
+        )
+    except YtDlpError as exc:
+        LOGGER.warning("video_to_text_openai_yt_dlp_failed", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="yt_dlp_failed",
+            stderr_tail=exc.stderr_tail,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr_tail = _stderr_tail(exc.stderr)
+        LOGGER.warning("video_to_text_openai_yt_dlp_failed", source=url_or_path, reason=stderr_tail)
+        return _failure(
+            source=url_or_path,
+            reason="yt_dlp_failed",
+            stderr_tail=stderr_tail,
+        )
+    except FFmpegMissingError:
+        LOGGER.warning("video_to_text_openai_ffmpeg_missing", source=url_or_path)
+        return _failure(source=url_or_path, reason="ffmpeg_missing")
+    except FFmpegFailedError as exc:
+        LOGGER.warning("video_to_text_openai_ffmpeg_failed", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="ffmpeg_failed",
+            stderr_tail=exc.stderr_tail,
+        )
+    except httpx.HTTPError as exc:
+        LOGGER.warning("video_to_text_openai_http_error", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="openai_api_error",
+            status=None,
+            body=_truncate_body(str(exc) or exc.__class__.__name__),
+        )
+    except OSError as exc:
+        LOGGER.warning("video_to_text_openai_local_file_error", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="local_file_error",
+            message=str(exc) or exc.__class__.__name__,
+        )
+    except Exception as exc:  # pragma: no cover - defensive boundary for runtime tools
+        LOGGER.warning("video_to_text_openai_unexpected_error", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="unexpected_error",
+            message=str(exc) or exc.__class__.__name__,
+        )
+
+    if response.status_code == 429:
+        return _failure(
+            source=url_or_path,
+            reason="rate_limited",
+            suggest="降级 video-to-text-local 或等待",
+        )
+
+    if response.status_code >= 400:
+        return _failure(
+            source=url_or_path,
+            reason="openai_api_error",
+            status=response.status_code,
+            body=_truncate_body(response.text),
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        LOGGER.warning("video_to_text_openai_invalid_json", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="openai_api_error",
+            status=response.status_code,
+            body=_truncate_body(response.text),
+        )
+
+    segments = payload.get("segments") if isinstance(payload, dict) else None
+    normalized_segments = segments if isinstance(segments, list) else []
+    return {
+        "ok": True,
+        "raw_txt": str(payload.get("text") or "") if isinstance(payload, dict) else "",
+        "subtitle_srt": _build_srt(normalized_segments),
+        "meta": {
+            "language": str(payload.get("language") or "") if isinstance(payload, dict) else "",
+            "duration_sec": _duration_seconds(payload, normalized_segments),
+            "model": OPENAI_MODEL,
+            "backend": OPENAI_BACKEND,
+        },
+        "audio_path": audio_path,
+        "source": url_or_path,
+    }
+
+
+def _prepare_audio(url_or_path: str) -> str:
+    if _looks_like_url(url_or_path):
+        return _extract_audio(url_or_path)
+
+    source_path = Path(url_or_path).expanduser()
+    if not source_path.exists():
+        raise FileNotFoundError(f"Local input file not found: {source_path}")
+
+    if _is_audio_file(source_path):
+        return str(source_path)
+
+    if _is_video_file(source_path):
+        return _convert_local_video_to_mp3(source_path)
+
+    return str(source_path)
+
+
+def _extract_audio(url_or_path: str) -> str:
+    tmp_dir = Path(tempfile.mkdtemp(prefix="autosearch-video-to-text-openai-"))
+    output_template = tmp_dir / "audio.%(ext)s"
+    command = [
+        "yt-dlp",
+        "--no-playlist",
+        "--extract-audio",
+        "--audio-format",
+        "mp3",
+        "--audio-quality",
+        "128K",
+        "--output",
+        str(output_template),
+        url_or_path,
+    ]
+
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        stderr = getattr(exc, "stderr", None)
+        raise YtDlpError(_stderr_tail(stderr)) from exc
+
+    mp3_path = tmp_dir / "audio.mp3"
+    if mp3_path.exists():
+        return str(mp3_path)
+
+    candidates = sorted(path for path in tmp_dir.glob("audio.*") if path.is_file())
+    if candidates:
+        return str(candidates[0])
+
+    raise YtDlpError(_stderr_tail(result.stderr))
+
+
+def _convert_local_video_to_mp3(source_path: Path) -> str:
+    tmp_dir = Path(tempfile.mkdtemp(prefix="autosearch-video-to-text-openai-"))
+    audio_path = tmp_dir / "audio.mp3"
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(source_path),
+        "-vn",
+        "-codec:a",
+        "libmp3lame",
+        "-b:a",
+        "128k",
+        str(audio_path),
+    ]
+
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise FFmpegMissingError from exc
+    except subprocess.CalledProcessError as exc:
+        raise FFmpegFailedError(_stderr_tail(exc.stderr)) from exc
+
+    return str(audio_path)
+
+
+def _post_transcription(
+    *,
+    audio_path: str,
+    api_key: str,
+    timeout_seconds: float,
+    http_client: httpx.Client | None,
+) -> httpx.Response:
+    path = Path(audio_path)
+    headers = {"Authorization": f"Bearer {api_key}"}
+    data = {"model": OPENAI_MODEL, "response_format": "verbose_json"}
+
+    with path.open("rb") as audio_file:
+        files = {"file": (path.name, audio_file, "audio/mpeg")}
+        if http_client is not None:
+            return http_client.post(
+                OPENAI_TRANSCRIPTIONS_URL,
+                data=data,
+                files=files,
+                headers=headers,
+                timeout=timeout_seconds,
+            )
+
+        with httpx.Client(timeout=timeout_seconds) as client:
+            return client.post(
+                OPENAI_TRANSCRIPTIONS_URL,
+                data=data,
+                files=files,
+                headers=headers,
+            )
+
+
+def _build_srt(segments: list[Any]) -> str:
+    entries: list[str] = []
+    for index, segment in enumerate(segments, start=1):
+        if not isinstance(segment, dict):
+            continue
+
+        start = _to_float(segment.get("start"), default=0.0)
+        end = _to_float(segment.get("end"), default=start)
+        text = str(segment.get("text") or "").strip()
+        entries.append(f"{index}\n{_format_timestamp(start)} --> {_format_timestamp(end)}\n{text}")
+
+    return "\n\n".join(entries) + ("\n" if entries else "")
+
+
+def _format_timestamp(seconds: float) -> str:
+    total_milliseconds = max(0, int(round(seconds * 1000)))
+    milliseconds = total_milliseconds % 1000
+    total_seconds = total_milliseconds // 1000
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    secs = total_seconds % 60
+    return f"{hours:02}:{minutes:02}:{secs:02},{milliseconds:03}"
+
+
+def _duration_seconds(payload: object, segments: list[Any]) -> float:
+    if isinstance(payload, dict) and payload.get("duration") is not None:
+        return _to_float(payload.get("duration"), default=0.0)
+
+    ends = [
+        _to_float(segment.get("end"), default=0.0)
+        for segment in segments
+        if isinstance(segment, dict)
+    ]
+    return max(ends, default=0.0)
+
+
+def _to_float(value: object, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _looks_like_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _is_audio_file(path: Path) -> bool:
+    return path.suffix.lower() in AUDIO_EXTENSIONS
+
+
+def _is_video_file(path: Path) -> bool:
+    return path.suffix.lower() in VIDEO_EXTENSIONS
+
+
+def _stderr_tail(stderr: object, *, max_chars: int = 1000) -> str:
+    if stderr is None:
+        return ""
+    if isinstance(stderr, bytes):
+        text = stderr.decode(errors="replace")
+    else:
+        text = str(stderr)
+    return text[-max_chars:]
+
+
+def _truncate_body(body: str, *, max_chars: int = 500) -> str:
+    return body[:max_chars]
+
+
+def _failure(*, source: str, reason: str, **extra: object) -> VideoToTextOpenAIResult:
+    result: VideoToTextOpenAIResult = {"ok": False, "source": source, "reason": reason}
+    result.update(extra)
+    return result

--- a/tests/skills/tools/video_to_text_openai/test_video_to_text_openai.py
+++ b/tests/skills/tools/video_to_text_openai/test_video_to_text_openai.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import httpx
+import pytest
+
+
+def _load_video_to_text_openai() -> ModuleType:
+    root = Path(__file__).resolve().parents[4]
+    transcribe_path = (
+        root / "autosearch" / "skills" / "tools" / "video-to-text-openai" / "transcribe.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "video_to_text_openai_under_test", transcribe_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VIDEO_TO_TEXT_OPENAI = _load_video_to_text_openai()
+
+
+def _client(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _verbose_json() -> dict[str, object]:
+    return {
+        "text": "Hello world. Second line.",
+        "language": "en",
+        "duration": 3.75,
+        "segments": [
+            {"start": 0.0, "end": 1.25, "text": "Hello world."},
+            {"start": 1.25, "end": 3.75, "text": "Second line."},
+        ],
+    }
+
+
+def test_url_happy_path_returns_text_srt_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_mp3 = tmp_path / "audio.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(VIDEO_TO_TEXT_OPENAI, "_extract_audio", lambda source: str(fake_mp3))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert str(request.url) == VIDEO_TO_TEXT_OPENAI.OPENAI_TRANSCRIPTIONS_URL
+        assert request.headers["authorization"] == "Bearer test-key"
+        assert b'name="model"' in request.content
+        assert b"whisper-1" in request.content
+        assert b'name="response_format"' in request.content
+        assert b"verbose_json" in request.content
+        return httpx.Response(200, json=_verbose_json(), request=request)
+
+    with _client(handler) as client:
+        result = VIDEO_TO_TEXT_OPENAI.transcribe(
+            "https://www.youtube.com/watch?v=example",
+            http_client=client,
+        )
+
+    assert result["ok"] is True
+    assert result["raw_txt"] == "Hello world. Second line."
+    assert "1\n00:00:00,000 --> 00:00:01,250\nHello world." in result["subtitle_srt"]
+    assert "2\n00:00:01,250 --> 00:00:03,750\nSecond line." in result["subtitle_srt"]
+    assert result["meta"] == {
+        "language": "en",
+        "duration_sec": 3.75,
+        "model": "whisper-1",
+        "backend": "openai",
+    }
+    assert result["audio_path"] == str(fake_mp3)
+    assert result["source"] == "https://www.youtube.com/watch?v=example"
+
+
+def test_local_audio_happy_path_skips_yt_dlp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mp3 = tmp_path / "local.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fail_extract(source: str) -> str:
+        raise AssertionError(f"yt-dlp should not run for local audio: {source}")
+
+    monkeypatch.setattr(VIDEO_TO_TEXT_OPENAI, "_extract_audio", fail_extract)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_verbose_json(), request=request)
+
+    with _client(handler) as client:
+        result = VIDEO_TO_TEXT_OPENAI.transcribe(str(fake_mp3), http_client=client)
+
+    assert result["ok"] is True
+    assert result["raw_txt"] == "Hello world. Second line."
+    assert result["audio_path"] == str(fake_mp3)
+
+
+def test_missing_openai_api_key_returns_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mp3 = tmp_path / "local.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    result = VIDEO_TO_TEXT_OPENAI.transcribe(str(fake_mp3))
+
+    assert result["ok"] is False
+    assert result["reason"] == "missing_api_key"
+    assert (
+        result["suggest"]
+        == "配置 OPENAI_API_KEY env var（付费 $0.006/min，https://platform.openai.com/api-keys）"
+    )
+
+
+def test_openai_429_returns_rate_limited(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake_mp3 = tmp_path / "local.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, text="too many requests", request=request)
+
+    with _client(handler) as client:
+        result = VIDEO_TO_TEXT_OPENAI.transcribe(str(fake_mp3), http_client=client)
+
+    assert result["ok"] is False
+    assert result["reason"] == "rate_limited"
+    assert result["suggest"] == "降级 video-to-text-local 或等待"
+
+
+def test_yt_dlp_failure_returns_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mp3 = tmp_path / "audio.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fail_extract(source: str) -> str:
+        raise subprocess.CalledProcessError(
+            1,
+            ["yt-dlp", source],
+            stderr="unsupported URL\nnetwork failure",
+        )
+
+    monkeypatch.setattr(VIDEO_TO_TEXT_OPENAI, "_extract_audio", fail_extract)
+
+    result = VIDEO_TO_TEXT_OPENAI.transcribe("https://unsupported.example/video")
+
+    assert result["ok"] is False
+    assert result["reason"] == "yt_dlp_failed"
+    assert "unsupported URL" in result["stderr_tail"]


### PR DESCRIPTION
## Summary

Second of the v2 transcription trio. Paid OpenAI Whisper API (~\$0.006/min) as fallback when Groq is rate-limited. Same output schema as `video-to-text-groq`.

- Path: `autosearch/skills/tools/video-to-text-openai/`
- BYOK: `OPENAI_API_KEY` (paid)
- Model: `whisper-1`, endpoint `https://api.openai.com/v1/audio/transcriptions`
- Downgrade chain: groq (free) → openai (paid) → local (Apple Silicon + LM Studio)
- `cost: paid` in frontmatter (distinguishes from groq's `cost: free`)

## Test plan

- [x] ruff check + format ✓
- [x] pytest 5/5 passed in 0.05s
- [ ] CI: three-commit + changelog + no-issue-link ✓

## Commits

- `feat(transcribe)`: add video-to-text-openai skill
- `test`: 5 cases
- `docs(changelog)`: record addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)