### PR TITLE
fix(windows): UTF-8 encoding for all read_text() — fix Windows charmap errors

### DIFF
--- a/scripts/validate/check_version_consistency.py
+++ b/scripts/validate/check_version_consistency.py
@@ -21,7 +21,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def _read_pyproject() -> str:
-    text = (ROOT / "pyproject.toml").read_text()
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
     if not m:
         raise ValueError("version not found in pyproject.toml")
@@ -29,7 +29,7 @@ def _read_pyproject() -> str:
 
 
 def _read_json_version(path: Path) -> str:
-    data = json.loads(path.read_text())
+    data = json.loads(path.read_text(encoding="utf-8"))
     v = data.get("version")
     if not v:
         raise ValueError(f"version not found in {path}")
@@ -37,7 +37,7 @@ def _read_json_version(path: Path) -> str:
 
 
 def _read_changelog() -> str:
-    text = (ROOT / "CHANGELOG.md").read_text()
+    text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     m = re.search(r"^## (\S+)", text, re.MULTILINE)
     if not m:
         raise ValueError("no ## heading found in CHANGELOG.md")

--- a/scripts/validate/pre_release_check.py
+++ b/scripts/validate/pre_release_check.py
@@ -74,7 +74,7 @@ def _check_gate12_bench() -> tuple[bool, str]:
         )
     latest = reports[-1]
     try:
-        stats = json.loads(latest.read_text())
+        stats = json.loads(latest.read_text(encoding="utf-8"))
         win_rate = stats.get("a_win_rate", stats.get("augmented_win_rate", 0.0))
         ok = float(win_rate) >= 0.50
         return ok, f"win_rate={float(win_rate):.1%} from {latest.parent.parent.name}"

--- a/scripts/validate/run_validation.py
+++ b/scripts/validate/run_validation.py
@@ -95,11 +95,11 @@ def _run_bench() -> bool:
     stats = judge_dir / "stats.json"
     if summary.exists():
         print("\n--- Gate 12 Summary ---")
-        print(summary.read_text())
+        print(summary.read_text(encoding="utf-8"))
     if stats.exists():
         import json
 
-        data = json.loads(stats.read_text())
+        data = json.loads(stats.read_text(encoding="utf-8"))
         win_rate = data.get("augmented_win_rate", data.get("a_win_rate", "N/A"))
         print(f"\nAugmented win rate: {win_rate}")
         if isinstance(win_rate, float):

--- a/scripts/validate/test_experience_e2e.py
+++ b/scripts/validate/test_experience_e2e.py
@@ -57,7 +57,7 @@ def main() -> int:
             )
 
         # Verify patterns.jsonl
-        lines = patterns_file.read_text().strip().splitlines()
+        lines = patterns_file.read_text(encoding="utf-8").strip().splitlines()
         if len(lines) != N_EVENTS:
             print(f"FAIL: expected {N_EVENTS} events in patterns.jsonl, got {len(lines)}")
             return 1
@@ -76,7 +76,7 @@ def main() -> int:
             print("FAIL: experience.md not created by compact()")
             return 1
 
-        md_lines = experience_md.read_text().splitlines()
+        md_lines = experience_md.read_text(encoding="utf-8").splitlines()
         if len(md_lines) > 120:
             print(f"FAIL: experience.md has {len(md_lines)} lines (> 120)")
             return 1

--- a/tests/unit/test_autosearch_command_wizard.py
+++ b/tests/unit/test_autosearch_command_wizard.py
@@ -75,7 +75,9 @@ def test_clarify_once_contract():
     # Verify commands/autosearch.md contains the "Only ask once" constraint
     from pathlib import Path
 
-    cmd_text = (Path(__file__).parents[2] / "commands" / "autosearch.md").read_text(encoding="utf-8")
+    cmd_text = (Path(__file__).parents[2] / "commands" / "autosearch.md").read_text(
+        encoding="utf-8"
+    )
     assert "Only ask once" in cmd_text, (
         "commands/autosearch.md must contain 'Only ask once' to document the single-clarification contract"
     )

--- a/tests/unit/test_autosearch_command_wizard.py
+++ b/tests/unit/test_autosearch_command_wizard.py
@@ -75,7 +75,7 @@ def test_clarify_once_contract():
     # Verify commands/autosearch.md contains the "Only ask once" constraint
     from pathlib import Path
 
-    cmd_text = (Path(__file__).parents[2] / "commands" / "autosearch.md").read_text()
+    cmd_text = (Path(__file__).parents[2] / "commands" / "autosearch.md").read_text(encoding="utf-8")
     assert "Only ask once" in cmd_text, (
         "commands/autosearch.md must contain 'Only ask once' to document the single-clarification contract"
     )

--- a/tests/unit/test_configure_cli.py
+++ b/tests/unit/test_configure_cli.py
@@ -37,7 +37,7 @@ def test_configure_writes_new_key(tmp_path):
         result = runner.invoke(app, ["configure", "NEW_KEY", "abc123"])
 
     assert result.exit_code == 0
-    content = secrets.read_text()
+    content = secrets.read_text(encoding="utf-8")
     assert "NEW_KEY=" in content
 
 
@@ -54,7 +54,7 @@ def test_configure_skips_existing_key(tmp_path):
 
     assert result.exit_code == 0
     assert "already exists" in result.output
-    assert "old" in secrets.read_text()
+    assert "old" in secrets.read_text(encoding="utf-8")
 
 
 def test_configure_aborted_on_no_confirm(tmp_path):


### PR DESCRIPTION
Fixes all remaining Windows cross-platform CI failures.

**Root cause**: Windows uses `charmap` as the default encoding. Any `read_text()` without `encoding='utf-8'` fails if the file contains non-ASCII chars (✅ 🟢 emoji in CHANGELOG.md, etc.).

**Changes**:
- `scripts/validate/check_version_consistency.py`: add `encoding='utf-8'` to all 3 `read_text()` calls
- `scripts/validate/pre_release_check.py`, `run_validation.py`, `test_experience_e2e.py`: same
- `tests/unit/test_autosearch_command_wizard.py`, `test_configure_cli.py`: same
- `tests/unit/test_nightly_local_shape.py`: skip executable-bit check on Windows
- `tests/unit/test_cli_init.py`: set USERPROFILE for Path.home() on Windows

All 422 unit tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)