### PR TITLE
docs(xiaohongshu): document account restriction (code=300011) causing silent empty results

### DIFF
--- a/autosearch/skills/channels/xiaohongshu/SKILL.md
+++ b/autosearch/skills/channels/xiaohongshu/SKILL.md
@@ -48,6 +48,20 @@ Xiaohongshu is a Chinese lifestyle and consumer discovery platform centered on s
 - TikHub search does not require local cookies or login state.
 - Evidence currently reflects note-body content only; comments are not included in this route.
 
+## ⚠️ Known Issue: via_signsrv Account Restriction (code=300011)
+
+XHS applies two-tier account restriction enforcement:
+1. **With valid signing**: restricted accounts return `code=0, 成功` but `items=[]` — silently empty, no error
+2. **Without signing**: returns `code=300011, 当前账号存在异常，请切换账号后重试`
+
+**This means**: if `via_signsrv` returns 0 results, it may be a restricted account, not genuinely empty search results.
+
+**Trigger**: New/unverified accounts, or accounts that triggered bot detection from excessive API calls.
+
+**Mitigation** (not yet implemented): When `via_signsrv` returns empty results, call `/api/sns/web/v2/user/me` to check account health. If `code=300011` is returned, surface `AccountRestrictedError` and prompt user to run `autosearch login xhs` with a different account.
+
+**Workaround**: Use `autosearch login xhs` with a normal, actively-used XHS account. `via_tikhub` is unaffected (uses TikHub's own accounts).
+
 # Quality Bar
 
 - Evidence items have non-empty title and url.


### PR DESCRIPTION
## Summary
Documents a discovered XHS behavior that can silently return empty search results:

**Root cause**: XHS enforces account restrictions in two ways:
1. With correct signing → `code=0, items=[]` (no error, looks like normal empty results)
2. Without signing → `code=300011` (explicit error)

This was discovered during via_signsrv testing with a new/flagged account (`小红薯60F83C0D`).

## Impact
- `via_signsrv` silently returns 0 results for restricted accounts
- `via_tikhub` is unaffected
- Users cannot tell if empty results mean "no content" or "account flagged"

## What's documented
- `SKILL.md` Known Issue section with the two-tier behavior
- Recommended mitigation: health-check call on empty results (not yet implemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)