### PR TITLE
fix(ci): add --repo flag to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+      - run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${{ github.event.pull_request.number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
gh pr merge needs --repo when not in a git checkout context. Fixes the 'not a git repository' error.