### PR TITLE
feat(npm): auto-run init on postinstall

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -16,5 +16,8 @@
   "files": ["bin"],
   "engines": {
     "node": ">=18"
+  },
+  "scripts": {
+    "postinstall": "node bin/autosearch-ai.js"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `postinstall` script to npm/package.json
- `npm install -g autosearch-ai` now runs `autosearch init` automatically after install
- No more need for the `&& autosearch-ai init` second step

## Test plan
- [ ] `npm install -g autosearch-ai` triggers init on a clean machine
- [ ] Init output visible in terminal during install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation configuration to execute an automated setup script upon installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->