### PR TITLE
feat(e2b): switch to autosearch-py312 template (Python 3.12 pre-installed)

### DIFF
--- a/scripts/e2b/bench_channels.py
+++ b/scripts/e2b/bench_channels.py
@@ -134,7 +134,7 @@ def run_channel_bench(
 
     try:
         log("sandbox.create")
-        sbx = Sandbox.create("autosearch-claude", timeout=1800, envs=secrets)
+        sbx = Sandbox.create("autosearch-py312", timeout=1800, envs=secrets)
     except Exception as exc:
         return {"channel": channel, "status": "sandbox_create_failed", "error": str(exc)}
 

--- a/scripts/e2b/bench_variance.py
+++ b/scripts/e2b/bench_variance.py
@@ -62,7 +62,7 @@ def run_one(
     t_overall = time.monotonic()
 
     try:
-        sbx = Sandbox.create("autosearch-claude", timeout=1800, envs=secrets)
+        sbx = Sandbox.create("autosearch-py312", timeout=1800, envs=secrets)
     except Exception as exc:
         return {
             "cell_id": cell_id,

--- a/scripts/e2b/sandbox_runner.py
+++ b/scripts/e2b/sandbox_runner.py
@@ -12,7 +12,7 @@ from typing import Any
 import httpx
 
 E2B_API_KEY = os.environ.get("E2B_API_KEY", "")
-TEMPLATE_ID = "y6nmb7m9h84kswgrddd6"  # autosearch-claude
+TEMPLATE_ID = "kiuqzrxuonk3458r5sn0"  # autosearch-py312 (Python 3.12 pre-installed)
 MANAGEMENT_URL = "https://api.e2b.app"
 SANDBOX_TIMEOUT = 900  # 15 min
 

--- a/scripts/e2b/templates/py312/e2b.Dockerfile
+++ b/scripts/e2b/templates/py312/e2b.Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System deps
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    curl git ca-certificates \
+    && add-apt-repository ppa:deadsnakes/ppa -y \
+    && apt-get update \
+    && apt-get install -y python3.12 python3.12-venv python3.12-dev python3-pip \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 \
+    && python3.12 -m ensurepip --upgrade \
+    && python3.12 -m pip install --upgrade pip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Pre-install autosearch and its deps (speeds up test setup)
+RUN python3.12 -m pip install \
+    httpx \
+    structlog \
+    pydantic \
+    typer \
+    "mcp[cli]" \
+    e2b \
+    pytest \
+    pytest-asyncio \
+    --quiet
+
+# Verify
+RUN python3.12 --version && python3.12 -m pip --version


### PR DESCRIPTION
## Summary
- Created new E2B template `autosearch-py312` (ID: `kiuqzrxuonk3458r5sn0`) via `e2b template create`
- Template pre-installs Python 3.12 via deadsnakes PPA + httpx/structlog/pydantic/pytest dependencies
- Eliminates ~48s deadsnakes PPA setup from every P-class desktop sandbox run
- Updated all three sandbox entrypoints to use the new template name

## Template
- E2B Template ID: `kiuqzrxuonk3458r5sn0`
- Template name: `autosearch-py312`
- Python: 3.12, RAM: 2048MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)