### PR TITLE
fix(security): replace pull_request_target with pull_request

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Labeler
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 permissions:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,7 +1,7 @@
 name: PR Lint
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- Replace `pull_request_target` with `pull_request` in `labeler.yml` and `pr-lint.yml`
- These workflows only read PR metadata (title, labels) and never checkout user code — `pull_request` is sufficient and eliminates the security risk of running with repo write permissions on fork PRs

## Security
`pull_request_target` triggers with full repo permissions even for fork PRs. Without careful isolation, a malicious PR could access secrets. Using `pull_request` removes this risk entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request workflow configurations for the labeler and linting processes to optimize continuous integration execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->