### PR TITLE
fix(test): skip bash execution on Windows — final cross-platform fix

### DIFF
--- a/tests/unit/test_static_checks.py
+++ b/tests/unit/test_static_checks.py
@@ -39,8 +39,8 @@ def test_channel_experience_init_script_exists():
     script = Path(__file__).resolve().parents[2] / "scripts/validate/init_channel_experience.sh"
     assert script.exists(), f"init_channel_experience.sh not found at {script}"
 
-    # Verify the script runs without error in dry-run mode (list channels only)
-    import subprocess
+    if sys.platform == "win32":
+        return  # bash not available on Windows — skip execution check
 
     result = subprocess.run(
         ["bash", str(script)],


### PR DESCRIPTION
`test_channel_experience_init_script_exists` runs `bash init_channel_experience.sh`. `bash` is not available on Windows CI runners by default.

Fix: add `if sys.platform == "win32": return` to skip the execution check on Windows (script existence is still verified).

This is the last remaining Windows cross-platform failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)