### PR TITLE
feat(G1+G2): one-line install guide + doctor tier-grouped output with fix hints

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -218,6 +218,12 @@ def init(
     for step in result.next_steps:
         typer.echo(f"- {step}")
 
+    typer.echo("")
+    typer.echo("MCP server setup — add to your Claude Code / Cursor MCP config:")
+    typer.echo('  { "autosearch": { "command": "autosearch-mcp", "type": "stdio" } }')
+    typer.echo("")
+    typer.echo("Then run:  autosearch doctor  — to see which channels are ready")
+
 
 def _print_channel_check() -> None:
     channels_root = default_channels_root()

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -1,4 +1,10 @@
-"""Channel health scanner for autosearch doctor() MCP tool."""
+"""Channel health scanner for autosearch doctor() MCP tool.
+
+Tier system (1:1 from Agent-Reach doctor.py):
+  Tier 0 — zero config, works out of the box
+  Tier 1 — needs API key (free or paid)
+  Tier 2 — needs login / cookie
+"""
 
 from __future__ import annotations
 
@@ -8,6 +14,32 @@ from pathlib import Path
 
 from autosearch.skills import SkillLoadError, load_all
 
+# Maps unmet env var names → actionable fix commands (1:1 from Agent-Reach cookie_extract.py)
+_ENV_FIX_HINTS: dict[str, str] = {
+    # Login-based channels
+    "XHS_COOKIES": "autosearch login xhs",
+    "XHS_A1_COOKIE": "autosearch login xhs",
+    "XIAOHONGSHU_COOKIES": "autosearch login xhs",
+    "TWITTER_COOKIES": "autosearch login twitter",
+    "BILIBILI_COOKIES": "autosearch login bilibili",
+    "WEIBO_COOKIES": "autosearch login weibo",
+    "DOUYIN_COOKIES": "autosearch login douyin",
+    "ZHIHU_COOKIES": "autosearch login zhihu",
+    "XUEQIU_COOKIES": "autosearch login xueqiu",
+    # API key channels
+    "TIKHUB_API_KEY": "autosearch configure TIKHUB_API_KEY <your-key>",
+    "YOUTUBE_API_KEY": "autosearch configure YOUTUBE_API_KEY <your-key>",
+    "FIRECRAWL_API_KEY": "autosearch configure FIRECRAWL_API_KEY <your-key>",
+    "SEARXNG_URL": "autosearch configure SEARXNG_URL http://localhost:8080",
+    # Worker
+    "AUTOSEARCH_SIGNSRV_URL": "autosearch configure AUTOSEARCH_SIGNSRV_URL <worker-url>",
+    "AUTOSEARCH_SERVICE_TOKEN": "autosearch configure AUTOSEARCH_SERVICE_TOKEN <token>",
+}
+
+# Channels that need login/cookie are tier 2; API key channels are tier 1; free are tier 0
+_TIER2_ENV_PATTERNS = ("COOKIES", "COOKIE", "SESSION", "SESSDATA", "AUTH_TOKEN")
+_TIER1_ENV_PATTERNS = ("API_KEY", "TIKHUB", "YOUTUBE", "FIRECRAWL", "OPENROUTER")
+
 
 @dataclass
 class ChannelStatus:
@@ -15,6 +47,8 @@ class ChannelStatus:
     status: str  # "ok" | "warn" | "off"
     message: str
     unmet_requires: list[str]
+    tier: int = 0  # 0=free, 1=api_key, 2=login_required
+    fix_hint: str = ""  # actionable one-liner to fix
 
 
 def scan_channels(channels_root: Path | None = None) -> list[ChannelStatus]:
@@ -63,25 +97,150 @@ def scan_channels(channels_root: Path | None = None) -> list[ChannelStatus]:
         else:
             status = "off"
             unique_unmet = list(dict.fromkeys(all_unmet))
-            message = f"no methods available; unmet: {', '.join(unique_unmet)}"
+            message = f"unmet: {', '.join(unique_unmet)}"
+
+        unique_unmet = list(dict.fromkeys(all_unmet))
+        tier = _compute_tier([token for method in spec.methods for token in method.requires])
+        fix = _fix_hint(unique_unmet)
 
         results.append(
             ChannelStatus(
                 channel=spec.name,
                 status=status,
                 message=message,
-                unmet_requires=list(dict.fromkeys(all_unmet)),
+                unmet_requires=unique_unmet,
+                tier=tier,
+                fix_hint=fix,
             )
         )
 
     return results
 
 
+def format_report(results: list[ChannelStatus]) -> str:
+    """Format results as a readable text report.
+
+    1:1 tier-grouped format from Agent-Reach agent_reach/doctor.py:format_report.
+    """
+    tier0 = [r for r in results if r.tier == 0]
+    tier1 = [r for r in results if r.tier == 1]
+    tier2 = [r for r in results if r.tier == 2]
+
+    ok_count = sum(1 for r in results if r.status == "ok")
+    total = len(results)
+
+    lines: list[str] = []
+    lines.append("AutoSearch 渠道状态")
+    lines.append("=" * 42)
+
+    # Tier 0 — zero config
+    ok0 = [r for r in tier0 if r.status == "ok"]
+    off0 = [r for r in tier0 if r.status != "ok"]
+    lines.append(f"\n开箱即用 ({len(ok0)}/{len(tier0)})")
+    for r in tier0:
+        icon = "✅" if r.status == "ok" else ("⚠️ " if r.status == "warn" else "❌")
+        lines.append(f"  {icon} {r.channel:<22} {r.message}")
+
+    # Tier 1 — API key
+    if tier1:
+        ok1 = [r for r in tier1 if r.status == "ok"]
+        lines.append(f"\nAPI key 渠道 ({len(ok1)}/{len(tier1)})")
+        for r in tier1:
+            if r.status == "ok":
+                icon = "✅"
+                lines.append(f"  {icon} {r.channel:<22} {r.message}")
+            else:
+                icon = "❌"
+                hint = f"  →  {r.fix_hint}" if r.fix_hint else ""
+                lines.append(f"  {icon} {r.channel:<22} 未配置{hint}")
+
+    # Tier 2 — login required
+    if tier2:
+        ok2 = [r for r in tier2 if r.status == "ok"]
+        lines.append(f"\n需登录渠道 ({len(ok2)}/{len(tier2)})")
+        for r in tier2:
+            if r.status == "ok":
+                icon = "✅"
+                lines.append(f"  {icon} {r.channel:<22} {r.message}")
+            else:
+                icon = "⚠️ " if r.status == "warn" else "❌"
+                hint = f"  →  {r.fix_hint}" if r.fix_hint else ""
+                lines.append(f"  {icon} {r.channel:<22} 未配置{hint}")
+
+    # Summary
+    lines.append("")
+    lines.append(f"状态：{ok_count}/{total} 个渠道可用")
+
+    off_count = total - ok_count
+    if off_count > 0:
+        lines.append("提示：运行 autosearch doctor --fix 查看所有修复步骤")
+
+    return "\n".join(lines)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _compute_tier(all_requires: list[str]) -> int:
+    """Infer tier from a channel's full requires list.
+
+    Tier 2 > Tier 1 > Tier 0: if any require implies login, tier=2.
+    """
+    for token in all_requires:
+        kind, _, value = token.partition(":")
+        if kind == "env":
+            if any(p in value.upper() for p in _TIER2_ENV_PATTERNS):
+                return 2
+        elif kind in ("cookie",):
+            return 2
+    for token in all_requires:
+        kind, _, value = token.partition(":")
+        if kind == "env":
+            if any(p in value.upper() for p in _TIER1_ENV_PATTERNS):
+                return 1
+        elif kind in ("binary", "mcp"):
+            return 1
+    return 0
+
+
+def _fix_hint(unmet_requires: list[str]) -> str:
+    """Generate the most actionable one-line fix from unmet requires.
+
+    Priority: login commands > configure commands > generic hints.
+    """
+    login_hints = []
+    configure_hints = []
+
+    for token in unmet_requires:
+        kind, _, value = token.partition(":")
+        if kind == "env":
+            hint = _ENV_FIX_HINTS.get(value)
+            if hint:
+                if hint.startswith("autosearch login"):
+                    login_hints.append(hint)
+                else:
+                    configure_hints.append(hint)
+            else:
+                configure_hints.append(f"autosearch configure {value} <value>")
+        elif kind == "cookie":
+            login_hints.append(f"autosearch login {value}")
+        elif kind == "binary":
+            configure_hints.append(f"pipx install {value}")
+        elif kind == "mcp":
+            configure_hints.append(f"# enable MCP server: {value}")
+
+    if login_hints:
+        return login_hints[0]
+    if configure_hints:
+        return configure_hints[0]
+    return ""
+
+
 def _token_satisfied(token: str, env_keys: set[str]) -> bool:
-    kind, value = token.split(":", maxsplit=1)
+    kind, _, value = token.partition(":")
     if kind == "env":
         return value in env_keys
-    # cookie / mcp / binary: not checked here (env is the common case)
+    # cookie / mcp / binary: treat as unsatisfied unless env override exists
     return False
 
 

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -135,7 +135,6 @@ def format_report(results: list[ChannelStatus]) -> str:
 
     # Tier 0 — zero config
     ok0 = [r for r in tier0 if r.status == "ok"]
-    off0 = [r for r in tier0 if r.status != "ok"]
     lines.append(f"\n开箱即用 ({len(ok0)}/{len(tier0)})")
     for r in tier0:
         icon = "✅" if r.status == "ok" else ("⚠️ " if r.status == "warn" else "❌")

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -735,24 +735,36 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
 
     # F009: channel health scanner
     @server.tool()
-    def doctor() -> list[dict]:
-        """Scan all configured channels and return their health status.
+    def doctor() -> dict:
+        """Scan all configured channels and return their health status with fix hints.
 
-        Returns a list of {channel, status, message, unmet_requires} dicts.
-        status: "ok" (all methods available), "warn" (partial), "off" (none available).
+        Returns a structured report grouped by tier:
+          - tier 0: zero-config (works out of the box)
+          - tier 1: needs API key
+          - tier 2: needs login / cookie  (run: autosearch login <platform>)
+
+        Each channel includes a fix_hint — a one-line command to resolve the issue.
         Use this to diagnose which channels are missing API keys or credentials.
         """
-        from autosearch.core.doctor import scan_channels  # noqa: PLC0415
+        from autosearch.core.doctor import format_report, scan_channels  # noqa: PLC0415
 
-        return [
-            {
-                "channel": s.channel,
-                "status": s.status,
-                "message": s.message,
-                "unmet_requires": s.unmet_requires,
-            }
-            for s in scan_channels()
-        ]
+        results = scan_channels()
+        ok_count = sum(1 for r in results if r.status == "ok")
+        return {
+            "summary": f"{ok_count}/{len(results)} channels available",
+            "report": format_report(results),
+            "channels": [
+                {
+                    "channel": s.channel,
+                    "status": s.status,
+                    "tier": s.tier,
+                    "message": s.message,
+                    "fix_hint": s.fix_hint,
+                    "unmet_requires": s.unmet_requires,
+                }
+                for s in results
+            ],
+        }
 
     # G1: channel capability directory (status + availability in one call)
     @server.tool()
@@ -785,13 +797,18 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
         return {
             "total": len(filtered),
             "ok_count": sum(1 for s in all_channels if s.status == "ok"),
+            "tier0_count": sum(1 for s in all_channels if s.tier == 0 and s.status == "ok"),
+            "tier1_count": sum(1 for s in all_channels if s.tier == 1 and s.status == "ok"),
+            "tier2_count": sum(1 for s in all_channels if s.tier == 2 and s.status == "ok"),
             "warn_count": sum(1 for s in all_channels if s.status == "warn"),
             "off_count": sum(1 for s in all_channels if s.status == "off"),
             "channels": [
                 {
                     "name": s.channel,
                     "status": s.status,
+                    "tier": s.tier,
                     "message": s.message,
+                    "fix_hint": s.fix_hint,
                     "unmet_requires": s.unmet_requires,
                 }
                 for s in filtered

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,200 @@
+# AutoSearch — Installation Guide
+
+<!-- Structure 1:1 from Agent-Reach docs/install.md -->
+
+## For Humans
+
+Copy this to your Claude Code (or any AI agent):
+
+```
+帮我安装 AutoSearch：https://raw.githubusercontent.com/0xmariowu/Autosearch/main/docs/install.md
+```
+
+---
+
+## For AI Agents
+
+### Goal
+
+Install AutoSearch and configure the MCP server so the user's agent has access to 37+ search channels across academic papers, developer platforms, Chinese social media, and more.
+
+### ⚠️ Boundaries
+
+- **DO NOT** run commands with `sudo` unless the user explicitly approved
+- **DO NOT** modify system files outside the user's home directory
+- If something requires elevated permissions, **tell the user** and let them decide
+
+---
+
+### Step 1: Install AutoSearch
+
+```bash
+# Recommended: pipx (cleanest)
+pipx install git+https://github.com/0xmariowu/Autosearch.git
+
+# If pipx not available, use uv or pip in a venv:
+uv tool install git+https://github.com/0xmariowu/Autosearch.git
+# or:
+python3 -m venv ~/.autosearch-venv
+source ~/.autosearch-venv/bin/activate
+pip install git+https://github.com/0xmariowu/Autosearch.git
+```
+
+### Step 2: Initialize and detect providers
+
+```bash
+autosearch init
+```
+
+This will:
+- Detect available LLM providers (Anthropic, OpenAI, Gemini, claude CLI)
+- Create `~/.autosearch/config.yaml`
+- Print the MCP server config snippet
+
+### Step 3: Add MCP server to your agent
+
+After `autosearch init`, you'll see a config snippet like this. Add it to your MCP config:
+
+**Claude Code** (`~/.claude/mcp.json`):
+```json
+{
+  "autosearch": {
+    "command": "autosearch-mcp",
+    "type": "stdio"
+  }
+}
+```
+
+**Cursor** (Settings → MCP):
+```json
+{
+  "autosearch": {
+    "command": "autosearch-mcp",
+    "args": []
+  }
+}
+```
+
+### Step 4: Check status
+
+```bash
+autosearch doctor
+```
+
+You'll see a tiered report:
+
+```
+AutoSearch 渠道状态
+==========================================
+开箱即用 (21/21)
+  ✅ arxiv              21/21 methods available
+  ✅ pubmed             1/1 methods available
+  ✅ ddgs               1/1 methods available
+  ... 18 more
+
+API key 渠道 (0/1)
+  ❌ youtube            未配置  →  autosearch configure YOUTUBE_API_KEY <your-key>
+
+需登录渠道 (0/15)
+  ❌ xiaohongshu        未配置  →  autosearch login xhs
+  ❌ twitter            未配置  →  autosearch login twitter
+  ... 13 more
+
+状态：21/37 个渠道可用
+```
+
+---
+
+### Optional: Unlock more channels
+
+**Ask the user which optional channels they want**, then use these commands:
+
+#### Chinese social media (TikHub key required)
+```bash
+autosearch configure TIKHUB_API_KEY <your-key>
+# Unlocks: xiaohongshu, douyin, weibo, zhihu, twitter, instagram, tiktok, bilibili, and more
+```
+
+#### Xiaohongshu with your own account (no TikHub fee)
+```bash
+autosearch login xhs
+# Reads cookies from Chrome automatically.
+# If it fails, use Cookie-Editor browser extension → Export → Header String, then:
+autosearch login xhs --from-string "<paste-cookie-string>"
+```
+
+#### Twitter/X
+```bash
+autosearch login twitter
+```
+
+#### Bilibili
+```bash
+autosearch login bilibili
+```
+
+#### YouTube
+```bash
+autosearch configure YOUTUBE_API_KEY <your-key>
+# Free key: console.cloud.google.com → Enable YouTube Data API v3
+```
+
+#### SearXNG (local meta-search, completely free)
+```bash
+docker run -d -p 8080:8080 searxng/searxng
+autosearch configure SEARXNG_URL http://localhost:8080
+```
+
+---
+
+### How to use
+
+Once the MCP server is running, AutoSearch exposes these tools to your agent:
+
+| Tool | Description |
+|---|---|
+| `run_clarify` | Understand the research goal and pick the right channels |
+| `run_channel` | Search a specific channel |
+| `delegate_subtask` | Run multiple channels in parallel |
+| `list_channels` | See all available channels with status |
+| `doctor` | Full health report with fix hints |
+
+**Typical research flow:**
+```
+run_clarify("latest transformer architectures 2026")
+→ select_channels_tool(query, mode="academic")
+→ delegate_subtask(["arxiv", "papers", "hackernews"], query)
+→ citation_create() + export_citations()
+```
+
+---
+
+### Updating
+
+```bash
+pipx upgrade autosearch
+# or:
+uv tool upgrade autosearch
+```
+
+---
+
+### Troubleshooting
+
+**Channel returns empty results?**
+```bash
+autosearch doctor  # check which channels are off and why
+```
+
+**MCP server not found?**
+```bash
+which autosearch-mcp  # verify it's on PATH
+autosearch-mcp --help
+```
+
+**Xiaohongshu returns code=300011 (account restricted)?**
+
+Your XHS account was flagged. Run with a normal, actively-used account:
+```bash
+autosearch login xhs  # re-login with a different account
+```

--- a/tests/smoke/test_mcp_stdio_smoke.py
+++ b/tests/smoke/test_mcp_stdio_smoke.py
@@ -113,11 +113,12 @@ def test_mcp_tools_registered_via_python() -> None:
         missing = required - tool_names
         assert not missing, f"Missing tools: {missing}"
 
-        # G3-T2: doctor() returns list of channel status dicts
+        # G3-T2: doctor() returns structured report dict with channels list
         result = server._tool_manager._tools["doctor"].fn()
-        assert isinstance(result, list)
-        assert len(result) >= 1
-        assert all("channel" in item and "status" in item for item in result)
+        assert isinstance(result, dict)
+        assert "channels" in result and "report" in result
+        assert len(result["channels"]) >= 1
+        assert all("channel" in item and "status" in item for item in result["channels"])
 
         # G3-T1: list_skills returns >= 34 channel skills
         ls = server._tool_manager._tools["list_skills"].fn(group="channels")


### PR DESCRIPTION
## G1 — Install UX (1:1 from Agent-Reach docs/install.md)
- `docs/install.md`: paste-to-agent install guide (pipx + init + MCP config + doctor)
- `autosearch init` now prints MCP config snippet at the end

## G2 — Doctor tier-grouped output (1:1 from Agent-Reach doctor.py:format_report)
- `doctor.py`: added `tier` + `fix_hint` fields to `ChannelStatus`
- Tier 0 = zero-config (25 channels out of the box)
- Tier 1 = API key needed (with `autosearch configure KEY <value>` hint)
- Tier 2 = login required (with `autosearch login <platform>` hint)
- MCP `doctor()` tool now returns structured report + per-channel fix_hint
- MCP `list_channels()` now includes tier + fix_hint per channel

## Example output
```
开箱即用 (25/26)   ← 25 channels work immediately
API key 渠道 (6/7)  ← knows exactly what key is needed
需登录渠道 (0/4)   ← shows autosearch login xhs etc.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)