### PR TITLE
fix(ci): move release.yml permissions to job level

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,14 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
## Summary
- Top-level `permissions: contents: write` granted write access to all jobs in the workflow.
- Changed to `permissions: {}` at workflow level (deny-all) and added `permissions: contents: write` at the `release` job level only.
- Only the job that creates the GitHub Release needs elevated permissions; all other jobs now run with no token permissions.

## Test plan
- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Verify a tag push triggers the release job and it can still create a GitHub Release
- [ ] Verify no other jobs/steps are broken by the permission scoping

Audit 2026-04-22.