### PR TITLE
fix(npm): detect Python 3.12+ explicitly for pip install

### DIFF
--- a/npm/bin/autosearch-ai.js
+++ b/npm/bin/autosearch-ai.js
@@ -14,49 +14,58 @@ function hasAutosearch() {
   }
 }
 
-function checkPython() {
-  try {
-    execSync("python3 --version", { stdio: "ignore" });
-    return true;
-  } catch {
+// Find Python 3.12+ and return the executable path, or null if not found.
+function findPython312() {
+  const candidates = ["python3.13", "python3.12", "python3", "python"];
+  for (const cmd of candidates) {
     try {
-      execSync("python --version", { stdio: "ignore" });
-      return true;
+      const out = execSync(`${cmd} -c "import sys; print(sys.version_info[:2])"`, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      const match = out.match(/\((\d+),\s*(\d+)\)/);
+      if (match && parseInt(match[1]) === 3 && parseInt(match[2]) >= 12) {
+        return cmd;
+      }
     } catch {
-      return false;
+      // try next
     }
   }
+  return null;
 }
 
-function install() {
+function install(python) {
   console.log("Installing autosearch...");
-  // pip3 first, then pip — both hardcoded, not from user input
-  let result = spawnSync("pip3", ["install", "--quiet", "--upgrade", "autosearch"], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    result = spawnSync("pip", ["install", "--quiet", "--upgrade", "autosearch"], {
-      stdio: "inherit",
-    });
+  // Use the detected Python 3.12+ to run pip, falling back to pip3/pip
+  const pipCmds = [
+    [python, ["-m", "pip", "install", "--quiet", "--upgrade", "autosearch"]],
+    ["pip3", ["install", "--quiet", "--upgrade", "autosearch"]],
+    ["pip", ["install", "--quiet", "--upgrade", "autosearch"]],
+  ];
+  for (const [cmd, pipArgs] of pipCmds) {
+    const result = spawnSync(cmd, pipArgs, { stdio: "inherit" });
+    if (result.status === 0) return true;
   }
-  return result.status === 0;
+  return false;
 }
 
-if (!checkPython()) {
+const python = findPython312();
+
+if (!python) {
   if (isPostinstall) {
     console.log("\nautosearch-ai installed. To complete setup, install Python 3.12+ then run: autosearch-ai");
     process.exit(0);
   }
-  console.error("Python not found. Install Python 3.12+ first: https://python.org");
+  console.error("Python 3.12+ not found. Install it first: https://python.org");
   process.exit(1);
 }
 
 if (!hasAutosearch()) {
-  const ok = install();
+  const ok = install(python);
   if (!ok) {
     if (isPostinstall) {
       console.log("\nautosearch-ai installed. To complete setup, run: autosearch-ai");
-      console.log("(requires Python 3.12+: pip install autosearch)");
+      console.log("(pip install autosearch failed — ensure Python 3.12+ pip is working)");
       process.exit(0);
     }
     console.error("pip install failed. Try manually: pip install autosearch");


### PR DESCRIPTION
## Problem
`autosearch` requires Python 3.12+. On Macs where `pip3` resolves to Xcode's bundled Python (3.9/3.10), pip says:
> ERROR: Could not find a version that satisfies the requirement autosearch (from versions: none)

This is correct pip behaviour — it filters out packages whose `requires-python` doesn't match the current interpreter.

## Fix
Before calling pip, probe `python3.12`, `python3.13`, `python3`, `python` in order and pick the first one that is 3.12+. Then invoke `<that-python> -m pip install autosearch` so we always use the right interpreter's pip. Falls back to `pip3`/`pip` as before.

## Test plan
- [ ] On a machine with only Xcode Python + a separate Python 3.12: `npm install -g autosearch-ai` succeeds and runs init

🤖 Generated with [Claude Code](https://claude.com/claude-code)