### PR TITLE
docs(claude): add local fast test command to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@
 
 A self-improving search system. The human provides intent. The AI does everything else: understand the goal, generate strategies, run them across all platforms, score results, reflect, iterate, and harvest.
 
+## Local test (run before push)
+
+```bash
+.venv/bin/python -m pytest tests/unit/ -x -q -m "not real_llm and not slow and not network"
+```
+
+Fast subset only (~4s). Full suite runs in CI.
+
 ## Session Checklist
 
 1. If working on AVO/skills → read § AVO rules below


### PR DESCRIPTION
## Summary

- Add **Local test** section to CLAUDE.md with the fast pytest command (~4s)
- AI and developers now have a documented equivalent of gstack's \`bun test\`

## Change Type

- [x] Docs

## Security Impact

- New permissions or capabilities added? No
- Secrets / tokens handling changed? No
- New network calls? No

## Test Plan

- [x] No tests needed because: docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)