### PR TITLE
fix(npm): graceful postinstall — pip failure no longer breaks npm install

### DIFF
--- a/npm/bin/autosearch-ai.js
+++ b/npm/bin/autosearch-ai.js
@@ -3,6 +3,7 @@
 
 const { execSync, spawnSync } = require("child_process");
 const args = process.argv.slice(2);
+const isPostinstall = process.env.npm_lifecycle_event === "postinstall";
 
 function hasAutosearch() {
   try {
@@ -38,19 +39,29 @@ function install() {
       stdio: "inherit",
     });
   }
-  if (result.status !== 0) {
-    console.error("pip install failed. Try manually: pip install autosearch");
-    process.exit(1);
-  }
+  return result.status === 0;
 }
 
 if (!checkPython()) {
+  if (isPostinstall) {
+    console.log("\nautosearch-ai installed. To complete setup, install Python 3.12+ then run: autosearch-ai");
+    process.exit(0);
+  }
   console.error("Python not found. Install Python 3.12+ first: https://python.org");
   process.exit(1);
 }
 
 if (!hasAutosearch()) {
-  install();
+  const ok = install();
+  if (!ok) {
+    if (isPostinstall) {
+      console.log("\nautosearch-ai installed. To complete setup, run: autosearch-ai");
+      console.log("(requires Python 3.12+: pip install autosearch)");
+      process.exit(0);
+    }
+    console.error("pip install failed. Try manually: pip install autosearch");
+    process.exit(1);
+  }
 }
 
 const cmd = args.length > 0 ? args : ["init"];


### PR DESCRIPTION
## Problem
`npm install -g autosearch-ai` was failing entirely when pip install failed (e.g., when PyPI package not available, or wrong Python version). The `process.exit(1)` in `install()` propagated to npm's exit code.

## Fix
- When running as `postinstall` (detected via `npm_lifecycle_event`), pip failure prints a helpful message and exits 0 — npm install succeeds
- User can run `autosearch-ai` again later once Python/pip is set up correctly
- Direct `autosearch-ai` calls (non-postinstall) still fail properly so the user knows something is wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)