### PR TITLE
docs(skill): fetch-playwright routing skill (upstream @playwright/mcp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `video-to-text-openai` skill: yt-dlp + OpenAI Whisper API transcription (paid, ~$0.006/min). Second of the v2 transcription trio; paid fallback when Groq is rate-limited. Same output shape as `video-to-text-groq`.
 - `video-to-text-local` skill: yt-dlp + local `mlx-whisper` transcription (Apple Silicon, offline, free). Third of the v2 transcription trio; opt-in advanced path for M-series Macs with mlx-whisper installed. Default model `mlx-community/whisper-large-v3-turbo`, overridable via `AUTOSEARCH_MLX_WHISPER_MODEL`.
 - `fetch-crawl4ai` skill: deep URL fetch via `crawl4ai` (Playwright-backed) for JS-rendered pages, anti-bot sites, and dynamic content. Slower than `fetch-jina` but handles pages that block simple fetchers. Opt-in (user installs `crawl4ai` + `playwright install chromium` separately; not a default autosearch dep to keep the core lightweight).
+- `fetch-playwright` skill: documentation-only skill routing the runtime AI to Microsoft's official `@playwright/mcp` server for interactive browser automation (click, type, wait, screenshot, navigate). No autosearch-side Python; the runtime AI calls the MCP tools directly. Install via one MCP-client config block, no API key.
 
 ### Changed
 

--- a/autosearch/skills/tools/fetch-playwright/SKILL.md
+++ b/autosearch/skills/tools/fetch-playwright/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: fetch-playwright
+description: Interactive browser automation (click, type, wait, screenshot, navigate) for dynamic pages that need user-like actions — pagination, login, form submission, infinite scroll. Uses Microsoft's official @playwright/mcp server; no autosearch-side Python. Use when fetch-jina and fetch-crawl4ai still cannot get the content.
+version: 0.1.0
+layer: leaf
+domains: [web-fetch, browser-automation]
+scenarios: [interactive-page, login-required, pagination, click-to-reveal, screenshot-capture]
+trigger_keywords: [playwright, 浏览器自动化, 点击, 登录, 分页, 截图, interactive fetch]
+model_tier: Standard
+auth_required: false
+cost: free
+experience_digest: experience.md
+---
+
+Drive a real Chromium browser from the runtime AI via Microsoft's official `@playwright/mcp` server. Use this when `fetch-jina` (cheapest) and `fetch-crawl4ai` (depth + basic JS) still cannot reach the content — typically because the page requires clicking, typing, scrolling, waiting for an event, or capturing a screenshot.
+
+## Architecture (why there is no Python file in this skill)
+
+This skill is **documentation-only**. The runtime AI calls `playwright-mcp` tools directly through its MCP client — autosearch does not wrap them. The skill exists so the runtime AI knows:
+
+1. When to reach for Playwright (vs. fetch-jina / fetch-crawl4ai).
+2. How to install `@playwright/mcp`.
+3. Which MCP tools to call for common web-research patterns.
+
+## Install
+
+Add to your MCP client config (Claude Code: `~/.claude/settings.json` or project `.mcp.json`; Cursor: `~/.cursor/mcp.json`; Zed: project `.zed/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+On first run, `npx` will download `@playwright/mcp` and Playwright will install a Chromium bundle. No API keys. Works offline for local pages.
+
+## Common Tool Calls (as used by the runtime AI)
+
+Tool names below come from `@playwright/mcp`. Exact schemas are served by the MCP server itself; the runtime AI enumerates them via the MCP client.
+
+- `browser_navigate(url)` — go to a URL.
+- `browser_snapshot()` — accessibility tree of the current page (cheap text form, no screenshot).
+- `browser_click(ref)` / `browser_type(ref, text)` / `browser_press_key(key)` — interact with elements from the snapshot.
+- `browser_wait_for(text | time | element)` — wait for an event or selector.
+- `browser_take_screenshot()` — capture the current page as an image.
+- `browser_evaluate(script)` — run custom JS (use sparingly).
+- `browser_network_requests()` / `browser_console_messages()` — inspection.
+- `browser_tabs(...)` — open, list, select, close tabs.
+- `browser_close()` — release the browser.
+
+## When to Use
+
+- Page requires clicking a "Show more" / "Accept cookies" before content renders.
+- Login-gated content where the user has supplied a session (via storage state).
+- Infinite-scroll feed where lazy-load fires on scroll.
+- Verifying a production flow where screenshots are the deliverable.
+- Debugging network / console errors on a third-party page.
+
+## When NOT to Use
+
+- Static article, documentation, blog post → `fetch-jina` is cheaper.
+- Lightly JS-rendered page that works with plain crawl → `fetch-crawl4ai`.
+- Paid, hardened anti-bot site → `fetch-firecrawl` (paid) may still succeed where an ordinary Chromium cannot.
+
+## Limits
+
+- `@playwright/mcp` requires Node.js >= 18 and writes a Playwright browser bundle to the user's cache on first run (~200 MB).
+- Long sessions consume memory; the runtime AI should call `browser_close()` when a task ends.
+- Headful mode requires a desktop; CI / headless servers must use the default headless mode.
+- Cookie / profile / storage state setup is the caller's responsibility (see `@playwright/mcp` docs for `storageState`).
+
+## Downgrade / Upgrade Chain
+
+- Below: `fetch-crawl4ai` (Playwright, same browser engine but no interactive control) → `fetch-jina` (HTTP Markdown only).
+- Above: `fetch-firecrawl` (paid, stronger anti-bot and managed infra).
+
+This tool does **not** produce a summary. The runtime AI processes the tool outputs directly; autosearch provides only the routing guidance in this SKILL.md.

--- a/autosearch/skills/tools/fetch-playwright/__init__.py
+++ b/autosearch/skills/tools/fetch-playwright/__init__.py
@@ -1,0 +1,6 @@
+"""fetch-playwright skill package marker.
+
+This skill is documentation-only: it instructs the runtime AI how to install
+and use the upstream @playwright/mcp server. No local Python implementation —
+the runtime AI calls the MCP tools directly through its MCP client.
+"""


### PR DESCRIPTION
## Summary

v2 fetch layer PR 7. Documentation-only skill that routes runtime AI to Microsoft's official `@playwright/mcp` server for interactive browser automation. No autosearch Python — the runtime AI invokes the MCP tools directly through its MCP client.

- Path: `autosearch/skills/tools/fetch-playwright/SKILL.md` + `__init__.py` (explains the no-Python architecture)
- Install instructions for Claude Code / Cursor / Zed MCP clients
- Tool-call catalog (navigate / snapshot / click / type / wait / screenshot / evaluate)
- When to reach for Playwright vs. fetch-jina / fetch-crawl4ai / fetch-firecrawl

## Test plan

- [x] ruff check + format ✓
- No pytest needed (no Python logic; docs-only skill)
- CI: docs prefix exempts three-commit-required
- [ ] CI: changelog-required ✓
- [ ] CI: PR closes issue check → `no-issue-link` label

## Commits

- `docs(skill)`: add fetch-playwright routing skill
- `docs(changelog)`: record addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)