### PR TITLE
fix(test): fix all Windows cross-platform CI failures

### DIFF
--- a/tests/unit/test_nightly_local_shape.py
+++ b/tests/unit/test_nightly_local_shape.py
@@ -15,7 +15,11 @@ SCRIPT = REPO_ROOT / "scripts" / "nightly-local.sh"
 
 
 def test_script_exists_and_is_executable():
+    import sys
+
     assert SCRIPT.is_file(), f"{SCRIPT} missing"
+    if sys.platform == "win32":
+        return  # Windows has no Unix executable bits — skip the permission check
     mode = SCRIPT.stat().st_mode
     assert mode & stat.S_IXUSR, "nightly-local.sh must be executable (+x for owner)"
 


### PR DESCRIPTION
Fixes all remaining cross-platform CI failures on Windows:

**1. `test_script_exists_and_is_executable` (nightly_local_shape)**
Windows has no Unix executable bits. Added `sys.platform == "win32"` early return for the permission check.

**2. `test_cli_init_prints_summary_and_writes_config`**
Windows `Path.home()` reads `USERPROFILE`, not `HOME`. Added `USERPROFILE` to the env dict so the config is written to `tmp_path`.

Both bugs were pre-existing (introduced April 17), hidden by the `-x` pytest flag stopping at the first failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform compatibility for executable permission verification, ensuring tests run correctly on both Windows and Unix-like systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->