### PR TITLE
feat(transcribe): video-to-text-local skill (mlx-whisper offline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `yt-dlp` dependency (>=2026.3.17): audio/video extraction for v2 video-to-text skills (bilibili / youtube / douyin / xiaoyuzhou) and media download utilities.
 - `video-to-text-groq` skill: yt-dlp + Groq Whisper API transcription (free tier). First of the v2 transcription trio; returns raw text + SRT + metadata. Summary is caller's responsibility (tool supplier principle).
 - `video-to-text-openai` skill: yt-dlp + OpenAI Whisper API transcription (paid, ~$0.006/min). Second of the v2 transcription trio; paid fallback when Groq is rate-limited. Same output shape as `video-to-text-groq`.
+- `video-to-text-local` skill: yt-dlp + local `mlx-whisper` transcription (Apple Silicon, offline, free). Third of the v2 transcription trio; opt-in advanced path for M-series Macs with mlx-whisper installed. Default model `mlx-community/whisper-large-v3-turbo`, overridable via `AUTOSEARCH_MLX_WHISPER_MODEL`.
 
 ### Changed
 

--- a/autosearch/skills/tools/video-to-text-local/SKILL.md
+++ b/autosearch/skills/tools/video-to-text-local/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: video-to-text-local
+description: Transcribe video/audio URL or local file to text + SRT using yt-dlp + local mlx-whisper (Apple Silicon). Free, offline, fastest on M-series Macs. Opt-in advanced path for users with Apple Silicon + mlx-whisper installed. Returns raw text and segments; summary is caller's responsibility.
+version: 0.1.0
+layer: leaf
+domains: [video-audio, transcription]
+scenarios: [video-to-text, subtitle-extraction, podcast-transcription, offline-transcription]
+trigger_keywords: [转文字, 字幕, 转录, transcribe, whisper, video to text, 播客字幕, 本地转录, offline transcribe]
+model_tier: Fast
+auth_required: false
+cost: free
+experience_digest: experience.md
+---
+
+Transcribe video or audio entirely on-device using `yt-dlp` audio extraction plus local `mlx-whisper` inference. Works offline, zero API cost, fastest on Apple Silicon M-series with MLX Metal acceleration.
+
+## Input Fit
+
+- YouTube URLs.
+- Bilibili URLs.
+- Douyin URLs.
+- Xiaoyuzhou podcast URLs.
+- Local audio files such as MP3, M4A, WAV, AAC, FLAC, OGG, and OPUS.
+- Local video files such as MP4, MOV, MKV, AVI, WEBM, FLV, and M4V.
+
+## Invocation
+
+Call `transcribe.py`'s sync `transcribe(url_or_path: str)` function with the original URL or local file path:
+
+```python
+result = transcribe("https://www.youtube.com/watch?v=example")
+```
+
+Successful calls return:
+
+```python
+{
+    "ok": True,
+    "raw_txt": "...",
+    "subtitle_srt": "1\n00:00:00,000 --> 00:00:03,100\n...\n",
+    "meta": {
+        "language": "en",
+        "duration_sec": 123.4,
+        "model": "mlx-community/whisper-large-v3-turbo",
+        "backend": "mlx-whisper",
+    },
+    "audio_path": "/tmp/autosearch-video-to-text-local-.../audio.mp3",
+    "source": "https://www.youtube.com/watch?v=example",
+}
+```
+
+## Failure Modes
+
+- Missing `mlx-whisper` package returns `reason: mlx_whisper_unavailable` (install with `pip install mlx-whisper`, Apple Silicon only).
+- Unsupported URLs, network failures, and non-zero `yt-dlp` exits return `reason: yt_dlp_failed`.
+- Missing local `ffmpeg` for video conversion returns `reason: ffmpeg_missing`.
+- Model download failure (no network on first run) returns `reason: model_download_failed`.
+- Other MLX / transcription runtime errors return `reason: mlx_whisper_runtime_error`.
+
+Downgrade chain: use `video-to-text-groq` as the free cloud fallback (requires `GROQ_API_KEY`), then `video-to-text-openai` as the paid cloud fallback.
+
+## Limits
+
+- Requires Apple Silicon (M1 / M2 / M3 / M4). Not compatible with Intel Macs, Linux, or Windows.
+- Requires `mlx-whisper` package installed separately: `pip install mlx-whisper` (not a default autosearch dependency because it's macOS/ARM-only).
+- First run downloads the Whisper model to `~/.cache/huggingface/hub/` (~3 GB for large-v3-turbo).
+- Default model: `mlx-community/whisper-large-v3-turbo`. Override via `AUTOSEARCH_MLX_WHISPER_MODEL` env var to any HuggingFace repo or local model path.
+
+This tool does **not** produce a summary. It returns `raw_txt` and subtitles so the runtime AI can decide how to process, summarize, quote, or cite the transcript.

--- a/autosearch/skills/tools/video-to-text-local/__init__.py
+++ b/autosearch/skills/tools/video-to-text-local/__init__.py
@@ -1,0 +1,1 @@
+"""video-to-text-local skill package marker."""

--- a/autosearch/skills/tools/video-to-text-local/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-local/transcribe.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from urllib.parse import urlparse
+
+import structlog
+
+LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="video-to-text-local")
+
+DEFAULT_MODEL = "mlx-community/whisper-large-v3-turbo"
+LOCAL_BACKEND = "mlx-whisper"
+MODEL_ENV_VAR = "AUTOSEARCH_MLX_WHISPER_MODEL"
+
+AUDIO_EXTENSIONS = {
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".wma",
+}
+VIDEO_EXTENSIONS = {
+    ".avi",
+    ".flv",
+    ".m4v",
+    ".mkv",
+    ".mov",
+    ".mp4",
+    ".mpeg",
+    ".mpg",
+    ".ts",
+    ".webm",
+}
+
+VideoToTextLocalResult = dict[str, object]
+
+
+class YtDlpError(RuntimeError):
+    def __init__(self, stderr_tail: str) -> None:
+        super().__init__(stderr_tail)
+        self.stderr_tail = stderr_tail
+
+
+class FFmpegMissingError(RuntimeError):
+    pass
+
+
+class FFmpegFailedError(RuntimeError):
+    def __init__(self, stderr_tail: str) -> None:
+        super().__init__(stderr_tail)
+        self.stderr_tail = stderr_tail
+
+
+class ModelDownloadError(RuntimeError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+def transcribe(
+    url_or_path: str,
+    *,
+    mlx_whisper_module: ModuleType | None = None,
+) -> VideoToTextLocalResult:
+    """Transcribe a video/audio URL or local file through local mlx-whisper."""
+    mlx = mlx_whisper_module if mlx_whisper_module is not None else _load_mlx_whisper()
+    if mlx is None:
+        return _failure(
+            source=url_or_path,
+            reason="mlx_whisper_unavailable",
+            suggest="pip install mlx-whisper（Apple Silicon 专用）或降级 video-to-text-groq",
+        )
+
+    model = os.environ.get(MODEL_ENV_VAR) or DEFAULT_MODEL
+
+    try:
+        audio_path = _prepare_audio(url_or_path)
+    except YtDlpError as exc:
+        LOGGER.warning("video_to_text_local_yt_dlp_failed", source=url_or_path, reason=str(exc))
+        return _failure(source=url_or_path, reason="yt_dlp_failed", stderr_tail=exc.stderr_tail)
+    except subprocess.CalledProcessError as exc:
+        stderr_tail = _stderr_tail(exc.stderr)
+        LOGGER.warning("video_to_text_local_yt_dlp_failed", source=url_or_path, reason=stderr_tail)
+        return _failure(source=url_or_path, reason="yt_dlp_failed", stderr_tail=stderr_tail)
+    except FFmpegMissingError:
+        LOGGER.warning("video_to_text_local_ffmpeg_missing", source=url_or_path)
+        return _failure(source=url_or_path, reason="ffmpeg_missing")
+    except FFmpegFailedError as exc:
+        LOGGER.warning("video_to_text_local_ffmpeg_failed", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="ffmpeg_failed",
+            stderr_tail=exc.stderr_tail,
+        )
+    except OSError as exc:
+        LOGGER.warning("video_to_text_local_local_file_error", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="local_file_error",
+            message=str(exc) or exc.__class__.__name__,
+        )
+
+    try:
+        payload = mlx.transcribe(audio_path, path_or_hf_repo=model)
+    except ModelDownloadError as exc:
+        LOGGER.warning(
+            "video_to_text_local_model_download_failed", source=url_or_path, reason=str(exc)
+        )
+        return _failure(
+            source=url_or_path,
+            reason="model_download_failed",
+            message=exc.message,
+            suggest="检查网络并重试，或预先下载模型到 ~/.cache/huggingface/hub/",
+        )
+    except Exception as exc:  # pragma: no cover - defensive boundary for runtime tools
+        LOGGER.warning("video_to_text_local_runtime_error", source=url_or_path, reason=str(exc))
+        return _failure(
+            source=url_or_path,
+            reason="mlx_whisper_runtime_error",
+            message=str(exc) or exc.__class__.__name__,
+        )
+
+    segments = payload.get("segments") if isinstance(payload, dict) else None
+    normalized_segments = segments if isinstance(segments, list) else []
+    return {
+        "ok": True,
+        "raw_txt": str(payload.get("text") or "") if isinstance(payload, dict) else "",
+        "subtitle_srt": _build_srt(normalized_segments),
+        "meta": {
+            "language": str(payload.get("language") or "") if isinstance(payload, dict) else "",
+            "duration_sec": _duration_seconds(payload, normalized_segments),
+            "model": model,
+            "backend": LOCAL_BACKEND,
+        },
+        "audio_path": audio_path,
+        "source": url_or_path,
+    }
+
+
+def _load_mlx_whisper() -> ModuleType | None:
+    try:
+        return importlib.import_module("mlx_whisper")
+    except ImportError:
+        return None
+
+
+def _prepare_audio(url_or_path: str) -> str:
+    if _looks_like_url(url_or_path):
+        return _extract_audio(url_or_path)
+
+    source_path = Path(url_or_path).expanduser()
+    if not source_path.exists():
+        raise FileNotFoundError(f"Local input file not found: {source_path}")
+
+    if _is_audio_file(source_path):
+        return str(source_path)
+
+    if _is_video_file(source_path):
+        return _convert_local_video_to_mp3(source_path)
+
+    return str(source_path)
+
+
+def _extract_audio(url_or_path: str) -> str:
+    tmp_dir = Path(tempfile.mkdtemp(prefix="autosearch-video-to-text-local-"))
+    output_template = tmp_dir / "audio.%(ext)s"
+    command = [
+        "yt-dlp",
+        "--no-playlist",
+        "--extract-audio",
+        "--audio-format",
+        "mp3",
+        "--audio-quality",
+        "128K",
+        "--output",
+        str(output_template),
+        url_or_path,
+    ]
+
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        stderr = getattr(exc, "stderr", None)
+        raise YtDlpError(_stderr_tail(stderr)) from exc
+
+    mp3_path = tmp_dir / "audio.mp3"
+    if mp3_path.exists():
+        return str(mp3_path)
+
+    candidates = sorted(path for path in tmp_dir.glob("audio.*") if path.is_file())
+    if candidates:
+        return str(candidates[0])
+
+    raise YtDlpError(_stderr_tail(result.stderr))
+
+
+def _convert_local_video_to_mp3(source_path: Path) -> str:
+    tmp_dir = Path(tempfile.mkdtemp(prefix="autosearch-video-to-text-local-"))
+    audio_path = tmp_dir / "audio.mp3"
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(source_path),
+        "-vn",
+        "-codec:a",
+        "libmp3lame",
+        "-b:a",
+        "128k",
+        str(audio_path),
+    ]
+
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise FFmpegMissingError from exc
+    except subprocess.CalledProcessError as exc:
+        raise FFmpegFailedError(_stderr_tail(exc.stderr)) from exc
+
+    return str(audio_path)
+
+
+def _build_srt(segments: list[Any]) -> str:
+    entries: list[str] = []
+    for index, segment in enumerate(segments, start=1):
+        if not isinstance(segment, dict):
+            continue
+
+        start = _to_float(segment.get("start"), default=0.0)
+        end = _to_float(segment.get("end"), default=start)
+        text = str(segment.get("text") or "").strip()
+        entries.append(f"{index}\n{_format_timestamp(start)} --> {_format_timestamp(end)}\n{text}")
+
+    return "\n\n".join(entries) + ("\n" if entries else "")
+
+
+def _format_timestamp(seconds: float) -> str:
+    total_milliseconds = max(0, int(round(seconds * 1000)))
+    milliseconds = total_milliseconds % 1000
+    total_seconds = total_milliseconds // 1000
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    secs = total_seconds % 60
+    return f"{hours:02}:{minutes:02}:{secs:02},{milliseconds:03}"
+
+
+def _duration_seconds(payload: object, segments: list[Any]) -> float:
+    if isinstance(payload, dict) and payload.get("duration") is not None:
+        return _to_float(payload.get("duration"), default=0.0)
+
+    ends = [
+        _to_float(segment.get("end"), default=0.0)
+        for segment in segments
+        if isinstance(segment, dict)
+    ]
+    return max(ends, default=0.0)
+
+
+def _to_float(value: object, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _looks_like_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _is_audio_file(path: Path) -> bool:
+    return path.suffix.lower() in AUDIO_EXTENSIONS
+
+
+def _is_video_file(path: Path) -> bool:
+    return path.suffix.lower() in VIDEO_EXTENSIONS
+
+
+def _stderr_tail(stderr: object, *, max_chars: int = 1000) -> str:
+    if stderr is None:
+        return ""
+    if isinstance(stderr, bytes):
+        text = stderr.decode(errors="replace")
+    else:
+        text = str(stderr)
+    return text[-max_chars:]
+
+
+def _failure(*, source: str, reason: str, **extra: object) -> VideoToTextLocalResult:
+    result: VideoToTextLocalResult = {"ok": False, "source": source, "reason": reason}
+    result.update(extra)
+    return result

--- a/tests/skills/tools/video_to_text_local/test_video_to_text_local.py
+++ b/tests/skills/tools/video_to_text_local/test_video_to_text_local.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _load_video_to_text_local() -> ModuleType:
+    root = Path(__file__).resolve().parents[4]
+    transcribe_path = (
+        root / "autosearch" / "skills" / "tools" / "video-to-text-local" / "transcribe.py"
+    )
+    spec = importlib.util.spec_from_file_location("video_to_text_local_under_test", transcribe_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VIDEO_TO_TEXT_LOCAL = _load_video_to_text_local()
+
+
+def _fake_mlx_payload() -> dict[str, object]:
+    return {
+        "text": "Hello world. Second line.",
+        "language": "en",
+        "duration": 3.75,
+        "segments": [
+            {"start": 0.0, "end": 1.25, "text": "Hello world."},
+            {"start": 1.25, "end": 3.75, "text": "Second line."},
+        ],
+    }
+
+
+def _mlx_module(transcribe_fn) -> SimpleNamespace:
+    return SimpleNamespace(transcribe=transcribe_fn)
+
+
+def test_url_happy_path_returns_text_srt_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_mp3 = tmp_path / "audio.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.setattr(VIDEO_TO_TEXT_LOCAL, "_extract_audio", lambda source: str(fake_mp3))
+
+    captured: dict[str, object] = {}
+
+    def fake_transcribe(audio_path: str, *, path_or_hf_repo: str) -> dict[str, object]:
+        captured["audio_path"] = audio_path
+        captured["model"] = path_or_hf_repo
+        return _fake_mlx_payload()
+
+    result = VIDEO_TO_TEXT_LOCAL.transcribe(
+        "https://www.youtube.com/watch?v=example",
+        mlx_whisper_module=_mlx_module(fake_transcribe),
+    )
+
+    assert result["ok"] is True
+    assert result["raw_txt"] == "Hello world. Second line."
+    assert "1\n00:00:00,000 --> 00:00:01,250\nHello world." in result["subtitle_srt"]
+    assert "2\n00:00:01,250 --> 00:00:03,750\nSecond line." in result["subtitle_srt"]
+    assert result["meta"] == {
+        "language": "en",
+        "duration_sec": 3.75,
+        "model": "mlx-community/whisper-large-v3-turbo",
+        "backend": "mlx-whisper",
+    }
+    assert result["audio_path"] == str(fake_mp3)
+    assert result["source"] == "https://www.youtube.com/watch?v=example"
+    assert captured["audio_path"] == str(fake_mp3)
+    assert captured["model"] == "mlx-community/whisper-large-v3-turbo"
+
+
+def test_local_audio_happy_path_skips_yt_dlp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mp3 = tmp_path / "local.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+
+    def fail_extract(source: str) -> str:
+        raise AssertionError(f"yt-dlp should not run for local audio: {source}")
+
+    monkeypatch.setattr(VIDEO_TO_TEXT_LOCAL, "_extract_audio", fail_extract)
+
+    def fake_transcribe(audio_path: str, *, path_or_hf_repo: str) -> dict[str, object]:
+        return _fake_mlx_payload()
+
+    result = VIDEO_TO_TEXT_LOCAL.transcribe(
+        str(fake_mp3),
+        mlx_whisper_module=_mlx_module(fake_transcribe),
+    )
+
+    assert result["ok"] is True
+    assert result["raw_txt"] == "Hello world. Second line."
+    assert result["audio_path"] == str(fake_mp3)
+
+
+def test_mlx_whisper_unavailable_returns_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mp3 = tmp_path / "local.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.setattr(VIDEO_TO_TEXT_LOCAL, "_load_mlx_whisper", lambda: None)
+
+    result = VIDEO_TO_TEXT_LOCAL.transcribe(str(fake_mp3))
+
+    assert result["ok"] is False
+    assert result["reason"] == "mlx_whisper_unavailable"
+    assert "mlx-whisper" in result["suggest"]
+    assert "video-to-text-groq" in result["suggest"]
+
+
+def test_custom_model_via_env_var_is_passed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mp3 = tmp_path / "local.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+    monkeypatch.setenv("AUTOSEARCH_MLX_WHISPER_MODEL", "mlx-community/whisper-tiny")
+
+    captured: dict[str, object] = {}
+
+    def fake_transcribe(audio_path: str, *, path_or_hf_repo: str) -> dict[str, object]:
+        captured["model"] = path_or_hf_repo
+        return _fake_mlx_payload()
+
+    result = VIDEO_TO_TEXT_LOCAL.transcribe(
+        str(fake_mp3),
+        mlx_whisper_module=_mlx_module(fake_transcribe),
+    )
+
+    assert result["ok"] is True
+    assert result["meta"]["model"] == "mlx-community/whisper-tiny"
+    assert captured["model"] == "mlx-community/whisper-tiny"
+
+
+def test_yt_dlp_failure_returns_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fail_extract(source: str) -> str:
+        raise subprocess.CalledProcessError(
+            1,
+            ["yt-dlp", source],
+            stderr="unsupported URL\nnetwork failure",
+        )
+
+    monkeypatch.setattr(VIDEO_TO_TEXT_LOCAL, "_extract_audio", fail_extract)
+
+    def fake_transcribe(audio_path: str, *, path_or_hf_repo: str) -> dict[str, object]:
+        raise AssertionError("mlx should not run if yt-dlp failed")
+
+    result = VIDEO_TO_TEXT_LOCAL.transcribe(
+        "https://unsupported.example/video",
+        mlx_whisper_module=_mlx_module(fake_transcribe),
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "yt_dlp_failed"
+    assert "unsupported URL" in result["stderr_tail"]
+
+
+def test_mlx_runtime_error_returns_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mp3 = tmp_path / "local.mp3"
+    fake_mp3.write_bytes(b"fake mp3")
+
+    def fake_transcribe(audio_path: str, *, path_or_hf_repo: str) -> dict[str, object]:
+        raise RuntimeError("metal kernel launch failed")
+
+    result = VIDEO_TO_TEXT_LOCAL.transcribe(
+        str(fake_mp3),
+        mlx_whisper_module=_mlx_module(fake_transcribe),
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "mlx_whisper_runtime_error"
+    assert "metal kernel launch failed" in result["message"]


### PR DESCRIPTION
## Summary

Third and final skill of the v2 transcription trio (wave 1 PR 5). Local on-device transcription via yt-dlp + mlx-whisper on Apple Silicon. Offline, free, fastest on M-series. Opt-in advanced path (user installs `mlx-whisper` separately; not a default autosearch dep because it's macOS/ARM-only).

- Path: `autosearch/skills/tools/video-to-text-local/`
- Backend: `mlx-whisper` Python package (Apple Silicon only)
- Default model: `mlx-community/whisper-large-v3-turbo`
- Model override: `AUTOSEARCH_MLX_WHISPER_MODEL` env var
- Frontmatter: `auth_required: false`, `cost: free`, `layer: leaf`, `domains: [video-audio, transcription]`
- Downgrade chain: local → groq (free cloud) → openai (paid cloud)

## Test plan

- [x] ruff check + format ✓
- [x] pytest 6/6 passed in 0.04s (url, local, unavailable, env-model, yt-dlp fail, runtime error)
- [ ] CI: three-commit + changelog + no-issue-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)