### PR TITLE
feat: autosearch login xhs + Worker local XHS signing

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -311,6 +311,105 @@ def configure(
     typer.echo(f"Written: {key} -> {secrets_path}")
 
 
+@app.command()
+def login(
+    platform: Annotated[str, typer.Argument(help="Platform to log in (e.g. xhs).")],
+    browser: Annotated[
+        str,
+        typer.Option(
+            "--browser", "-b", help="Browser to read cookies from (chrome/firefox/edge/brave)."
+        ),
+    ] = "chrome",
+) -> None:
+    """Import cookies from your local browser — no copy-paste needed.
+
+    You must already be logged in to the platform in the specified browser.
+
+    Example:
+        autosearch login xhs
+        autosearch login xhs --browser firefox
+    """
+    from pathlib import Path
+
+    supported = {"xhs": (".xiaohongshu.com",)}
+    if platform not in supported:
+        typer.echo(f"Unsupported platform: {platform}. Supported: {', '.join(supported)}", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        import rookiepy
+    except ImportError:
+        typer.echo(
+            "Cookie import requires rookiepy. Install it with:\n"
+            "  uv pip install rookiepy\n"
+            "or: pip install rookiepy",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    domain = supported[platform]
+    browser_lower = browser.lower()
+    browser_map = {
+        "chrome": rookiepy.chrome,
+        "firefox": rookiepy.firefox,
+        "edge": rookiepy.edge,
+        "brave": rookiepy.brave,
+        "opera": rookiepy.opera,
+    }
+    if browser_lower not in browser_map:
+        typer.echo(f"Unsupported browser: {browser}. Use: {', '.join(browser_map)}", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Reading {platform} cookies from {browser}...")
+    try:
+        raw = browser_map[browser_lower](list(domain))
+    except Exception as exc:
+        typer.echo(f"Could not read cookies: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if not raw:
+        typer.echo(
+            f"No {platform} cookies found in {browser}. "
+            f"Make sure you're logged in to {platform} in {browser}.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    cookie_str = "; ".join(f"{c['name']}={c['value']}" for c in raw)
+    n = len(raw)
+
+    env_key = {"xhs": "XHS_COOKIES"}[platform]
+    secrets_path = Path.home() / ".config" / "ai-secrets.env"
+    secrets_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_keys: set[str] = set()
+    if secrets_path.exists():
+        for line in secrets_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and "=" in stripped:
+                existing_keys.add(stripped.split("=", 1)[0].strip())
+
+    import shlex
+
+    if env_key in existing_keys:
+        # Update existing entry
+        lines = secrets_path.read_text(encoding="utf-8").splitlines()
+        new_lines = []
+        for line in lines:
+            if line.strip().startswith(f"{env_key}="):
+                new_lines.append(f"{env_key}={shlex.quote(cookie_str)}")
+            else:
+                new_lines.append(line)
+        secrets_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+        typer.echo(f"Updated {env_key} ({n} cookies) → {secrets_path}")
+    else:
+        with secrets_path.open("a", encoding="utf-8") as fh:
+            fh.write(f"\n{env_key}={shlex.quote(cookie_str)}\n")
+        typer.echo(f"Written {env_key} ({n} cookies) → {secrets_path}")
+
+    typer.echo(f"Done. XHS searches will now use your {browser} session automatically.")
+
+
 def _stderr_event_writer(event: dict[str, object]) -> None:
     sys.stderr.write(json.dumps(event, ensure_ascii=False) + "\n")
     sys.stderr.flush()

--- a/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
@@ -168,12 +168,40 @@ async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> li
             return []
 
         payload = xhs_resp.json()
+        xhs_code = payload.get("code", 0)
+
+        # code=300011: account flagged by XHS — silently returns empty instead of error
+        if xhs_code == 300011:
+            LOGGER.warning(
+                "xhs_account_restricted",
+                reason="XHS account flagged (code=300011). Run 'autosearch login xhs' with a normal account.",
+            )
+            return []
+
         outer = payload.get("data", {})
         inner = outer.get("data", {}) if isinstance(outer, Mapping) else {}
         items = inner.get("items", []) if isinstance(inner, Mapping) else []
 
         if not isinstance(items, list):
             return []
+
+        # Empty results on a seemingly successful response → check if account is restricted
+        if not items and xhs_code == 0:
+            try:
+                me_resp = await _client.get(
+                    "https://edith.xiaohongshu.com/api/sns/web/v2/user/me",
+                    headers={k: v for k, v in xhs_headers.items() if k not in ("Content-Type",)},
+                    timeout=8,
+                )
+                me = me_resp.json()
+                if me.get("code") == 300011:
+                    LOGGER.warning(
+                        "xhs_account_restricted",
+                        reason="XHS account flagged — search silently returns empty. Run 'autosearch login xhs' with a normal account.",
+                    )
+                    return []
+            except Exception:
+                pass  # health check failure is non-fatal; return empty results
 
         fetched_at = datetime.now(UTC)
         results: list[Evidence] = []

--- a/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
@@ -3,11 +3,12 @@
 Requires:
   AUTOSEARCH_SIGNSRV_URL   → e.g. https://autosearch-signsrv.xxx.workers.dev
   AUTOSEARCH_SERVICE_TOKEN → as_xxx service token
-  XHS_A1_COOKIE            → user's XHS a1 cookie value
+  XHS_COOKIES              → full XHS cookie string: "a1=xxx; web_session=yyy; ..."
+                             (also accepts XHS_A1_COOKIE for bare a1 — legacy)
 
 Flow:
-  1. POST Worker /sign/xhs with uri + data + a1 → X-s/X-t/X-s-common
-  2. POST XHS native API with signed headers → search results
+  1. POST Worker /sign/xhs with cookies + uri + data → X-s/X-t/X-s-common (local signing, no TikHub)
+  2. POST XHS native API with signed headers + full cookies → search results
 """
 
 from __future__ import annotations
@@ -26,7 +27,12 @@ LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="xiaoh
 
 _SIGNSRV_URL = os.environ.get("AUTOSEARCH_SIGNSRV_URL", "").rstrip("/")
 _SERVICE_TOKEN = os.environ.get("AUTOSEARCH_SERVICE_TOKEN", "")
-_XHS_A1_COOKIE = os.environ.get("XHS_A1_COOKIE", "")
+# Prefer full cookie string; fall back to bare a1 for legacy compatibility
+_XHS_COOKIES = (
+    os.environ.get("XHS_COOKIES")
+    or os.environ.get("XIAOHONGSHU_COOKIES")
+    or os.environ.get("XHS_A1_COOKIE", "")
+)
 
 _XHS_SEARCH_URL = "https://edith.xiaohongshu.com/api/sns/web/v1/search/notes"
 _XHS_SEARCH_PATH = "/api/sns/web/v1/search/notes"
@@ -35,7 +41,7 @@ MAX_SNIPPET_LENGTH = 300
 
 
 def _is_configured() -> bool:
-    return bool(_SIGNSRV_URL and _SERVICE_TOKEN and _XHS_A1_COOKIE)
+    return bool(_SIGNSRV_URL and _SERVICE_TOKEN and _XHS_COOKIES)
 
 
 def _clean_text(value: object) -> str:
@@ -119,7 +125,7 @@ async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> li
                     "Authorization": f"Bearer {_SERVICE_TOKEN}",
                     "Content-Type": "application/json",
                 },
-                json={"uri": _XHS_SEARCH_PATH, "data": search_data, "a1": _XHS_A1_COOKIE},
+                json={"uri": _XHS_SEARCH_PATH, "data": search_data, "cookies": _XHS_COOKIES},
                 timeout=8,
             )
             sign_resp.raise_for_status()
@@ -138,7 +144,7 @@ async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> li
             "X-t": str(sign_data["X-t"]),
             "X-s-common": sign_data["X-s-common"],
             "X-b3-traceid": sign_data["X-b3-traceid"],
-            "Cookie": f"a1={_XHS_A1_COOKIE}",
+            "Cookie": _XHS_COOKIES,
             "Content-Type": "application/json;charset=UTF-8",
             "User-Agent": (
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "


### PR DESCRIPTION
## Summary
- `autosearch login xhs`: auto-extract XHS cookies from local browser (rookiepy) — no manual copy-paste
- `via_signsrv.py`: accept full `XHS_COOKIES` cookie string (includes `web_session`), pass it to XHS API
- Cloudflare Worker: local xhshow signing (no TikHub dependency for XHS signature computation)

## How it works
```
autosearch login xhs           # reads cookies from Chrome automatically
autosearch login xhs --browser firefox  # or Firefox/Edge/Brave
```
Writes `XHS_COOKIES` to `~/.config/ai-secrets.env`. Done.

## Notes on via_signsrv search
Worker signing is correct (session valid, homefeed returns 5 items).
XHS search endpoint specifically blocks non-browser IPs regardless of signing.
Fallback: `via_tikhub` handles search (22 results). `via_signsrv` stays for non-search operations.

## Tests
- 422 unit tests pass
- `autosearch login xhs`: extracts 13 cookies including `web_session` ✅
- Worker signs locally with no TikHub calls ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `autosearch login` command for Xiaohongshu authentication. Users can select their browser, and the command automatically reads browser cookies and securely stores them for authenticated requests.

* **Refactor**
  * Updated Xiaohongshu authentication system to use full cookie-based authentication, improving compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->