### PR TITLE
fix(ci): add exit 0 after expected pip failure — Windows 3.11 cross-platform

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -205,3 +205,4 @@ jobs:
           } else {
             Write-Host "PASS: Install failed with clear Python version message"
           }
+          exit 0  # pip failure was expected — don't propagate $LASTEXITCODE


### PR DESCRIPTION
The Windows Python 3.11 test expects pip install to fail. After the failure, `$LASTEXITCODE = 1`. The PowerShell script printed "PASS" but exited with code 1 because we never reset it.

Fix: add `exit 0` at the end of the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)