### PR TITLE
refactor(outline): remove redundant normalize calls

### DIFF
--- a/autosearch/synthesis/outline.py
+++ b/autosearch/synthesis/outline.py
@@ -202,16 +202,14 @@ def _clone_outline_node(node: OutlineNode, *, level: int) -> OutlineNode:
 
 
 def _top_level_headings(outline: OutlineNode) -> list[str]:
-    normalized = _normalize_outline_tree(outline)
-    if normalized.heading:
-        return [normalized.heading]
-    return [child.heading for child in normalized.children if child.heading.strip()]
+    if outline.heading:
+        return [outline.heading]
+    return [child.heading for child in outline.children if child.heading.strip()]
 
 
 def _outline_to_markdown(outline: OutlineNode) -> str:
-    normalized = _normalize_outline_tree(outline)
     lines: list[str] = []
-    roots = normalized.children if not normalized.heading else [normalized]
+    roots = outline.children if not outline.heading else [outline]
     for root in roots:
         _append_outline_lines(root, level=1, lines=lines)
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- `_top_level_headings` and `_outline_to_markdown` each called `_normalize_outline_tree` internally, but every call site already passes a normalized outline
- Removes the two internal normalize calls — these functions now expect normalized input (which they always receive)
- `_ensure_valid_outline` and `refine_outline` remain the only normalization points

## Test plan
- [x] `pytest tests/unit/ -k outline` — 19 passed
- [x] Full unit suite — 422 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal outline processing logic by streamlining helper functions to use direct data access patterns, reducing complexity while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->