### PR TITLE
feat: npx autosearch-ai as one-command installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 Or install directly:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
+npx autosearch-ai
 ```
 
 After install, your Agent searches 39 channels simultaneously — academic papers, developer communities, Chinese social media — results deduplicated and ranked, every result includes a source URL.

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,7 +42,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 或者直接安装：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
+npx autosearch-ai
 ```
 
 安装后你的 Agent 能同时搜 39 个渠道——学术论文、开发者社区、中文社媒，结果去重排序，每条结果都有来源链接。

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,23 +27,20 @@ Install AutoSearch and configure the MCP server so the user's agent has access t
 ### Step 1: Install AutoSearch
 
 ```bash
-# Option 1: npm (no Python setup required)
-npm install -g autosearch-ai
+# Option 1: npx — one command, no setup required (recommended)
+npx autosearch-ai
 
-# Option 2: pip
-pip install autosearch
+# Option 2: curl install script
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 
-# Option 3: pipx (cleanest Python install)
-pipx install autosearch
+# Option 3: pip
+pip install autosearch && autosearch init
+
+# Option 4: pipx
+pipx install autosearch && autosearch init
 ```
 
-### Step 2: Initialize
-
-> **npm users**: init runs automatically — skip this step.
-
-```bash
-autosearch init      # pip/pipx only
-```
+> npx and curl options run `autosearch init` automatically.
 
 This will:
 - Detect available LLM providers (Anthropic, OpenAI, Gemini, claude CLI)

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -11,8 +11,8 @@ Works with **Claude Code**, **Cursor**, and any MCP-compatible client.
 
 <CodeGroup>
 
-```bash npm (recommended)
-npm install -g autosearch-ai
+```bash npx (recommended)
+npx autosearch-ai
 ```
 
 ```bash pip

--- a/npm/bin/autosearch-ai.js
+++ b/npm/bin/autosearch-ai.js
@@ -4,6 +4,9 @@
 const { execSync, spawnSync } = require("child_process");
 const args = process.argv.slice(2);
 
+const INSTALL_SCRIPT =
+  "https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh";
+
 function hasAutosearch() {
   try {
     execSync("autosearch --version", { stdio: "ignore" });
@@ -14,12 +17,11 @@ function hasAutosearch() {
 }
 
 if (!hasAutosearch()) {
-  console.log("");
-  console.log("AutoSearch is not installed yet. Run:");
-  console.log("");
-  console.log("  curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash");
-  console.log("");
-  process.exit(0);
+  // Download and run install.sh — handles uv/pipx/pip + shows init screen
+  const result = spawnSync("bash", ["-c", `curl -fsSL ${INSTALL_SCRIPT} | bash`], {
+    stdio: "inherit",
+  });
+  process.exit(result.status ?? 0);
 }
 
 const cmd = args.length > 0 ? args : ["init"];


### PR DESCRIPTION
## Summary
- `npx autosearch-ai` now works as a complete one-command installer
  - autosearch installed → runs `autosearch init` directly
  - not installed → downloads and runs `install.sh` (uv/pipx/pip) → shows init screen
- Updated README.md, README.zh.md, introduction.mdx, install.md to use npx as primary command
- curl install script kept as explicit option in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)