### PR TITLE
feat: curl install script — proper install with init screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 Or install directly:
 
 ```bash
-npm install -g autosearch-ai
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 ```
 
 After install, your Agent searches 39 channels simultaneously — academic papers, developer communities, Chinese social media — results deduplicated and ranked, every result includes a source URL.

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,7 +42,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 或者直接安装：
 
 ```bash
-npm install -g autosearch-ai
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 ```
 
 安装后你的 Agent 能同时搜 39 个渠道——学术论文、开发者社区、中文社媒，结果去重排序，每条结果都有来源链接。

--- a/npm/bin/autosearch-ai.js
+++ b/npm/bin/autosearch-ai.js
@@ -3,7 +3,6 @@
 
 const { execSync, spawnSync } = require("child_process");
 const args = process.argv.slice(2);
-const isPostinstall = process.env.npm_lifecycle_event === "postinstall";
 
 function hasAutosearch() {
   try {
@@ -14,63 +13,13 @@ function hasAutosearch() {
   }
 }
 
-// Find Python 3.12+ and return the executable path, or null if not found.
-function findPython312() {
-  const candidates = ["python3.13", "python3.12", "python3", "python"];
-  for (const cmd of candidates) {
-    try {
-      const out = execSync(`${cmd} -c "import sys; print(sys.version_info[:2])"`, {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
-      const match = out.match(/\((\d+),\s*(\d+)\)/);
-      if (match && parseInt(match[1]) === 3 && parseInt(match[2]) >= 12) {
-        return cmd;
-      }
-    } catch {
-      // try next
-    }
-  }
-  return null;
-}
-
-function install(python) {
-  console.log("Installing autosearch...");
-  // Use the detected Python 3.12+ to run pip, falling back to pip3/pip
-  const pipCmds = [
-    [python, ["-m", "pip", "install", "--quiet", "--upgrade", "autosearch"]],
-    ["pip3", ["install", "--quiet", "--upgrade", "autosearch"]],
-    ["pip", ["install", "--quiet", "--upgrade", "autosearch"]],
-  ];
-  for (const [cmd, pipArgs] of pipCmds) {
-    const result = spawnSync(cmd, pipArgs, { stdio: "inherit" });
-    if (result.status === 0) return true;
-  }
-  return false;
-}
-
-const python = findPython312();
-
-if (!python) {
-  if (isPostinstall) {
-    console.log("\nautosearch-ai installed. To complete setup, install Python 3.12+ then run: autosearch-ai");
-    process.exit(0);
-  }
-  console.error("Python 3.12+ not found. Install it first: https://python.org");
-  process.exit(1);
-}
-
 if (!hasAutosearch()) {
-  const ok = install(python);
-  if (!ok) {
-    if (isPostinstall) {
-      console.log("\nautosearch-ai installed. To complete setup, run: autosearch-ai");
-      console.log("(pip install autosearch failed — ensure Python 3.12+ pip is working)");
-      process.exit(0);
-    }
-    console.error("pip install failed. Try manually: pip install autosearch");
-    process.exit(1);
-  }
+  console.log("");
+  console.log("AutoSearch is not installed yet. Run:");
+  console.log("");
+  console.log("  curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash");
+  console.log("");
+  process.exit(0);
 }
 
 const cmd = args.length > 0 ? args : ["init"];

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -e
+
+REPO="https://raw.githubusercontent.com/0xmariowu/Autosearch/main"
+BOLD="\033[1m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+RED="\033[31m"
+RESET="\033[0m"
+
+info()    { echo -e "${BOLD}$*${RESET}"; }
+success() { echo -e "${GREEN}✓${RESET} $*"; }
+warn()    { echo -e "${YELLOW}!${RESET} $*"; }
+die()     { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+
+echo ""
+echo -e "${BOLD}  AutoSearch — Install${RESET}"
+echo "  ─────────────────────────────────────"
+echo ""
+
+# ── 1. Find Python 3.12+ ────────────────────────────────────────────────────
+find_python() {
+  for cmd in python3.13 python3.12 python3 python; do
+    if command -v "$cmd" &>/dev/null; then
+      version=$("$cmd" -c "import sys; print(sys.version_info[:2])" 2>/dev/null)
+      if echo "$version" | grep -qE "\(3, (1[2-9]|[2-9][0-9])"; then
+        echo "$cmd"; return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+# ── 2. Install autosearch ────────────────────────────────────────────────────
+install_autosearch() {
+  # uv tool install (best: isolated, cross-platform, fast)
+  if command -v uv &>/dev/null; then
+    info "Installing via uv..."
+    uv tool install autosearch --quiet && success "Installed via uv" && return 0
+  fi
+
+  # pipx (also isolated, widely available)
+  if command -v pipx &>/dev/null; then
+    info "Installing via pipx..."
+    pipx install autosearch && success "Installed via pipx" && return 0
+  fi
+
+  # pip with Python 3.12+
+  PYTHON=$(find_python || true)
+  if [ -n "$PYTHON" ]; then
+    info "Installing via pip ($PYTHON)..."
+    "$PYTHON" -m pip install --quiet --upgrade --break-system-packages autosearch 2>/dev/null \
+      || "$PYTHON" -m pip install --quiet --upgrade autosearch
+    success "Installed via pip" && return 0
+  fi
+
+  die "Could not install autosearch. Install Python 3.12+ first: https://python.org"
+}
+
+# ── 3. Ensure autosearch is in PATH ─────────────────────────────────────────
+fix_path() {
+  # uv tool bin
+  if command -v uv &>/dev/null; then
+    UV_BIN=$(uv tool dir 2>/dev/null | sed 's|tools$|bin|' || echo "")
+    if [ -n "$UV_BIN" ] && [ -d "$UV_BIN" ] && [[ ":$PATH:" != *":$UV_BIN:"* ]]; then
+      export PATH="$UV_BIN:$PATH"
+    fi
+  fi
+
+  # ~/.local/bin (pipx default)
+  if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
+}
+
+# ── 4. Persist PATH to shell profile ─────────────────────────────────────────
+persist_path() {
+  local line='export PATH="$HOME/.local/bin:$PATH"'
+  for profile in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+    if [ -f "$profile" ] && ! grep -q '.local/bin' "$profile" 2>/dev/null; then
+      echo "" >> "$profile"
+      echo "# Added by AutoSearch installer" >> "$profile"
+      echo "$line" >> "$profile"
+      warn "Added ~/.local/bin to PATH in $profile"
+      break
+    fi
+  done
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+install_autosearch
+fix_path
+
+if ! command -v autosearch &>/dev/null; then
+  persist_path
+  fix_path
+fi
+
+if ! command -v autosearch &>/dev/null; then
+  echo ""
+  warn "autosearch not found in PATH. Restart your terminal, then run: autosearch init"
+  exit 0
+fi
+
+echo ""
+echo "  ─────────────────────────────────────"
+echo ""
+
+# Run init — this shows the full AutoSearch setup screen
+autosearch init


### PR DESCRIPTION
## What changed
- `scripts/install.sh`: one-command installer that works on any machine
  - tries uv → pipx → pip (with --break-system-packages) in order
  - runs `autosearch init` at the end so user sees the full setup screen
- `npm/bin/autosearch-ai.js`: simplified to pure launcher — no more pip logic
  - if autosearch installed: run it
  - if not: print the curl install command
- README.md / README.zh.md: direct install now uses curl command

## Why
npm-based pip install is inherently fragile across macOS/Windows/Linux Python environments (Xcode Python, Homebrew PEP 668, etc.). curl script has full terminal control and can show the install screen properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)