### PR TITLE
fix(test): set USERPROFILE for Windows Path.home() in test_cli_init

### DIFF
--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -22,7 +22,9 @@ def test_cli_init_prints_summary_and_writes_config(
     }
     monkeypatch.setattr(cli_main.InitRunner, "detect_providers", lambda self: providers)
 
-    result = runner.invoke(app, ["init"], env={"HOME": str(tmp_path)})
+    # Set both HOME (Unix) and USERPROFILE (Windows) so Path.home() is redirected on all platforms
+    home_env = {"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)}
+    result = runner.invoke(app, ["init"], env=home_env)
 
     assert result.exit_code == 0
     assert "Python 3.12+" in result.stdout


### PR DESCRIPTION
On Windows, `Path.home()` reads `USERPROFILE`, not `HOME`. The test was setting only `HOME`, so `InitRunner` wrote config to the real home dir instead of `tmp_path`, causing `assert config.yaml.exists()` to fail.

Fix: set both `HOME` (Unix) and `USERPROFILE` (Windows).

This bug was hidden earlier by the papers test failing first (`-x` stops at first failure). Fixed papers test revealed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)