### PR TITLE
fix(papers): dummy mode guard skips injected fake sources — cross-platform CI fix

### DIFF
--- a/autosearch/skills/channels/papers/methods/via_paper_search.py
+++ b/autosearch/skills/channels/papers/methods/via_paper_search.py
@@ -36,9 +36,9 @@ async def search(
     max_results_per_source: int = 5,
     per_source_timeout_seconds: float = PER_SOURCE_TIMEOUT_SECONDS,
 ) -> list[Evidence]:
-    if os.getenv("AUTOSEARCH_LLM_MODE") == "dummy":
-        return []
     active_sources = sources or SOURCES
+    if os.getenv("AUTOSEARCH_LLM_MODE") == "dummy" and sources is None:
+        return []
     fetched_at = datetime.now(UTC)
     source_items = list(active_sources.items())
     tasks = [


### PR DESCRIPTION
## Root cause
`via_paper_search.py` had:
```python
if os.getenv("AUTOSEARCH_LLM_MODE") == "dummy":
    return []
```
CI sets `AUTOSEARCH_LLM_MODE=dummy` to skip real network calls. But this early-return fired even when the test injected fake `sources`, returning `[]` before the fake searchers could run.

This caused `assert 0 == 10` on every macOS/Windows CI run since the beginning.

## Fix
Move the guard AFTER `active_sources` is resolved, and only apply when `sources is None` (real searchers):
```python
active_sources = sources or SOURCES
if os.getenv("AUTOSEARCH_LLM_MODE") == "dummy" and sources is None:
    return []
```

## Verified
`AUTOSEARCH_LLM_MODE=dummy pytest tests/channels/papers/` → 7 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)