### PR TITLE
fix(xiaohongshu): remove broken TikHub sign step

### DIFF
--- a/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
@@ -26,7 +26,7 @@ LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="xiaoh
 
 _SIGNSRV_URL = os.environ.get("AUTOSEARCH_SIGNSRV_URL", "").rstrip("/")
 _SERVICE_TOKEN = os.environ.get("AUTOSEARCH_SERVICE_TOKEN", "")
-_XHS_A1_COOKIE = os.environ.get("XHS_A1_COOKIE", "")
+_XHS_A1_COOKIE = os.environ.get("XHS_A1_COOKIE") or os.environ.get("XIAOHONGSHU_COOKIES", "")
 
 _XHS_SEARCH_URL = "https://edith.xiaohongshu.com/api/sns/web/v1/search/notes"
 _XHS_SEARCH_PATH = "/api/sns/web/v1/search/notes"

--- a/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
@@ -11,10 +11,6 @@ from autosearch.lib.tikhub_client import TikhubClient, TikhubError
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="xiaohongshu")
 
-# Two-step flow: sign first, then search.
-# Step 1: POST to get X-s/X-t/X-s-common signing tokens.
-SIGN_PATH = "/api/v1/xiaohongshu/web/sign"
-# Step 2: GET search results with those tokens as headers.
 SEARCH_PATH = "/api/v1/xiaohongshu/web_v3/fetch_search_notes"
 
 MAX_SNIPPET_LENGTH = 300
@@ -81,44 +77,11 @@ def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidenc
 async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Evidence]:
     tikhub_client = client or TikhubClient()
 
-    # Step 1: get signing tokens for this search request
-    sign_body = {
-        "path": "/api/sns/web/v1/search/notes",
-        "data": {
-            "keyword": query.text,
-            "page": 1,
-            "page_size": 20,
-            "search_id": "",
-            "sort": "general",
-            "note_type": 0,
-        },
-    }
-    try:
-        sign_payload = await tikhub_client.post(SIGN_PATH, sign_body)
-    except (TikhubError, ValueError) as exc:
-        LOGGER.warning("xiaohongshu_tikhub_sign_failed", reason=str(exc))
-        return []
-
-    sign_data = sign_payload.get("data", {})
-    if not isinstance(sign_data, Mapping):
-        LOGGER.warning("xiaohongshu_tikhub_sign_failed", reason="missing_sign_data")
-        return []
-
-    xs = str(sign_data.get("X-s") or "").strip()
-    xt = str(sign_data.get("X-t") or "").strip()
-    xs_common = str(sign_data.get("X-s-common") or "").strip()
-
-    if not xs:
-        LOGGER.warning("xiaohongshu_tikhub_sign_failed", reason="empty_xs_token")
-        return []
-
-    # Step 2: search with signing tokens as headers
-    extra_headers: dict[str, str] = {"X-s": xs, "X-t": xt, "X-s-common": xs_common}
+    # TikHub web_v3 handles XHS signing internally — direct GET, no sign step needed.
     try:
         payload = await tikhub_client.get(
             SEARCH_PATH,
-            {"keyword": query.text, "page": 1},
-            extra_headers=extra_headers,
+            {"keyword": query.text, "page": 1, "page_size": 20, "sort": "general", "note_type": 0},
         )
     except (TikhubError, ValueError) as exc:
         LOGGER.warning("xiaohongshu_tikhub_search_failed", reason=str(exc))

--- a/tests/channels/xiaohongshu/test_via_tikhub.py
+++ b/tests/channels/xiaohongshu/test_via_tikhub.py
@@ -30,13 +30,8 @@ def _load_module():
 
 
 MODULE = _load_module()
-SIGN_PATH = MODULE.SIGN_PATH
 SEARCH_PATH = MODULE.SEARCH_PATH
 search = MODULE.search
-
-_FAKE_SIGN_RESPONSE = {
-    "data": {"X-s": "fake-xs-token", "X-t": "1234567890", "X-s-common": "fake-xs-common"}
-}
 
 
 class _Logger:
@@ -48,36 +43,26 @@ class _Logger:
 
 
 class _FakeTikhubClient:
-    """Two-step fake: post() returns sign tokens, get() returns search results."""
+    """Single-step fake: get() returns search results directly (no sign step)."""
 
     def __init__(self, search_payload: dict[str, object]) -> None:
         self.search_payload = search_payload
-        self.post_calls: list[tuple[str, dict[str, object]]] = []
         self.get_calls: list[tuple[str, dict[str, object]]] = []
-
-    async def post(self, path: str, body: dict[str, object]) -> dict[str, object]:
-        self.post_calls.append((path, body))
-        return _FAKE_SIGN_RESPONSE
 
     async def get(
         self,
         path: str,
         params: dict[str, object],
-        extra_headers: dict[str, str] | None = None,
     ) -> dict[str, object]:
         self.get_calls.append((path, params))
         return self.search_payload
 
 
 class _FailingTikhubClient:
-    async def post(self, path: str, body: dict[str, object]) -> dict[str, object]:
-        raise TikhubError(f"request failed for {path}")
-
     async def get(
         self,
         path: str,
         params: dict[str, object],
-        extra_headers: dict[str, str] | None = None,
     ) -> dict[str, object]:
         raise TikhubError(f"request failed for {path}")
 
@@ -92,7 +77,6 @@ def _note_item(
     desc: str = "",
     xsec_token: str = "",
 ) -> dict[str, object]:
-    """Build a note item in the web_v3 flat format."""
     return {
         "id": note_id,
         "xsecToken": xsec_token,
@@ -131,14 +115,10 @@ async def test_search_maps_xhs_items_to_evidence() -> None:
 
     results = await search(_query(), client=cast(TikhubClient, client))
 
-    # sign step: POST to SIGN_PATH
-    assert len(client.post_calls) == 1
-    assert client.post_calls[0][0] == SIGN_PATH
-    assert client.post_calls[0][1]["data"]["keyword"] == "防晒"
-
-    # search step: GET to SEARCH_PATH
+    # Direct GET to SEARCH_PATH — no sign step
     assert len(client.get_calls) == 1
-    assert client.get_calls[0] == (SEARCH_PATH, {"keyword": "防晒", "page": 1})
+    assert client.get_calls[0][0] == SEARCH_PATH
+    assert client.get_calls[0][1]["keyword"] == "防晒"
 
     assert len(results) == 2
 
@@ -186,7 +166,7 @@ async def test_search_skips_item_without_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_returns_empty_on_sign_tikhub_error(
+async def test_search_returns_empty_on_tikhub_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = _Logger()
@@ -196,7 +176,7 @@ async def test_search_returns_empty_on_sign_tikhub_error(
 
     assert results == []
     assert logger.events
-    assert logger.events[0][0] == "xiaohongshu_tikhub_sign_failed"
+    assert logger.events[0][0] == "xiaohongshu_tikhub_search_failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- TikHub `/api/v1/xiaohongshu/web/sign` endpoint now returns 400 for all requests — it appears TikHub updated their XHS integration so `web_v3/fetch_search_notes` handles signing internally
- Remove the two-step sign→search flow from `via_tikhub.py`; direct GET now returns 22 results
- Also update `via_signsrv.py` to accept `XIAOHONGSHU_COOKIES` as fallback for `XHS_A1_COOKIE` env var

## Verified
- `via_tikhub` live test: **22 results** for "AI编程工具" ✅
- All 422 unit tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)