### PR TITLE
feat(f009-f010): doctor MCP tool, configure CLI, 5 workflow skill tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.22.2"
+  "version": "2026.04.22.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.22.2",
+  "version": "2026.04.22.3",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.04.22.3 — 2026-04-22
+
+- You can now run `autosearch doctor` (via MCP) to scan all channel health — shows which channels are ready, missing API keys, or unavailable.
+- You can now run `autosearch configure KEY value` CLI to safely append API keys to `~/.config/ai-secrets.env` with TTY confirmation.
+- New MCP workflow tools: `trace_harvest` (extract winning query patterns), `perspective_questioning` (multi-viewpoint sub-questions), `graph_search_plan` (parallel DAG batching), `recent_signal_fusion` (recency filter), `context_retention_policy` (token-budget trim).
+
+
 ## 2026.04.22.2 — 2026-04-22
 
 - `autosearch query` CLI now exits immediately with a v2 deprecation notice directing you to `list_skills / run_clarify / run_channel` MCP tools.

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -274,6 +274,46 @@ def _channel_status_symbol(row: ChannelStatus) -> str:
 
 
 @app.command()
+def configure(
+    key: Annotated[str, typer.Argument(help="Environment variable name, e.g. OPENAI_API_KEY.")],
+    value: Annotated[str, typer.Argument(help="Value to store.")],
+) -> None:
+    """Write a key=value pair to ~/.config/ai-secrets.env (append-only, TTY required)."""
+    import shlex
+    from pathlib import Path
+
+    if not _is_tty():
+        typer.echo("error: configure requires an interactive TTY", err=True)
+        raise typer.Exit(code=1)
+
+    secrets_path = Path.home() / ".config" / "ai-secrets.env"
+
+    existing_keys: set[str] = set()
+    if secrets_path.exists():
+        for line in secrets_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and "=" in stripped:
+                existing_keys.add(stripped.split("=", 1)[0].strip())
+
+    if key in existing_keys:
+        typer.echo(f"{key} already exists in {secrets_path}. Edit the file manually to change it.")
+        raise typer.Exit(code=0)
+
+    typer.echo(f"Will append to {secrets_path}:")
+    typer.echo(f"  {key}=***")
+    confirmed = typer.confirm("Confirm?", default=False)
+    if not confirmed:
+        typer.echo("Aborted.")
+        raise typer.Exit(code=0)
+
+    secrets_path.parent.mkdir(parents=True, exist_ok=True)
+    with secrets_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"\n{key}={shlex.quote(value)}\n")
+
+    typer.echo(f"Written: {key} -> {secrets_path}")
+
+
+@app.command()
 def serve(
     host: Annotated[
         str,
@@ -327,6 +367,10 @@ def _is_authentication_error(error: Exception) -> bool:
             "invalid x-api-key",
         )
     )
+
+
+def _is_tty() -> bool:
+    return sys.stdin.isatty()
 
 
 def _exit_query_failure(message: str, *, exit_code: int, json_output: bool) -> None:

--- a/autosearch/core/context_retention_policy.py
+++ b/autosearch/core/context_retention_policy.py
@@ -1,0 +1,36 @@
+"""Context-retention-policy: trim evidence list to a token budget."""
+
+from __future__ import annotations
+
+
+def trim_to_budget(
+    evidence_list: list[dict],
+    token_budget: int,
+    *,
+    score_key: str = "score",
+) -> list[dict]:
+    """Return evidence items that fit within token_budget, highest score first.
+
+    Token estimation: len(str(item)) // 4 (rough approximation).
+    Items are sorted by score descending before trimming, so the most
+    relevant items are kept. Items with no score field are treated as 0.
+    """
+    if token_budget <= 0:
+        return []
+
+    scored = sorted(
+        evidence_list,
+        key=lambda item: float(item.get(score_key) or 0),
+        reverse=True,
+    )
+
+    kept: list[dict] = []
+    used = 0
+    for item in scored:
+        cost = max(1, len(str(item)) // 4)
+        if used + cost > token_budget:
+            break
+        kept.append(item)
+        used += cost
+
+    return kept

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -1,0 +1,93 @@
+"""Channel health scanner for autosearch doctor() MCP tool."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from autosearch.skills import SkillLoadError, load_all
+
+
+@dataclass
+class ChannelStatus:
+    channel: str
+    status: str  # "ok" | "warn" | "off"
+    message: str
+    unmet_requires: list[str]
+
+
+def scan_channels(channels_root: Path | None = None) -> list[ChannelStatus]:
+    """Scan all channel skills and return health status for each.
+
+    status:
+      ok   — all methods have their requires satisfied
+      warn — at least one method available, some unmet
+      off  — no methods available (all requires unmet or no methods)
+    """
+    root = channels_root or _default_channels_root()
+    if not root.is_dir():
+        return []
+
+    try:
+        specs = load_all(root)
+    except SkillLoadError:
+        return []
+
+    env_keys = _current_env_keys()
+    results: list[ChannelStatus] = []
+
+    for spec in sorted(specs, key=lambda s: s.name):
+        all_unmet: list[str] = []
+        available_methods = 0
+        for method in spec.methods:
+            unmet = [token for token in method.requires if not _token_satisfied(token, env_keys)]
+            if not unmet:
+                available_methods += 1
+            else:
+                all_unmet.extend(unmet)
+
+        if not spec.methods:
+            status = "off"
+            message = "no methods defined"
+        elif available_methods == len(spec.methods):
+            status = "ok"
+            message = f"{available_methods}/{len(spec.methods)} methods available"
+        elif available_methods > 0:
+            status = "warn"
+            unique_unmet = list(dict.fromkeys(all_unmet))
+            message = (
+                f"{available_methods}/{len(spec.methods)} methods available; "
+                f"unmet: {', '.join(unique_unmet)}"
+            )
+        else:
+            status = "off"
+            unique_unmet = list(dict.fromkeys(all_unmet))
+            message = f"no methods available; unmet: {', '.join(unique_unmet)}"
+
+        results.append(
+            ChannelStatus(
+                channel=spec.name,
+                status=status,
+                message=message,
+                unmet_requires=list(dict.fromkeys(all_unmet)),
+            )
+        )
+
+    return results
+
+
+def _token_satisfied(token: str, env_keys: set[str]) -> bool:
+    kind, value = token.split(":", maxsplit=1)
+    if kind == "env":
+        return value in env_keys
+    # cookie / mcp / binary: not checked here (env is the common case)
+    return False
+
+
+def _current_env_keys() -> set[str]:
+    return {key for key, val in os.environ.items() if val}
+
+
+def _default_channels_root() -> Path:
+    return Path(__file__).resolve().parent.parent / "skills" / "channels"

--- a/autosearch/core/graph_search_plan.py
+++ b/autosearch/core/graph_search_plan.py
@@ -1,0 +1,66 @@
+"""Graph-search-plan: represent a research plan as a DAG and return parallel batches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SubTask:
+    id: str
+    description: str
+    depends_on: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SearchGraph:
+    nodes: list[SubTask] = field(default_factory=list)
+
+    def node_ids(self) -> set[str]:
+        return {node.id for node in self.nodes}
+
+
+def get_parallel_batches(graph: SearchGraph) -> list[list[str]]:
+    """Topological sort returning groups of node IDs that can run in parallel.
+
+    Each batch contains nodes whose dependencies are all satisfied by
+    previous batches. Nodes with no dependencies are in the first batch.
+
+    Raises ValueError for unknown dependency references or cycles.
+    """
+    node_ids = graph.node_ids()
+    deps: dict[str, set[str]] = {}
+    for node in graph.nodes:
+        unknown = [d for d in node.depends_on if d not in node_ids]
+        if unknown:
+            raise ValueError(f"node '{node.id}' depends on unknown nodes: {unknown}")
+        deps[node.id] = set(node.depends_on)
+
+    batches: list[list[str]] = []
+    completed: set[str] = set()
+
+    remaining = dict(deps)
+    while remaining:
+        ready = [nid for nid, d in remaining.items() if d <= completed]
+        if not ready:
+            raise ValueError(f"cycle detected among nodes: {list(remaining.keys())}")
+        batch = sorted(ready)
+        batches.append(batch)
+        completed.update(batch)
+        for nid in batch:
+            del remaining[nid]
+
+    return batches
+
+
+def graph_from_dicts(subtasks: list[dict]) -> SearchGraph:
+    """Build a SearchGraph from a list of dicts with keys: id, description, depends_on."""
+    nodes = [
+        SubTask(
+            id=str(item["id"]),
+            description=str(item.get("description") or ""),
+            depends_on=[str(d) for d in (item.get("depends_on") or [])],
+        )
+        for item in subtasks
+    ]
+    return SearchGraph(nodes=nodes)

--- a/autosearch/core/perspective_questioning.py
+++ b/autosearch/core/perspective_questioning.py
@@ -1,0 +1,41 @@
+"""Perspective-questioning: generate multi-viewpoint sub-questions for a topic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_VIEWPOINTS = ["user", "expert", "critic", "competitor"]
+
+_TEMPLATES: dict[str, str] = {
+    "user": "From a practitioner's perspective: what practical problems does {topic} solve, and where does it fall short?",
+    "expert": "From a domain expert's perspective: what are the key technical constraints or nuances of {topic} that non-experts miss?",
+    "critic": "From a skeptic's perspective: what are the strongest objections to {topic}, and where is the evidence weakest?",
+    "competitor": "From a competitor's perspective: how does {topic} compare to alternatives, and where do alternatives win?",
+}
+
+
+@dataclass
+class SubQuestion:
+    viewpoint: str
+    question: str
+
+
+def generate_perspectives(topic: str, n: int = 4) -> list[SubQuestion]:
+    """Generate n sub-questions covering different viewpoints on a topic.
+
+    n is clamped to [1, len(_VIEWPOINTS)]. Viewpoints are always selected
+    in the order: user → expert → critic → competitor.
+    """
+    if not topic or not topic.strip():
+        return []
+
+    n = max(1, min(n, len(_VIEWPOINTS)))
+    selected = _VIEWPOINTS[:n]
+
+    return [
+        SubQuestion(
+            viewpoint=viewpoint,
+            question=_TEMPLATES[viewpoint].format(topic=topic.strip()),
+        )
+        for viewpoint in selected
+    ]

--- a/autosearch/core/recent_signal_fusion.py
+++ b/autosearch/core/recent_signal_fusion.py
@@ -1,0 +1,75 @@
+"""Recent-signal-fusion: filter and sort evidence by recency."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+
+def filter_recent(
+    evidence_list: list[dict],
+    days: int = 30,
+    *,
+    date_keys: tuple[str, ...] = ("date", "published_at", "created_at", "ts", "timestamp"),
+) -> list[dict]:
+    """Return evidence items published within the last `days` days, newest first.
+
+    Tries each key in date_keys to find a parseable date. Items with no
+    parseable date are excluded from results.
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    dated: list[tuple[datetime, dict]] = []
+
+    for item in evidence_list:
+        dt = _parse_date(item, date_keys)
+        if dt is not None and dt >= cutoff:
+            dated.append((dt, item))
+
+    dated.sort(key=lambda pair: pair[0], reverse=True)
+    return [item for _, item in dated]
+
+
+def _parse_date(item: dict, date_keys: tuple[str, ...]) -> datetime | None:
+    for key in date_keys:
+        raw = item.get(key)
+        if not raw:
+            continue
+        dt = _try_parse(str(raw))
+        if dt is not None:
+            return dt
+    return None
+
+
+def _try_parse(raw: str) -> datetime | None:
+    from datetime import timezone
+
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    # ISO 8601 with Z suffix
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+
+    formats = [
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S.%f%z",
+        "%Y-%m-%d %H:%M:%S%z",
+        "%Y-%m-%d",
+    ]
+    for fmt in formats:
+        try:
+            dt = datetime.strptime(raw, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            continue
+
+    # Unix timestamp (int or float string)
+    try:
+        ts = float(raw)
+        return datetime.fromtimestamp(ts, tz=UTC)
+    except (ValueError, OSError):
+        pass
+
+    return None

--- a/autosearch/core/trace_harvest.py
+++ b/autosearch/core/trace_harvest.py
@@ -1,0 +1,78 @@
+"""Trace-harvest: extract winning query patterns from run_channel traces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Pattern:
+    query: str
+    channel: str
+    score: float  # 0.0–1.0 based on count_returned / count_total
+
+
+def extract_winning_patterns(
+    trace: dict,
+    *,
+    min_score: float = 0.5,
+) -> list[Pattern]:
+    """Extract high-scoring query patterns from a run_channel trace dict.
+
+    trace format (subset of RunChannelResponse fields):
+      {channel, query, count_returned, count_total, outcome}
+
+    Returns patterns with score >= min_score.
+    """
+    channel = str(trace.get("channel") or "")
+    query = str(trace.get("query") or "")
+    outcome = str(trace.get("outcome") or "")
+    count_returned = int(trace.get("count_returned") or 0)
+    count_total = int(trace.get("count_total") or 0)
+
+    if not channel or not query or outcome == "error":
+        return []
+
+    score = (count_returned / count_total) if count_total > 0 else 0.0
+    if score < min_score:
+        return []
+
+    return [Pattern(query=query, channel=channel, score=score)]
+
+
+def harvest_to_patterns_jsonl(
+    traces: list[dict],
+    channel_name: str,
+    *,
+    min_score: float = 0.5,
+    patterns_file: Path | None = None,
+) -> list[Pattern]:
+    """Extract winning patterns from a list of traces and append to patterns.jsonl.
+
+    Returns the list of patterns that passed the score threshold.
+    """
+    import json
+    from datetime import UTC, datetime
+
+    winners: list[Pattern] = []
+    for trace in traces:
+        winners.extend(extract_winning_patterns(trace, min_score=min_score))
+
+    if winners and patterns_file is not None:
+        patterns_file.parent.mkdir(parents=True, exist_ok=True)
+        with patterns_file.open("a", encoding="utf-8") as fh:
+            for pattern in winners:
+                fh.write(
+                    json.dumps(
+                        {
+                            "query": pattern.query,
+                            "channel": pattern.channel,
+                            "score": pattern.score,
+                            "ts": datetime.now(UTC).isoformat(),
+                        }
+                    )
+                    + "\n"
+                )
+
+    return winners

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -660,6 +660,109 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             "budget_used": result.budget_used,
         }
 
+    # F009: channel health scanner
+    @server.tool()
+    def doctor() -> list[dict]:
+        """Scan all configured channels and return their health status.
+
+        Returns a list of {channel, status, message, unmet_requires} dicts.
+        status: "ok" (all methods available), "warn" (partial), "off" (none available).
+        Use this to diagnose which channels are missing API keys or credentials.
+        """
+        from autosearch.core.doctor import scan_channels  # noqa: PLC0415
+
+        return [
+            {
+                "channel": s.channel,
+                "status": s.status,
+                "message": s.message,
+                "unmet_requires": s.unmet_requires,
+            }
+            for s in scan_channels()
+        ]
+
+    # F010: workflow skills
+    @server.tool()
+    def trace_harvest(
+        channel: str,
+        query: str,
+        count_returned: int = 0,
+        count_total: int = 0,
+        outcome: str = "success",
+    ) -> list[dict]:
+        """Extract winning query patterns from a run_channel trace.
+
+        Pass the channel name, query, and result counts from a run_channel call.
+        Returns a list of {query, channel, score} pattern dicts (empty if score < 0.5).
+        Write results to the channel's patterns.jsonl to accumulate learning.
+        """
+        from autosearch.core.trace_harvest import extract_winning_patterns  # noqa: PLC0415
+
+        trace = {
+            "channel": channel,
+            "query": query,
+            "count_returned": count_returned,
+            "count_total": count_total,
+            "outcome": outcome,
+        }
+        patterns = extract_winning_patterns(trace)
+        return [{"query": p.query, "channel": p.channel, "score": p.score} for p in patterns]
+
+    @server.tool()
+    def perspective_questioning(topic: str, n: int = 4) -> list[dict]:
+        """Generate n sub-questions covering different viewpoints on a topic.
+
+        Viewpoints: user (practitioner), expert (domain), critic (skeptic),
+        competitor (alternatives). n is clamped to [1, 4].
+        Returns list of {viewpoint, question} dicts.
+        """
+        from autosearch.core.perspective_questioning import generate_perspectives  # noqa: PLC0415
+
+        subs = generate_perspectives(topic, n)
+        return [{"viewpoint": s.viewpoint, "question": s.question} for s in subs]
+
+    @server.tool()
+    def graph_search_plan(subtasks: list[dict]) -> list[list[str]]:
+        """Build a DAG from subtasks and return topologically sorted parallel batches.
+
+        Each subtask dict: {id, description, depends_on?: [id, ...]}.
+        Returns list of batches; subtasks in the same batch can run in parallel.
+        Raises on unknown dependency references or cycles.
+        """
+        from autosearch.core.graph_search_plan import SearchGraph, SubTask, get_parallel_batches  # noqa: PLC0415
+
+        nodes = [
+            SubTask(
+                id=str(t["id"]),
+                description=str(t.get("description") or ""),
+                depends_on=[str(d) for d in (t.get("depends_on") or [])],
+            )
+            for t in subtasks
+        ]
+        return get_parallel_batches(SearchGraph(nodes=nodes))
+
+    @server.tool()
+    def recent_signal_fusion(evidence: list[dict], days: int = 30) -> list[dict]:
+        """Filter evidence to items published within the last `days` days, newest first.
+
+        Looks for date in keys: date, published_at, created_at, ts, timestamp.
+        Items with no parseable date are excluded.
+        """
+        from autosearch.core.recent_signal_fusion import filter_recent  # noqa: PLC0415
+
+        return filter_recent(evidence, days)
+
+    @server.tool()
+    def context_retention_policy(evidence: list[dict], token_budget: int) -> list[dict]:
+        """Trim evidence list to fit within token_budget, keeping highest-scored items.
+
+        Token estimate: len(str(item)) // 4 per item.
+        Items sorted by 'score' field descending before trimming.
+        """
+        from autosearch.core.context_retention_policy import trim_to_budget  # noqa: PLC0415
+
+        return trim_to_budget(evidence, token_budget)
+
     return server
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.22.2"
+version = "2026.04.22.3"
 description = "AutoSearch v2 M1 skeleton"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/test_configure_cli.py
+++ b/tests/unit/test_configure_cli.py
@@ -1,0 +1,71 @@
+"""Tests for autosearch configure CLI subcommand."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from autosearch.cli.main import app
+
+runner = CliRunner()
+
+
+def test_configure_non_tty_rejected():
+    result = runner.invoke(app, ["configure", "MY_KEY", "myvalue"])
+    assert result.exit_code == 1
+    assert "TTY" in result.output
+
+
+def _tty_mock():
+    """Return a mock stdin that reports as TTY."""
+    from unittest.mock import MagicMock
+
+    m = MagicMock()
+    m.isatty.return_value = True
+    return m
+
+
+def test_configure_writes_new_key(tmp_path):
+    secrets = tmp_path / ".config" / "ai-secrets.env"
+
+    with (
+        patch("autosearch.cli.main._is_tty", return_value=True),
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("typer.confirm", return_value=True),
+    ):
+        result = runner.invoke(app, ["configure", "NEW_KEY", "abc123"])
+
+    assert result.exit_code == 0
+    content = secrets.read_text()
+    assert "NEW_KEY=" in content
+
+
+def test_configure_skips_existing_key(tmp_path):
+    secrets = tmp_path / ".config" / "ai-secrets.env"
+    secrets.parent.mkdir(parents=True)
+    secrets.write_text("EXISTING_KEY=old\n")
+
+    with (
+        patch("autosearch.cli.main._is_tty", return_value=True),
+        patch("pathlib.Path.home", return_value=tmp_path),
+    ):
+        result = runner.invoke(app, ["configure", "EXISTING_KEY", "newval"])
+
+    assert result.exit_code == 0
+    assert "already exists" in result.output
+    assert "old" in secrets.read_text()
+
+
+def test_configure_aborted_on_no_confirm(tmp_path):
+    with (
+        patch("autosearch.cli.main._is_tty", return_value=True),
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("typer.confirm", return_value=False),
+    ):
+        result = runner.invoke(app, ["configure", "NEW_KEY", "val"])
+
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    secrets = tmp_path / ".config" / "ai-secrets.env"
+    assert not secrets.exists()

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,0 +1,74 @@
+"""Tests for autosearch.core.doctor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+from autosearch.core.doctor import scan_channels
+
+
+def _make_spec(name: str, requires: list[str]):
+    """Build a minimal SkillSpec-like object for mocking."""
+    from autosearch.skills.loader import MethodSpec, SkillSpec
+
+    method = MethodSpec(id="api_search", impl="methods/api_search.py", requires=requires)
+    return SkillSpec(
+        name=name,
+        description="test",
+        methods=[method],
+        skill_dir=Path(f"/fake/skills/channels/{name}"),
+    )
+
+
+def test_scan_channels_ok_when_all_env_set(tmp_path):
+    specs = [_make_spec("mychann", ["env:MY_API_KEY"])]
+    with (
+        patch("autosearch.core.doctor.load_all", return_value=specs),
+        patch("autosearch.core.doctor._current_env_keys", return_value={"MY_API_KEY"}),
+    ):
+        results = scan_channels(tmp_path)
+
+    assert len(results) == 1
+    assert results[0].channel == "mychann"
+    assert results[0].status == "ok"
+    assert results[0].unmet_requires == []
+
+
+def test_scan_channels_off_when_no_env(tmp_path):
+    specs = [_make_spec("mychann", ["env:MISSING_KEY"])]
+    with (
+        patch("autosearch.core.doctor.load_all", return_value=specs),
+        patch("autosearch.core.doctor._current_env_keys", return_value=set()),
+    ):
+        results = scan_channels(tmp_path)
+
+    assert results[0].status == "off"
+    assert "env:MISSING_KEY" in results[0].unmet_requires
+
+
+def test_scan_channels_warn_when_partial(tmp_path):
+    from autosearch.skills.loader import MethodSpec, SkillSpec
+
+    m1 = MethodSpec(id="free", impl="methods/free.py", requires=[])
+    m2 = MethodSpec(id="paid", impl="methods/paid.py", requires=["env:PAID_KEY"])
+    spec = SkillSpec(
+        name="hybrid",
+        description="test",
+        methods=[m1, m2],
+        skill_dir=Path("/fake/skills/channels/hybrid"),
+    )
+    with (
+        patch("autosearch.core.doctor.load_all", return_value=[spec]),
+        patch("autosearch.core.doctor._current_env_keys", return_value=set()),
+    ):
+        results = scan_channels(tmp_path)
+
+    assert results[0].status == "warn"
+    assert "env:PAID_KEY" in results[0].unmet_requires
+
+
+def test_scan_channels_empty_root(tmp_path):
+    results = scan_channels(tmp_path / "nonexistent")
+    assert results == []

--- a/tests/unit/test_workflow_skills.py
+++ b/tests/unit/test_workflow_skills.py
@@ -1,0 +1,207 @@
+"""Tests for F010 workflow skill core modules."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from autosearch.core.context_retention_policy import trim_to_budget
+from autosearch.core.graph_search_plan import SearchGraph, SubTask, get_parallel_batches
+from autosearch.core.perspective_questioning import SubQuestion, generate_perspectives
+from autosearch.core.recent_signal_fusion import filter_recent
+from autosearch.core.trace_harvest import extract_winning_patterns
+
+
+# --- trace_harvest ---
+
+
+def test_extract_winning_pattern_high_score():
+    trace = {
+        "channel": "arxiv",
+        "query": "LLM eval",
+        "count_returned": 8,
+        "count_total": 10,
+        "outcome": "success",
+    }
+    patterns = extract_winning_patterns(trace)
+    assert len(patterns) == 1
+    assert patterns[0].channel == "arxiv"
+    assert patterns[0].score == pytest.approx(0.8)
+
+
+def test_extract_winning_pattern_low_score_excluded():
+    trace = {
+        "channel": "arxiv",
+        "query": "LLM eval",
+        "count_returned": 2,
+        "count_total": 10,
+        "outcome": "success",
+    }
+    assert extract_winning_patterns(trace) == []
+
+
+def test_extract_winning_pattern_error_excluded():
+    trace = {
+        "channel": "arxiv",
+        "query": "LLM eval",
+        "count_returned": 10,
+        "count_total": 10,
+        "outcome": "error",
+    }
+    assert extract_winning_patterns(trace) == []
+
+
+def test_extract_winning_pattern_zero_total():
+    trace = {
+        "channel": "arxiv",
+        "query": "test",
+        "count_returned": 0,
+        "count_total": 0,
+        "outcome": "success",
+    }
+    assert extract_winning_patterns(trace) == []
+
+
+# --- perspective_questioning ---
+
+
+def test_generate_perspectives_default_n():
+    subs = generate_perspectives("AI coding tools")
+    assert len(subs) == 4
+    viewpoints = [s.viewpoint for s in subs]
+    assert viewpoints == ["user", "expert", "critic", "competitor"]
+
+
+def test_generate_perspectives_n_2():
+    subs = generate_perspectives("AI coding tools", n=2)
+    assert len(subs) == 2
+    assert subs[0].viewpoint == "user"
+    assert subs[1].viewpoint == "expert"
+
+
+def test_generate_perspectives_n_clamped():
+    subs = generate_perspectives("topic", n=99)
+    assert len(subs) == 4  # clamped to max viewpoints
+
+
+def test_generate_perspectives_empty_topic():
+    assert generate_perspectives("") == []
+
+
+def test_generate_perspectives_has_viewpoint_field():
+    subs = generate_perspectives("test", n=1)
+    assert isinstance(subs[0], SubQuestion)
+    assert subs[0].viewpoint == "user"
+    assert "test" in subs[0].question
+
+
+# --- graph_search_plan ---
+
+
+def test_get_parallel_batches_simple_chain():
+    nodes = [
+        SubTask(id="A", description="", depends_on=[]),
+        SubTask(id="B", description="", depends_on=["A"]),
+        SubTask(id="C", description="", depends_on=["B"]),
+    ]
+    batches = get_parallel_batches(SearchGraph(nodes=nodes))
+    assert batches == [["A"], ["B"], ["C"]]
+
+
+def test_get_parallel_batches_diamond():
+    # A → B, A → C, B+C → D
+    nodes = [
+        SubTask(id="A", description="", depends_on=[]),
+        SubTask(id="B", description="", depends_on=["A"]),
+        SubTask(id="C", description="", depends_on=["A"]),
+        SubTask(id="D", description="", depends_on=["B", "C"]),
+    ]
+    batches = get_parallel_batches(SearchGraph(nodes=nodes))
+    assert batches[0] == ["A"]
+    assert sorted(batches[1]) == ["B", "C"]
+    assert batches[2] == ["D"]
+
+
+def test_get_parallel_batches_no_deps():
+    nodes = [SubTask(id="A", description=""), SubTask(id="B", description="")]
+    batches = get_parallel_batches(SearchGraph(nodes=nodes))
+    assert len(batches) == 1
+    assert sorted(batches[0]) == ["A", "B"]
+
+
+def test_get_parallel_batches_cycle_raises():
+    nodes = [
+        SubTask(id="A", description="", depends_on=["B"]),
+        SubTask(id="B", description="", depends_on=["A"]),
+    ]
+    with pytest.raises(ValueError, match="cycle"):
+        get_parallel_batches(SearchGraph(nodes=nodes))
+
+
+def test_get_parallel_batches_unknown_dep_raises():
+    nodes = [SubTask(id="A", description="", depends_on=["UNKNOWN"])]
+    with pytest.raises(ValueError, match="unknown"):
+        get_parallel_batches(SearchGraph(nodes=nodes))
+
+
+# --- recent_signal_fusion ---
+
+
+def _item(days_ago: int, score: float = 1.0) -> dict:
+    dt = datetime.now(UTC) - timedelta(days=days_ago)
+    return {"title": f"item-{days_ago}d", "date": dt.isoformat(), "score": score}
+
+
+def test_filter_recent_keeps_new():
+    items = [_item(1), _item(5), _item(40)]
+    result = filter_recent(items, days=30)
+    assert len(result) == 2
+    assert all("40d" not in r["title"] for r in result)
+
+
+def test_filter_recent_sorted_newest_first():
+    items = [_item(10), _item(2), _item(7)]
+    result = filter_recent(items, days=30)
+    ages = [int(r["title"].split("-")[1].rstrip("d")) for r in result]
+    assert ages == sorted(ages)
+
+
+def test_filter_recent_excludes_no_date():
+    items = [{"title": "no-date", "score": 1.0}, _item(1)]
+    result = filter_recent(items, days=7)
+    assert len(result) == 1
+    assert result[0]["title"] == "item-1d"
+
+
+def test_filter_recent_empty():
+    assert filter_recent([], days=30) == []
+
+
+# --- context_retention_policy ---
+
+
+def test_trim_to_budget_keeps_high_score_first():
+    items = [
+        {"title": "low", "score": 0.1, "body": "x" * 100},
+        {"title": "high", "score": 0.9, "body": "x" * 100},
+    ]
+    # each item is ~35 tokens (len(str(item))//4); budget=40 fits one, not two
+    result = trim_to_budget(items, token_budget=40)
+    assert len(result) == 1
+    assert result[0]["title"] == "high"
+
+
+def test_trim_to_budget_zero_budget():
+    items = [{"title": "a", "score": 1.0}]
+    assert trim_to_budget(items, token_budget=0) == []
+
+
+def test_trim_to_budget_fits_all():
+    items = [{"title": "a", "score": 1.0}, {"title": "b", "score": 0.5}]
+    result = trim_to_budget(items, token_budget=10000)
+    assert len(result) == 2
+
+
+def test_trim_to_budget_empty():
+    assert trim_to_budget([], token_budget=1000) == []


### PR DESCRIPTION
## Summary

- **F009**: `doctor()` MCP tool scans all channel health (ok/warn/off) based on env keys; `autosearch configure KEY val` CLI appends to `~/.config/ai-secrets.env` with TTY confirmation
- **F010**: 5 new MCP workflow tools: `trace_harvest`, `perspective_questioning`, `graph_search_plan`, `recent_signal_fusion`, `context_retention_policy` — all backed by pure Python modules in `autosearch/core/`
- 30 new tests, 690 total passing

## Test plan

- [x] `pytest tests/unit/test_doctor.py` — 4 tests
- [x] `pytest tests/unit/test_workflow_skills.py` — 20 tests
- [x] `pytest tests/unit/test_configure_cli.py` — 4 tests (TTY mock via `_is_tty` helper)
- [x] Full suite `pytest -x -q --ignore=tests/perf` — 690 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `autosearch doctor` command to scan and report channel health, readiness status, and missing API keys.
  * Added `autosearch configure` command for secure API key management.
  * Added five new workflow tools: multi-perspective question generation, dependency graph execution planning, recency-based evidence filtering, execution trace pattern extraction, and token-budget-aware evidence optimization.

* **Chores**
  * Version bumped to 2026.04.22.3.
  * Updated changelog with new features.

* **Tests**
  * Added comprehensive test coverage for new CLI commands and workflow tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->