### PR TITLE
docs: simplify install — npm install is now enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 Or install directly:
 
 ```bash
-npm install -g autosearch-ai && autosearch-ai init
+npm install -g autosearch-ai
 ```
 
 After install, your Agent searches 39 channels simultaneously — academic papers, developer communities, Chinese social media — results deduplicated and ranked, every result includes a source URL.

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,7 +42,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 或者直接安装：
 
 ```bash
-npm install -g autosearch-ai && autosearch-ai init
+npm install -g autosearch-ai
 ```
 
 安装后你的 Agent 能同时搜 39 个渠道——学术论文、开发者社区、中文社媒，结果去重排序，每条结果都有来源链接。

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,10 +39,10 @@ pipx install autosearch
 
 ### Step 2: Initialize
 
+> **npm users**: init runs automatically — skip this step.
+
 ```bash
-autosearch-ai init   # if installed via npm
-# or
-autosearch init      # if installed via pip/pipx
+autosearch init      # pip/pipx only
 ```
 
 This will:

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -13,7 +13,6 @@ Works with **Claude Code**, **Cursor**, and any MCP-compatible client.
 
 ```bash npm (recommended)
 npm install -g autosearch-ai
-autosearch-ai init
 ```
 
 ```bash pip

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,10 +7,9 @@ description: "First search in 5 minutes"
 
 ```bash
 npm install -g autosearch-ai
-autosearch-ai init
 ```
 
-`init` auto-configures the MCP server. You should see:
+`init` runs automatically after install and configures the MCP server. You should see:
 
 ```
 ✅ Python 3.12+              [OK]


### PR DESCRIPTION
## Summary
- Removed `&& autosearch-ai init` from all docs (README.md, README.zh.md, introduction.mdx, quickstart.mdx)
- Updated install.md to note npm users skip Step 2
- Follows postinstall change in v2026.04.23.6 — init now runs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)