### PR TITLE
feat(fetch): fetch-crawl4ai skill (Playwright-backed deep fetch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `video-to-text-groq` skill: yt-dlp + Groq Whisper API transcription (free tier). First of the v2 transcription trio; returns raw text + SRT + metadata. Summary is caller's responsibility (tool supplier principle).
 - `video-to-text-openai` skill: yt-dlp + OpenAI Whisper API transcription (paid, ~$0.006/min). Second of the v2 transcription trio; paid fallback when Groq is rate-limited. Same output shape as `video-to-text-groq`.
 - `video-to-text-local` skill: yt-dlp + local `mlx-whisper` transcription (Apple Silicon, offline, free). Third of the v2 transcription trio; opt-in advanced path for M-series Macs with mlx-whisper installed. Default model `mlx-community/whisper-large-v3-turbo`, overridable via `AUTOSEARCH_MLX_WHISPER_MODEL`.
+- `fetch-crawl4ai` skill: deep URL fetch via `crawl4ai` (Playwright-backed) for JS-rendered pages, anti-bot sites, and dynamic content. Slower than `fetch-jina` but handles pages that block simple fetchers. Opt-in (user installs `crawl4ai` + `playwright install chromium` separately; not a default autosearch dep to keep the core lightweight).
 
 ### Changed
 

--- a/autosearch/skills/tools/fetch-crawl4ai/SKILL.md
+++ b/autosearch/skills/tools/fetch-crawl4ai/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: fetch-crawl4ai
+description: Deep URL fetch using crawl4ai (Playwright-powered) for JS-rendered pages, anti-bot sites, and dynamic content. Slower than fetch-jina but handles sites that block simple fetchers. Requires user-installed crawl4ai package.
+version: 0.1.0
+layer: leaf
+domains: [web-fetch]
+scenarios: [url-reading, js-heavy, anti-bot-site, dynamic-content]
+trigger_keywords: [fetch, 深抓, crawl, JS 渲染, playwright, 动态页, anti-bot]
+model_tier: Standard
+auth_required: false
+cost: free
+experience_digest: experience.md
+---
+
+Deep URL fetch through `crawl4ai`, backed by Playwright and Chromium. Use this as the fallback when `fetch-jina` fails, refuses a URL, returns an empty page, or cannot see JavaScript-rendered content.
+
+## Input Fit
+
+- JavaScript-heavy SPAs where server HTML is mostly empty.
+- Anti-bot or dynamic sites that block simple HTTP fetchers.
+- Pages that need a CSS selector wait before extraction.
+- Public pages where a local Chromium browser can render the content.
+
+## Invocation
+
+Call `fetch.py`'s sync `fetch(url: str, wait_for: str | None = None, timeout_seconds: float = 30.0)` function:
+
+```python
+result = fetch("https://example.com/app", wait_for=".loaded")
+```
+
+Successful calls return:
+
+```python
+{
+    "ok": True,
+    "markdown": "...",
+    "title": "Rendered page title",
+    "url": "https://example.com/final-url",
+    "meta": {
+        "status_code": 200,
+        "backend": "crawl4ai",
+        "browser": "chromium",
+        "elapsed_sec": 2.4,
+    },
+    "source": "https://example.com/app",
+}
+```
+
+## Failure Modes
+
+- Missing `crawl4ai` package returns `reason: crawl4ai_unavailable`. Install with `pip install crawl4ai` plus `playwright install chromium`, or fall back to `fetch-jina`.
+- Browser or crawl4ai runtime failures return `reason: crawl4ai_runtime_error` with the error message or stderr tail.
+- DNS, connection, and transport failures return `reason: network_error`.
+- Slow pages that exceed `timeout_seconds` return `reason: timeout`.
+- HTTP 403 or detectable challenge pages return `reason: anti_bot_blocked`; degrade to `fetch-playwright` or `fetch-firecrawl` paid fallback.
+- Successful crawls with empty or too-short Markdown return `reason: empty_content`.
+
+## Limits
+
+- Requires user opt-in installation: `pip install crawl4ai`.
+- Requires a Chromium browser installed for Playwright: `playwright install chromium`.
+- This tool is slower and heavier than `fetch-jina`; use it only when a simple fetch cannot retrieve the useful content.
+- It does not solve sites that require authentication, strong bot mitigation, paid proxies, or long interactive flows.

--- a/autosearch/skills/tools/fetch-crawl4ai/__init__.py
+++ b/autosearch/skills/tools/fetch-crawl4ai/__init__.py
@@ -1,0 +1,1 @@
+"""fetch-crawl4ai skill package marker."""

--- a/autosearch/skills/tools/fetch-crawl4ai/fetch.py
+++ b/autosearch/skills/tools/fetch-crawl4ai/fetch.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import time
+from types import ModuleType
+from typing import Any
+
+import structlog
+
+LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="fetch-crawl4ai")
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+CRAWL4AI_UNAVAILABLE_SUGGEST = (
+    "pip install crawl4ai + playwright install chromium, or fall back to fetch-jina"
+)
+ANTI_BOT_SUGGEST = "try fetch-playwright or fetch-firecrawl paid fallback"
+ANTI_BOT_STATUS_CODES = {401, 403, 418, 429, 451}
+ANTI_BOT_MARKERS = (
+    "access denied",
+    "anti-bot",
+    "blocked by anti-bot",
+    "captcha",
+    "cloudflare",
+    "forbidden",
+    "perimeterx",
+    "please verify",
+    "robot",
+    "security check",
+    "security verification",
+    "verify you are human",
+    "访问验证",
+    "安全验证",
+)
+NETWORK_ERROR_MARKERS = (
+    "connection refused",
+    "connection reset",
+    "dns",
+    "err_aborted",
+    "err_connection",
+    "err_name_not_resolved",
+    "net::",
+    "network",
+    "socket",
+)
+
+FetchCrawl4AIResult = dict[str, object]
+
+
+def fetch(
+    url: str,
+    *,
+    wait_for: str | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    crawl4ai_module: ModuleType | None = None,
+) -> FetchCrawl4AIResult:
+    """Fetch a URL as Markdown through crawl4ai's Playwright-backed crawler."""
+    crawl4ai = crawl4ai_module if crawl4ai_module is not None else _load_crawl4ai()
+    if crawl4ai is None:
+        return _failure(
+            source=url,
+            reason="crawl4ai_unavailable",
+            suggest=CRAWL4AI_UNAVAILABLE_SUGGEST,
+        )
+
+    started = time.perf_counter()
+    try:
+        result = asyncio.run(
+            asyncio.wait_for(
+                _crawl_once(
+                    url,
+                    wait_for=wait_for,
+                    timeout_seconds=timeout_seconds,
+                    crawl4ai=crawl4ai,
+                ),
+                timeout=max(timeout_seconds, 0.001),
+            )
+        )
+    except Exception as exc:  # crawl4ai intentionally stays optional at import time.
+        elapsed_sec = time.perf_counter() - started
+        reason = _classify_exception(exc)
+        LOGGER.warning("fetch_crawl4ai_failed", url=url, reason=reason, error=str(exc))
+        return _failure(
+            source=url,
+            reason=reason,
+            message=str(exc) or exc.__class__.__name__,
+            stderr_tail=_stderr_tail(getattr(exc, "stderr", None)),
+            meta=_failure_meta(elapsed_sec=elapsed_sec),
+        )
+
+    elapsed_sec = time.perf_counter() - started
+    status_code = _to_int(getattr(result, "status_code", None))
+    markdown = _extract_markdown(result)
+    html = str(getattr(result, "html", "") or "")
+    error_message = str(getattr(result, "error_message", "") or "")
+    final_url = str(getattr(result, "redirected_url", None) or getattr(result, "url", None) or url)
+    metadata = getattr(result, "metadata", None)
+    title = _extract_title(markdown=markdown, metadata=metadata)
+
+    if _looks_like_anti_bot(
+        status_code=status_code,
+        markdown=markdown,
+        html=html,
+        error_message=error_message,
+    ):
+        return _failure(
+            source=url,
+            reason="anti_bot_blocked",
+            message=error_message or f"crawl4ai reported blocked HTTP {status_code}",
+            status_code=status_code,
+            suggest=ANTI_BOT_SUGGEST,
+            meta=_failure_meta(elapsed_sec=elapsed_sec, status_code=status_code),
+        )
+
+    if not bool(getattr(result, "success", False)):
+        return _failure(
+            source=url,
+            reason="crawl4ai_runtime_error",
+            message=error_message or "crawl4ai returned an unsuccessful result",
+            status_code=status_code,
+            meta=_failure_meta(elapsed_sec=elapsed_sec, status_code=status_code),
+        )
+
+    if len(markdown.strip()) < 10:
+        return _failure(
+            source=url,
+            reason="empty_content",
+            message="crawl4ai returned empty or too-short markdown",
+            status_code=status_code,
+            meta=_failure_meta(elapsed_sec=elapsed_sec, status_code=status_code),
+        )
+
+    return {
+        "ok": True,
+        "markdown": markdown,
+        "title": title,
+        "url": final_url,
+        "meta": {
+            "status_code": status_code,
+            "backend": "crawl4ai",
+            "browser": "chromium",
+            "elapsed_sec": elapsed_sec,
+        },
+        "source": url,
+    }
+
+
+def _load_crawl4ai() -> ModuleType | None:
+    try:
+        return importlib.import_module("crawl4ai")
+    except ImportError:
+        return None
+
+
+async def _crawl_once(
+    url: str,
+    *,
+    wait_for: str | None,
+    timeout_seconds: float,
+    crawl4ai: ModuleType,
+) -> Any:
+    browser_config = crawl4ai.BrowserConfig(headless=True)
+    run_config = crawl4ai.CrawlerRunConfig(
+        cache_mode=crawl4ai.CacheMode.BYPASS,
+        wait_for=wait_for,
+        page_timeout=max(1, int(timeout_seconds * 1000)),
+    )
+
+    async with crawl4ai.AsyncWebCrawler(config=browser_config) as crawler:
+        return await crawler.arun(url=url, config=run_config)
+
+
+def _failure(*, source: str, reason: str, **extra: object) -> FetchCrawl4AIResult:
+    result: FetchCrawl4AIResult = {"ok": False, "reason": reason, "source": source}
+    result.update({key: value for key, value in extra.items() if value is not None})
+    return result
+
+
+def _failure_meta(*, elapsed_sec: float, status_code: int | None = None) -> dict[str, object]:
+    return {
+        "status_code": status_code,
+        "backend": "crawl4ai",
+        "browser": "chromium",
+        "elapsed_sec": elapsed_sec,
+    }
+
+
+def _extract_markdown(result: object) -> str:
+    markdown = getattr(result, "markdown", "")
+    if markdown is None:
+        return ""
+
+    raw_markdown = getattr(markdown, "raw_markdown", None)
+    if raw_markdown is not None:
+        return str(raw_markdown)
+
+    if isinstance(markdown, dict):
+        return str(markdown.get("raw_markdown") or markdown.get("markdown") or "")
+
+    return str(markdown)
+
+
+def _extract_title(*, markdown: str, metadata: object) -> str:
+    if isinstance(metadata, dict):
+        for key in ("title", "og:title", "twitter:title"):
+            value = metadata.get(key)
+            if value:
+                return str(value).strip()
+
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        lower = stripped.lower()
+        if lower.startswith("title:"):
+            return stripped.split(":", maxsplit=1)[1].strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip()
+    return ""
+
+
+def _looks_like_anti_bot(
+    *,
+    status_code: int | None,
+    markdown: str,
+    html: str,
+    error_message: str,
+) -> bool:
+    if status_code in ANTI_BOT_STATUS_CODES:
+        return True
+
+    haystack = f"{error_message}\n{markdown}\n{html}".lower()
+    return any(marker in haystack for marker in ANTI_BOT_MARKERS)
+
+
+def _classify_exception(exc: Exception) -> str:
+    if isinstance(exc, TimeoutError | asyncio.TimeoutError):
+        return "timeout"
+
+    exc_name = exc.__class__.__name__.lower()
+    message = str(exc).lower()
+    if "timeout" in exc_name or "timeout" in message or "timed out" in message:
+        return "timeout"
+    if _looks_like_network_error(exc_name=exc_name, message=message):
+        return "network_error"
+    return "crawl4ai_runtime_error"
+
+
+def _looks_like_network_error(*, exc_name: str, message: str) -> bool:
+    if any(marker in exc_name for marker in ("connection", "network", "socket")):
+        return True
+    return any(marker in message for marker in NETWORK_ERROR_MARKERS)
+
+
+def _stderr_tail(stderr: object, *, max_chars: int = 1000) -> str:
+    if stderr is None:
+        return ""
+    if isinstance(stderr, bytes):
+        text = stderr.decode(errors="replace")
+    else:
+        text = str(stderr)
+    return text[-max_chars:]
+
+
+def _to_int(value: object) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None

--- a/tests/skills/tools/fetch_crawl4ai/test_fetch_crawl4ai.py
+++ b/tests/skills/tools/fetch_crawl4ai/test_fetch_crawl4ai.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _load_fetch_crawl4ai() -> ModuleType:
+    root = Path(__file__).resolve().parents[4]
+    fetch_path = root / "autosearch" / "skills" / "tools" / "fetch-crawl4ai" / "fetch.py"
+    spec = importlib.util.spec_from_file_location("fetch_crawl4ai_under_test", fetch_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+FETCH_CRAWL4AI = _load_fetch_crawl4ai()
+
+
+class FakeBrowserConfig:
+    def __init__(self, *, headless: bool) -> None:
+        self.headless = headless
+
+
+class FakeCrawlerRunConfig:
+    def __init__(
+        self,
+        *,
+        cache_mode: object,
+        wait_for: str | None,
+        page_timeout: int,
+    ) -> None:
+        self.cache_mode = cache_mode
+        self.wait_for = wait_for
+        self.page_timeout = page_timeout
+
+
+def _crawl4ai_module(
+    result: object | None = None,
+    *,
+    arun_error: Exception | None = None,
+    captured: dict[str, object] | None = None,
+) -> SimpleNamespace:
+    captured = captured if captured is not None else {}
+    cache_mode = SimpleNamespace(BYPASS="bypass")
+
+    class FakeAsyncWebCrawler:
+        def __init__(self, *, config: FakeBrowserConfig) -> None:
+            captured["browser_config"] = config
+
+        async def __aenter__(self) -> "FakeAsyncWebCrawler":
+            captured["entered"] = True
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            captured["exited"] = True
+
+        async def arun(self, *, url: str, config: FakeCrawlerRunConfig) -> object:
+            captured["url"] = url
+            captured["run_config"] = config
+            if arun_error is not None:
+                raise arun_error
+            return result
+
+    return SimpleNamespace(
+        AsyncWebCrawler=FakeAsyncWebCrawler,
+        BrowserConfig=FakeBrowserConfig,
+        CrawlerRunConfig=FakeCrawlerRunConfig,
+        CacheMode=cache_mode,
+    )
+
+
+def test_url_happy_path_returns_markdown() -> None:
+    result = SimpleNamespace(
+        success=True,
+        markdown=SimpleNamespace(raw_markdown="# Rendered Title\n\nHello from the browser."),
+        url="https://example.test/input",
+        redirected_url="https://example.test/final",
+        status_code=200,
+        metadata={"title": "Rendered Title"},
+    )
+
+    response = FETCH_CRAWL4AI.fetch(
+        "https://example.test/input",
+        crawl4ai_module=_crawl4ai_module(result),
+    )
+
+    assert response["ok"] is True
+    assert response["markdown"] == "# Rendered Title\n\nHello from the browser."
+    assert response["title"] == "Rendered Title"
+    assert response["url"] == "https://example.test/final"
+    assert response["meta"]["status_code"] == 200
+    assert response["meta"]["backend"] == "crawl4ai"
+    assert response["meta"]["browser"] == "chromium"
+    assert isinstance(response["meta"]["elapsed_sec"], float)
+    assert response["source"] == "https://example.test/input"
+
+
+def test_crawl4ai_unavailable_returns_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(FETCH_CRAWL4AI, "_load_crawl4ai", lambda: None)
+
+    response = FETCH_CRAWL4AI.fetch("https://example.test")
+
+    assert response == {
+        "ok": False,
+        "reason": "crawl4ai_unavailable",
+        "source": "https://example.test",
+        "suggest": "pip install crawl4ai + playwright install chromium, or fall back to fetch-jina",
+    }
+
+
+def test_runtime_error_returns_structured_error() -> None:
+    response = FETCH_CRAWL4AI.fetch(
+        "https://example.test",
+        crawl4ai_module=_crawl4ai_module(arun_error=RuntimeError("browser crashed")),
+    )
+
+    assert response["ok"] is False
+    assert response["reason"] == "crawl4ai_runtime_error"
+    assert response["source"] == "https://example.test"
+    assert response["message"] == "browser crashed"
+    assert response["meta"]["backend"] == "crawl4ai"
+
+
+def test_empty_markdown_returns_empty_content_error() -> None:
+    result = SimpleNamespace(
+        success=True,
+        markdown=SimpleNamespace(raw_markdown="short"),
+        url="https://example.test",
+        status_code=200,
+        metadata={},
+    )
+
+    response = FETCH_CRAWL4AI.fetch(
+        "https://example.test",
+        crawl4ai_module=_crawl4ai_module(result),
+    )
+
+    assert response["ok"] is False
+    assert response["reason"] == "empty_content"
+    assert response["source"] == "https://example.test"
+    assert response["status_code"] == 200
+
+
+def test_wait_for_selector_is_passed_to_crawler_config() -> None:
+    captured: dict[str, object] = {}
+    result = SimpleNamespace(
+        success=True,
+        markdown="Title: Dashboard\n\nLoaded dynamic content.",
+        url="https://example.test/dashboard",
+        status_code=200,
+        metadata={},
+    )
+    crawl4ai = _crawl4ai_module(result, captured=captured)
+
+    response = FETCH_CRAWL4AI.fetch(
+        "https://example.test/dashboard",
+        wait_for=".dashboard-ready",
+        timeout_seconds=12.5,
+        crawl4ai_module=crawl4ai,
+    )
+
+    assert response["ok"] is True
+    assert captured["url"] == "https://example.test/dashboard"
+    assert isinstance(captured["browser_config"], FakeBrowserConfig)
+    assert captured["browser_config"].headless is True
+    assert isinstance(captured["run_config"], FakeCrawlerRunConfig)
+    assert captured["run_config"].cache_mode == crawl4ai.CacheMode.BYPASS
+    assert captured["run_config"].wait_for == ".dashboard-ready"
+    assert captured["run_config"].page_timeout == 12500
+
+
+def test_anti_bot_blocked_returns_degradation_hint() -> None:
+    result = SimpleNamespace(
+        success=False,
+        markdown="Access denied",
+        html="<html><body>Verify you are human</body></html>",
+        url="https://blocked.example",
+        status_code=403,
+        error_message="Blocked by anti-bot protection",
+        metadata={},
+    )
+
+    response = FETCH_CRAWL4AI.fetch(
+        "https://blocked.example",
+        crawl4ai_module=_crawl4ai_module(result),
+    )
+
+    assert response["ok"] is False
+    assert response["reason"] == "anti_bot_blocked"
+    assert response["suggest"] == "try fetch-playwright or fetch-firecrawl paid fallback"
+    assert response["status_code"] == 403


### PR DESCRIPTION
## Summary

v2 fetch layer PR 6. `crawl4ai`-backed deep URL fetch for JS-rendered pages, anti-bot sites, and dynamic content. Use when `fetch-jina` fails on pages that require a real browser.

- Path: `autosearch/skills/tools/fetch-crawl4ai/`
- Backend: `crawl4ai` Python package (Playwright Chromium)
- Opt-in: user installs separately (`pip install crawl4ai` + `playwright install chromium`); not a default dep to keep core lightweight
- Frontmatter: `auth_required: false`, `cost: free`, `model_tier: Standard`, `domains: [web-fetch]`
- Downgrade chain: fetch-jina (cheapest) → fetch-crawl4ai (depth + JS) → fetch-playwright (interactive) → fetch-firecrawl (paid)

## Test plan

- [x] ruff check + format ✓
- [x] pytest 6/6 passed in 0.03s (success / unavailable / runtime error / empty content / wait_for propagation)
- [ ] CI: three-commit + changelog + no-issue-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional web fetching skill that handles JavaScript-rendered, anti-bot-protected, and dynamic content as a fallback when other fetchers encounter issues. Requires separate installation of additional dependencies.

* **Documentation**
  * Added changelog entry and comprehensive documentation for the new fetching capability, including usage notes and limitations.

* **Tests**
  * Added test coverage for the new fetching functionality across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->