### PR TITLE
docs: add WeChat Channels (视频号) to channel table

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ After install, your Agent searches 39 channels simultaneously — academic paper
 | 📱 **36kr / InfoQ** | Chinese tech & business news | — | No config needed |
 | 🎬 **YouTube** | Video search + transcripts | — | Set `YOUTUBE_API_KEY` |
 | 📺 **Bilibili** | Chinese tech videos | — | Set `TIKHUB_API_KEY` |
+| 📹 **WeChat Channels** | Chinese short videos (视频号) | — | `TIKHUB_API_KEY` |
 | 🌸 **Xiaohongshu** | Lifestyle + product reviews | More stable | `autosearch login xhs` or `TIKHUB_API_KEY` |
 | 🐦 **Twitter / X** | Real-time discussion + tech news | — | `TIKHUB_API_KEY` |
 | 📣 **Weibo / Douyin / Zhihu** | Chinese social + in-depth discussion | — | `TIKHUB_API_KEY` |

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,6 +69,7 @@ npm install -g autosearch-ai && autosearch-ai init
 | 📱 **36kr / InfoQ** | 中文科技商业资讯 | — | 无需配置 |
 | 🎬 **YouTube** | 视频搜索 + 字幕 | — | 设置 `YOUTUBE_API_KEY` |
 | 📺 **Bilibili** | 中文技术视频 | — | 设置 `TIKHUB_API_KEY` |
+| 📹 **微信视频号** | 中文短视频 | — | `TIKHUB_API_KEY` |
 | 🌸 **小红书** | 生活方式 + 产品口碑 | 更稳定 | `autosearch login xhs` 或 `TIKHUB_API_KEY` |
 | 🐦 **Twitter / X** | 实时讨论 + 技术动态 | — | `TIKHUB_API_KEY` |
 | 📣 **微博 / 抖音 / 知乎** | 中文舆论 + 深度讨论 | — | `TIKHUB_API_KEY` |


### PR DESCRIPTION
## Summary
- Adds 📹 WeChat Channels (视频号) row to channel table in both README.md and README.zh.md
- Channel is already implemented (`wechat_channels` skill via TikHub), was missing from docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WeChat Channels (视频号/WeChat Video Channel) to the list of supported channels in documentation, specifying that it's ready out of the box with `TIKHUB_API_KEY` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->