### PR TITLE
fix(hook): scan CLAUDE.md for PII — remove blanket file exclusion

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -23,7 +23,7 @@ if [ "$AUTHOR_NAME" != "0xmariowu" ]; then
 fi
 
 # Content scan on staged files — codenames, personal paths, hostnames
-SCAN_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.gitleaks\.toml$|\.example$|\.husky/|^CLAUDE\.md$|\.github/workflows/)' || true)
+SCAN_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.gitleaks\.toml$|\.example$|\.husky/|\.github/workflows/)' || true)
 if [ -n "$SCAN_FILES" ]; then
   # Internal project codenames
   CN_MATCHES=$(echo "$SCAN_FILES" | while IFS= read -r f; do grep -nEH '\b(Armory|AIMD|atoms|kalami2?|alaya[_-]os)\b' "$f" 2>/dev/null; done || true)
@@ -32,8 +32,8 @@ if [ -n "$SCAN_FILES" ]; then
     echo "$CN_MATCHES"
     exit 1
   fi
-  # Personal paths and hostnames
-  PII_MATCHES=$(echo "$SCAN_FILES" | while IFS= read -r f; do grep -nEH '/Users/[a-zA-Z]|/home/[a-z]|\.ts\.net|tailcca|vimalamac' "$f" 2>/dev/null; done || true)
+  # Personal paths and hostnames (placeholder patterns like /Users/xxx are whitelisted)
+  PII_MATCHES=$(echo "$SCAN_FILES" | while IFS= read -r f; do grep -nEH '/Users/[a-zA-Z]|/home/[a-z]|\.ts\.net|tailcca|vimalamac' "$f" 2>/dev/null; done | grep -vE '/Users/(xxx|yourusername|example|your-username)' || true)
   if [ -n "$PII_MATCHES" ]; then
     echo "error: personal paths or hostnames in staged files:"
     echo "$PII_MATCHES"


### PR DESCRIPTION
## What

Remove `^CLAUDE\.md$` from the pre-commit hook file exclusion list. CLAUDE.md is now scanned for PII and codenames like any other staged file.

Add a match-level whitelist for placeholder patterns (`/Users/xxx`, `/Users/yourusername`, etc.) to avoid false positives from example paths.

## Why

The exclusion was the root cause of a known incident: AI wrote real absolute paths and internal project names into CLAUDE.md, and the hook couldn't catch it because the file was excluded before the scan ran.

CI `hygiene.yml` had the same exclusion — that workflow is being removed as part of the CI cleanup (hooks are the right enforcement layer, not CI).

## Test

```bash
# Should be caught:
echo "/Users/vimala/lazie" > test-pii.md
git add test-pii.md
# → hook fires: "error: personal paths or hostnames in staged files"

# Should pass:
echo "/Users/xxx/lazie" > test-ok.md
git add test-ok.md
# → hook passes (placeholder whitelisted)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development tooling configuration to refine validation checks during the development process.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->