### PR TITLE
docs: show both npx and curl install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Or install directly:
 
 ```bash
 npx autosearch-ai
+# or
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 ```
 
 After install, your Agent searches 39 channels simultaneously — academic papers, developer communities, Chinese social media — results deduplicated and ranked, every result includes a source URL.

--- a/README.zh.md
+++ b/README.zh.md
@@ -43,6 +43,8 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 
 ```bash
 npx autosearch-ai
+# 或者
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 ```
 
 安装后你的 Agent 能同时搜 39 个渠道——学术论文、开发者社区、中文社媒，结果去重排序，每条结果都有来源链接。

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -15,6 +15,10 @@ Works with **Claude Code**, **Cursor**, and any MCP-compatible client.
 npx autosearch-ai
 ```
 
+```bash curl
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
+```
+
 ```bash pip
 pip install autosearch
 autosearch init


### PR DESCRIPTION
- README.md / README.zh.md: npx first, curl as second option
- docs/introduction.mdx: added curl tab in CodeGroup alongside npx and pip

🤖 Generated with [Claude Code](https://claude.com/claude-code)