### PR TITLE
docs: rewrite README in Agent-Reach style

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 </h1>
 
 <p align="center">
-  <strong>Deep research MCP server for AI developers.</strong><br>
-  39 search channels across academic, developer, and Chinese platforms — cited results, no hallucination.
+  <strong>给你的 AI Agent 装上 39 个搜索渠道</strong>
 </p>
 
 <p align="center">
@@ -18,101 +17,78 @@
 <p align="center">
   <a href="https://docs.autosearch.dev">Docs</a> &bull;
   <a href="https://docs.autosearch.dev/install">Install</a> &bull;
-  <a href="https://docs.autosearch.dev/channels">Channels</a> &bull;
-  <a href="#mcp-tools">MCP Tools</a>
+  <a href="https://docs.autosearch.dev/channels">Channels</a>
 </p>
 
 ---
 
-## Install
+你让 AI 去研究一个问题，它给你的是截止训练数据的知识——
 
-```bash
-# Option 1 — npm (recommended, no Python setup required)
-npm install -g autosearch-ai
-autosearch-ai init
+- "帮我看看 arxiv 上这周的 LLM 论文" → **搜不了**，没有学术数据库访问
+- "小红书上大家怎么评价这个产品" → **打不开**，必须登录才能搜
+- "GitHub 上有没有类似的开源项目" → **结果很水**，只能用通用搜索
+- "帮我整理一下推特上对这个技术的讨论" → **看不到**，Twitter 没有公开 API
+- "这个话题在知乎和 Reddit 上分别是什么观点" → 要跑两个平台，结果还得手动汇总
 
-# Option 2 — pip
-pip install autosearch
-autosearch init
+**AutoSearch 把这件事变成一句话：**
+
+复制给你的 AI Agent（Claude Code、Cursor 等）：
+
+```
+Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosearch/main/docs/install.md
 ```
 
-`init` auto-detects your LLM providers and writes the MCP config to `~/.claude/mcp.json` and `~/.cursor/mcp.json`.
+或者直接安装：
+
+```bash
+npm install -g autosearch-ai && autosearch-ai init
+```
+
+安装后你的 Agent 能同时搜 39 个渠道——学术论文、开发者社区、中文社媒，结果去重排序，每条结果都有来源链接。
 
 ---
 
-## What it does
+## 支持的渠道
 
-AutoSearch runs as an **MCP server** inside Claude Code, Cursor, or any MCP-compatible client. Your AI agent calls tools like `run_channel`, `delegate_subtask`, and `consolidate_research` — AutoSearch searches real sources and returns structured, cited results.
+| 渠道 | 装好即用 | 配置后解锁 | 怎么配 |
+|------|---------|-----------|-------|
+| 📄 **arxiv** | 学术预印本 CS/ML/物理 | — | 无需配置 |
+| 🔬 **PubMed / OpenAlex / DBLP** | 生物医学 + 跨学科论文 | — | 无需配置 |
+| 🐙 **GitHub** | 代码、Issue、仓库搜索 | — | 无需配置 |
+| 🔍 **DuckDuckGo** | 通用网页搜索 | — | 无需配置 |
+| 🟠 **Hacker News** | 开发者讨论 + 早期产品信号 | — | 无需配置 |
+| 📖 **Reddit** | 社区讨论 + 用户真实体验 | — | 无需配置 |
+| 🤗 **Hugging Face** | 开源 ML 模型搜索 | — | 无需配置 |
+| 📦 **Stack Overflow** | 编程 Q&A | — | 无需配置 |
+| 📰 **Google News** | 实时新闻聚合 | — | 无需配置 |
+| 💻 **dev.to** | 开发者博客 | — | 无需配置 |
+| 📊 **SEC EDGAR** | 美股公司财报 | — | 无需配置 |
+| 🌐 **Wikipedia / Wikidata** | 百科 + 结构化知识 | — | 无需配置 |
+| 💬 **微信公众号** | 公众号文章全文搜索 | — | 无需配置 |
+| 📱 **36kr / InfoQ** | 中文科技商业资讯 | — | 无需配置 |
+| 🎬 **YouTube** | 视频搜索 + 字幕 | — | 设置 `YOUTUBE_API_KEY` |
+| 📺 **Bilibili** | 中文技术视频 | — | 设置 `TIKHUB_API_KEY` |
+| 🌸 **小红书** | 生活方式 + 产品口碑 | 更稳定 | `autosearch login xhs` 或 `TIKHUB_API_KEY` |
+| 🐦 **Twitter / X** | 实时讨论 + 技术动态 | — | `TIKHUB_API_KEY` |
+| 📣 **微博 / 抖音 / 知乎** | 中文舆论 + 深度讨论 | — | `TIKHUB_API_KEY` |
+| 📈 **雪球** | A股/港股讨论 | — | `autosearch login xueqiu` |
+| 💼 **LinkedIn** | 公开页面 via Jina Reader | — | 无需配置 |
 
-- **39 channels**: arxiv, PubMed, GitHub, Hacker News, Reddit, Xiaohongshu, Weibo, Twitter, Douyin, and more
-- **22 MCP tools**: search, delegation, loop management, citation export
-- **5 search modes**: academic / news / chinese_ugc / developer / product — auto-detected from query
-- **No hallucination**: every result cites the source URL
+> 不知道怎么配？直接告诉 Agent「帮我配 XXX」，它会引导你一步步完成。
 
 ---
 
-## MCP Tools
+## 安装完之后
 
-| Tool | Description |
-|---|---|
-| `run_clarify` | Detect query intent, pick mode and channels |
-| `run_channel` | Search one channel with dedup + BM25 ranking |
-| `delegate_subtask` | Run multiple channels in parallel |
-| `consolidate_research` | Compress evidence to prevent context overflow |
-| `loop_init` / `loop_update` / `loop_gaps` | Deep research loop |
-| `citation_create` / `citation_add` / `citation_export` | Citation management |
-| `list_skills` / `list_channels` / `list_modes` | Discover available resources |
-| `doctor` | Full channel health report with fix hints |
+运行 `autosearch doctor` 查看每个渠道的状态：
 
----
-
-## Supported Channels
-
-Run `autosearch doctor` to see live status. Generated from `autosearch/skills/channels/*/SKILL.md`.
-
-<!-- channels-table-start -->
-### Tier 0 - always-on (21)
-| Channel | Languages | Description | Typical yield |
-|---|---|---|---|
-| arxiv | en | Use for academic preprint searches in CS/ML/physics when query is English or mixed and expects peer-reviewed or preprint papers. | medium-high |
-| crossref | en | Cross-publisher scholarly search via the Crossref DOI registry, useful for journal articles, book chapters, and citation-linked research metadata. | medium |
-| dblp | en | Computer science bibliography search — technical papers, proceedings, and journal articles indexed by venue, author, and year. | medium |
-| ddgs | en, mixed | DuckDuckGo Search — free general web search with no auth, use as broad default for any English or mixed query. | medium |
-| devto | en, mixed | Developer blog articles tagged by technology topic, via the public dev.to API. | medium |
-| github | en | Use for code-level, issue-level, and repository discovery when query involves a library, framework, or implementation detail. | high |
-| google_news | en, mixed | Current news headlines aggregated across publishers via Google News RSS (English US feed). | high |
-| hackernews | en | Use for real-time developer discussion, tooling opinions, and early-stage product signals from the HN community. | medium-high |
-| huggingface_hub | en, mixed | Discover open machine learning models on Hugging Face Hub via the public model search API. | high |
-| infoq_cn | zh, mixed | Chinese engineering articles covering architecture, AI, and enterprise tech from InfoQ 中文, via public RSS feed. | medium |
-| kr36 | zh, mixed | Chinese tech business news, startup funding, and industry analysis from 36kr. | medium |
-| openalex | en, mixed | Search scholarly works through OpenAlex's public works search API with open-access URL fallback. | high |
-| package_search | en, mixed | Discover packages across PyPI (exact-name lookup) and npm (full-text search) registries. | medium |
-| papers | en, mixed | Multi-source academic paper search (arxiv, pubmed, biorxiv, medrxiv, google_scholar) via paper-search-mcp. | high |
-| podcast_cn | zh, mixed | Chinese-language podcasts searchable via the Apple iTunes store public API. | low |
-| reddit | en, mixed | Reddit community discussions, user experience reports, and topic debates via the public search.json endpoint. | medium |
-| sec_edgar | en | US public company filings (10-K, 10-Q, 8-K) via SEC EDGAR full-text search — financial and regulatory disclosures for research. | medium |
-| sogou_weixin | zh, mixed | Chinese WeChat Official Account articles via the public Sogou WeChat search SERP. | high |
-| stackoverflow | en, mixed | Programming Q&A with community-voted answers across 200+ technical tags via api.stackexchange.com. | high |
-| wikidata | en, mixed | Structured entity data (people, places, concepts) from Wikidata knowledge graph. | medium |
-| wikipedia | en, mixed | Authoritative encyclopedia articles via the Wikipedia Action API (English edition). | high |
-
-### Tier 1 - env-gated (1)
-| Channel | Languages | Required env | Description | Typical yield |
-|---|---|---|---|---|
-| youtube | en, zh, mixed | env:YOUTUBE_API_KEY | Use for video tutorial discovery, conference talks, technical walkthroughs, and product demos. | medium |
-
-### Tier 2 - BYOK paid (8)
-| Channel | Languages | Required env | Description | Typical yield |
-|---|---|---|---|---|
-| bilibili | zh, mixed | env:TIKHUB_API_KEY | Chinese tech video platform with tutorials, conference recordings, and uploader-authored articles, via TikHub. | medium |
-| douyin | zh | env:TIKHUB_API_KEY | Chinese short-video content with product demos, tech reviews, and viral trends, via TikHub. | medium |
-| kuaishou | zh, mixed | env:TIKHUB_API_KEY | Chinese short-video platform with lifestyle, humor, regional culture, and product demos, via TikHub. | medium |
-| tiktok | en, mixed | env:TIKHUB_API_KEY | Global short-video platform with creator content, product demos, viral trends, and topical reactions, via TikHub. | medium |
-| twitter | en, mixed | env:TIKHUB_API_KEY | Real-time public discourse including product launches, tech announcements, and breaking news, via TikHub. | medium |
-| weibo | zh, mixed | env:TIKHUB_API_KEY | Chinese microblog platform for real-time opinion, trending topics, and event-level commentary in Chinese discourse, via TikHub. | medium |
-| xiaohongshu | zh, mixed | env:TIKHUB_API_KEY | Chinese lifestyle + experience-sharing notes with strong product/beauty/travel/food coverage, via TikHub. | high |
-| zhihu | zh, mixed | env:TIKHUB_API_KEY | Chinese Q&A platform with deep technical discussions and user experience reports — use when query is Chinese or mixed and targets developer opinions, comparisons, or tutorials. | medium-high |
-<!-- channels-table-end -->
+```
+AutoSearch Channel Status
+==========================================
+Always-on (21/21)   ✅ arxiv  ✅ github  ✅ hackernews ...
+Env-gated  (0/1)    ○  youtube  →  set YOUTUBE_API_KEY
+Login      (0/15)   ○  xiaohongshu  →  autosearch login xhs
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Rewrites README leading with pain points (arxiv / 小红书 / GitHub / Twitter scenarios)
- Two install formats: Agent one-liner URL + `npm install -g autosearch-ai`
- Channel table with 装好即用 / 配置后解锁 / 怎么配 columns
- Removes v1/v2/rewrite language and technical spec framing
- Adds `autosearch doctor` status example

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Both install commands are copy-pasteable

🤖 Generated with [Claude Code](https://claude.com/claude-code)