### PR TITLE
feat: discourse_forum channel + skill-metadata-driven channel governance (rebased from #309)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p align="center">
-  Open-source deep research for coding agents. An alternative to OpenAI and Perplexity Deep Research — 39 channels including Chinese sources.
+  Open-source deep research for coding agents. An alternative to OpenAI and Perplexity Deep Research — 40 channels including Chinese sources.
 </p>
 
 <p align="center">
@@ -47,7 +47,7 @@ Or paste into your AI Agent (Claude Code, Cursor, etc.):
 Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosearch/main/docs/install.md
 ```
 
-After install, your Agent searches 39 channels simultaneously — academic papers, developer communities, Chinese social media — results deduplicated and ranked, every result includes a source URL.
+After install, your Agent searches 40 channels simultaneously — academic papers, developer communities, Chinese social media, and Linux DO forum threads — results deduplicated and ranked, every result includes a source URL.
 
 ---
 
@@ -69,6 +69,7 @@ After install, your Agent searches 39 channels simultaneously — academic paper
 | 🌐 **Wikipedia / Wikidata** | Encyclopedia + structured knowledge | — | No config needed |
 | 💬 **WeChat Official Accounts** | Full-text article search | — | No config needed |
 | 📱 **36kr / InfoQ** | Chinese tech & business news | — | No config needed |
+| 🧵 **Linux DO / Discourse Forums** | Linux DO topics and Discourse-based public forum discussions | — | No config needed |
 | 🎬 **YouTube** | Video search + transcripts | — | Set `YOUTUBE_API_KEY` |
 | 📺 **Bilibili** | Chinese tech videos | — | Set `TIKHUB_API_KEY` |
 | 📹 **WeChat Channels** | Chinese short videos (视频号) | — | `TIKHUB_API_KEY` |

--- a/README.zh.md
+++ b/README.zh.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p align="center">
-  面向编程 Agent 的开源深度研究工具。OpenAI 和 Perplexity Deep Research 的替代方案——39 个渠道，含中文信息源。
+  面向编程 Agent 的开源深度研究工具。OpenAI 和 Perplexity Deep Research 的替代方案——40 个渠道，含中文信息源。
 </p>
 
 <p align="center">
@@ -47,7 +47,7 @@ curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/i
 Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosearch/main/docs/install.md
 ```
 
-安装后你的 Agent 能同时搜 39 个渠道——学术论文、开发者社区、中文社媒，结果去重排序，每条结果都有来源链接。
+安装后你的 Agent 能同时搜 40 个渠道——学术论文、开发者社区、中文社媒、Linux DO 论坛帖子，结果去重排序，每条结果都有来源链接。
 
 ---
 
@@ -69,6 +69,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 | 🌐 **Wikipedia / Wikidata** | 百科 + 结构化知识 | — | 无需配置 |
 | 💬 **微信公众号** | 公众号文章全文搜索 | — | 无需配置 |
 | 📱 **36kr / InfoQ** | 中文科技商业资讯 | — | 无需配置 |
+| 🧵 **Linux DO / Discourse 论坛** | Linux DO 话题和基于 Discourse 的公开论坛讨论 | — | 无需配置 |
 | 🎬 **YouTube** | 视频搜索 + 字幕 | — | 设置 `YOUTUBE_API_KEY` |
 | 📺 **Bilibili** | 中文技术视频 | — | 设置 `TIKHUB_API_KEY` |
 | 📹 **微信视频号** | 中文短视频 | — | `TIKHUB_API_KEY` |

--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -69,6 +69,12 @@ class ChannelMetadata:
     languages: list[str]
     when_to_use: WhenToUse | None
     quality_hint: QualityHint | None
+    layer: str | None
+    domains: list[str]
+    scenarios: list[str]
+    model_tier: str | None
+    tier: int | None
+    fix_hint: str | None
     methods: list[CompiledMethod]
     fallback_chain: list[str]
 
@@ -222,6 +228,12 @@ class ChannelRegistry:
                 languages=list(skill.languages),
                 when_to_use=skill.when_to_use,
                 quality_hint=skill.quality_hint,
+                layer=skill.layer,
+                domains=list(skill.domains),
+                scenarios=list(skill.scenarios),
+                model_tier=skill.model_tier,
+                tier=skill.tier,
+                fix_hint=skill.fix_hint,
                 methods=methods,
                 fallback_chain=list(skill.fallback_chain),
             )

--- a/autosearch/core/channel_select.py
+++ b/autosearch/core/channel_select.py
@@ -188,6 +188,9 @@ def _channel_aliases(name: str) -> tuple[str, ...]:
         _normalize_text(name.replace("_", "")),
     }
     for alias in _CHANNEL_ALIASES.get(name, ()):
+        normalized_alias = _normalize_channel_name(alias)
+        if normalized_alias:
+            variants.add(normalized_alias)
         variants.update(_keyword_variants(alias))
 
     return tuple(sorted(variant for variant in variants if variant))
@@ -290,12 +293,30 @@ def _has_cjk(value: str) -> bool:
     return bool(_CJK_PATTERN.search(value))
 
 
-def _channel_match_score(spec: ChannelRouteSpec, query_lower: str) -> int:
-    alias_score = sum(3 for alias in spec.aliases if alias and alias in query_lower)
+def _query_tokens(query_lower: str) -> set[str]:
+    return set(_WORD_PATTERN.findall(query_lower))
+
+
+def _matches_query(term: str, query_lower: str, query_tokens: set[str]) -> bool:
+    if len(term) < 3 and term.isascii():
+        return term in query_tokens
+    return term in query_lower
+
+
+def _channel_match_score(
+    spec: ChannelRouteSpec,
+    query_lower: str,
+    query_tokens: set[str],
+) -> int:
+    alias_score = sum(
+        3 for alias in spec.aliases if alias and _matches_query(alias, query_lower, query_tokens)
+    )
     keyword_score = sum(
         1
         for keyword in spec.keywords
-        if keyword and keyword not in spec.aliases and keyword in query_lower
+        if keyword
+        and keyword not in spec.aliases
+        and _matches_query(keyword, query_lower, query_tokens)
     )
     return alias_score + keyword_score
 
@@ -311,11 +332,12 @@ def _domain_score(
     domain: str,
     *,
     query_lower: str,
+    query_tokens: set[str],
     channels: tuple[ChannelRouteSpec, ...],
 ) -> int:
     keyword_score = sum(1 for keyword in _DOMAIN_KEYWORDS.get(domain, ()) if keyword in query_lower)
     channel_scores = sorted(
-        (_channel_match_score(spec, query_lower) for spec in channels),
+        (_channel_match_score(spec, query_lower, query_tokens) for spec in channels),
         reverse=True,
     )
     metadata_score = sum(score for score in channel_scores[:2] if score > 0)
@@ -338,13 +360,19 @@ def select_channels(
     limit = min(_MODE_LIMITS.get(mode, 5), max_channels)
 
     query_lower = _normalize_text(query)
+    query_tokens = _query_tokens(query_lower)
     has_cjk = _has_cjk(query)
     catalog = _load_channel_route_catalog()
     channels_by_domain = _channels_by_domain(catalog)
 
     scores: dict[str, int] = {}
     for domain, specs in channels_by_domain.items():
-        score = _domain_score(domain, query_lower=query_lower, channels=specs)
+        score = _domain_score(
+            domain,
+            query_lower=query_lower,
+            query_tokens=query_tokens,
+            channels=specs,
+        )
         if score > 0:
             scores[domain] = score
 
@@ -365,7 +393,7 @@ def select_channels(
             for spec in sorted(
                 channels_by_domain.get(group, ()),
                 key=lambda spec: (
-                    -_channel_match_score(spec, query_lower),
+                    -_channel_match_score(spec, query_lower, query_tokens),
                     -_language_affinity(spec, has_cjk=has_cjk),
                     spec.name,
                 ),

--- a/autosearch/core/channel_select.py
+++ b/autosearch/core/channel_select.py
@@ -1,34 +1,55 @@
-"""Group-first two-stage channel selection for v2 tool-supplier."""
+"""Metadata-assisted channel selection for v2 tool-supplier."""
 
 from __future__ import annotations
 
-_GROUP_KEYWORDS: dict[str, list[str]] = {
-    "chinese-ugc": [
-        "Linux DO",
+from collections import defaultdict
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+import re
+
+from autosearch.skills.loader import SkillLoadError, _extract_frontmatter
+
+_SKILLS_ROOT = Path(__file__).resolve().parents[1] / "skills" / "channels"
+_MODE_LIMITS = {"fast": 5, "deep": 8}
+_GENERIC_WEB_DOMAIN = "generic-web"
+_CJK_PATTERN = re.compile(r"[\u3400-\u9FFF]")
+_WORD_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)?", re.IGNORECASE)
+_DOMAIN_ALIASES: dict[str, str] = {
+    "brand": "market-product",
+    "consumer": "market-product",
+    "finance": "market-product",
+    "infrastructure": "code-package",
+    "lifestyle": "market-product",
+    "medical": "academic",
+    "professional": "social-career",
+    "social": "social-career",
+    "video": "video-audio",
+}
+
+_DOMAIN_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "chinese-ugc": (
         "linux do",
         "linux.do",
         "linuxdo",
         "discourse",
         "小红书",
         "抖音",
-        "B站",
+        "b站",
         "微博",
         "知乎",
         "播客",
         "快手",
-        "雪球",
-        "V2EX",
-        "bilibili",
-        "xhs",
-        "douyin",
-        "weibo",
-        "zhihu",
-        "xiaohongshu",
-        "kuaishou",
-    ],
-    "cn-tech": ["36kr", "CSDN", "掘金", "InfoQ", "公众号", "juejin", "infoq", "csdn"],
-    "academic": [
+        "v2ex",
+        "贴吧",
+        "公众号",
+        "wechat article",
+        "wechat official account",
+    ),
+    "cn-tech": ("36kr", "csdn", "掘金", "infoq", "公众号", "juejin"),
+    "academic": (
         "paper",
+        "papers",
         "arxiv",
         "citation",
         "benchmark",
@@ -36,15 +57,14 @@ _GROUP_KEYWORDS: dict[str, list[str]] = {
         "survey",
         "openreview",
         "semantic scholar",
-        "semanticscholar",
         "conference",
         "ieee",
         "acm",
-    ],
-    "code-package": [
+    ),
+    "code-package": (
         "github",
         "repo",
-        "code",
+        "repository",
         "issue",
         "npm",
         "pypi",
@@ -52,31 +72,21 @@ _GROUP_KEYWORDS: dict[str, list[str]] = {
         "package",
         "library",
         "sdk",
-        "crate",
-        "gem",
-    ],
-    "market-product": [
-        "crunchbase",
-        "融资",
-        "producthunt",
-        "G2",
-        "review",
-        "startup",
-        "funding",
-        "投资",
-        "竞品",
-    ],
-    "community-en": [
+        "docker image",
+        "container image",
+    ),
+    "community-en": (
         "stackoverflow",
+        "stack overflow",
         "hacker news",
         "hackernews",
         "dev.to",
         "devto",
         "reddit",
         "hn",
-    ],
-    "social-career": ["twitter", "linkedin", "X ", "职业", "career", "招聘", "hiring"],
-    "video-audio": [
+    ),
+    "social-career": ("twitter", "linkedin", " career ", "招聘", "hiring", "job"),
+    "video-audio": (
         "视频",
         "字幕",
         "转录",
@@ -84,25 +94,232 @@ _GROUP_KEYWORDS: dict[str, list[str]] = {
         "youtube",
         "video",
         "transcript",
-        "bilibili视频",
         "音频",
-    ],
-    "generic-web": ["搜索", "search", "news", "网页", "google", "bing", "tavily", "exa", "ddgs"],
+    ),
+    _GENERIC_WEB_DOMAIN: ("搜索", "search", "news", "网页", "google", "bing", "ddgs"),
 }
 
-_GROUP_CHANNELS: dict[str, list[str]] = {
-    "chinese-ugc": ["discourse_forum", "bilibili", "xiaohongshu", "zhihu", "weibo", "douyin"],
-    "cn-tech": ["kr36", "infoq_cn", "sogou_weixin"],
-    "academic": ["arxiv", "papers", "google_scholar"],
-    "code-package": ["github", "package_search"],
-    "market-product": ["hackernews", "ddgs"],
-    "community-en": ["hackernews", "stackoverflow", "reddit"],
-    "social-career": ["twitter", "ddgs"],
-    "video-audio": ["youtube"],
-    "generic-web": ["ddgs", "exa", "tavily"],
+_CHANNEL_ALIASES: dict[str, tuple[str, ...]] = {
+    "bilibili": ("b站", "哔哩哔哩"),
+    "discourse_forum": ("linux do", "linux.do", "linuxdo", "discourse"),
+    "douyin": ("抖音",),
+    "github": ("github", "git repo", "repository"),
+    "google_news": ("google news", "新闻"),
+    "hackernews": ("hacker news", "hackernews", "hn"),
+    "infoq_cn": ("infoq",),
+    "kr36": ("36kr",),
+    "package_search": ("npm", "pypi", "package", "dependency"),
+    "podcast_cn": ("播客", "podcast"),
+    "reddit": ("reddit",),
+    "sogou_weixin": ("公众号", "微信文章", "wechat article", "wechat official account"),
+    "stackoverflow": ("stackoverflow", "stack overflow"),
+    "tieba": ("贴吧", "百度贴吧"),
+    "twitter": ("twitter", "tweet", "x "),
+    "v2ex": ("v2ex",),
+    "weibo": ("微博",),
+    "wechat_channels": ("视频号", "微信视频号", "wechat channels"),
+    "xiaohongshu": ("小红书", "xhs", "rednote"),
+    "xueqiu": ("雪球",),
+    "youtube": ("youtube", "视频"),
+    "zhihu": ("知乎",),
 }
 
-_MODE_LIMITS = {"fast": 5, "deep": 8}
+
+@dataclass(frozen=True, slots=True)
+class ChannelRouteSpec:
+    name: str
+    domains: tuple[str, ...]
+    scenarios: tuple[str, ...]
+    query_types: tuple[str, ...]
+    query_languages: tuple[str, ...]
+    aliases: tuple[str, ...]
+    keywords: tuple[str, ...]
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.casefold().replace("_", " ").split())
+
+
+def _normalize_channel_name(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def _normalize_values(values: object) -> tuple[str, ...]:
+    if not isinstance(values, list):
+        return ()
+    normalized: list[str] = []
+    for value in values:
+        if isinstance(value, str):
+            text = _normalize_text(value)
+            if text:
+                normalized.append(text)
+    return tuple(normalized)
+
+
+def _normalize_domain(value: str) -> str:
+    normalized = _normalize_text(value)
+    return _DOMAIN_ALIASES.get(normalized, normalized)
+
+
+def _keyword_variants(value: str) -> set[str]:
+    normalized = _normalize_text(value.replace("-", " "))
+    if not normalized:
+        return set()
+
+    variants = {normalized}
+    compact = normalized.replace(" ", "")
+    if compact and compact != normalized:
+        variants.add(compact)
+
+    if _CJK_PATTERN.search(normalized):
+        return {variant for variant in variants if variant}
+
+    for token in _WORD_PATTERN.findall(normalized):
+        if len(token) >= 3:
+            variants.add(token)
+
+    return {variant for variant in variants if len(variant) >= 3}
+
+
+def _channel_aliases(name: str) -> tuple[str, ...]:
+    variants = {
+        _normalize_channel_name(name),
+        _normalize_text(name),
+        _normalize_text(name.replace("_", "")),
+    }
+    for alias in _CHANNEL_ALIASES.get(name, ()):
+        variants.update(_keyword_variants(alias))
+
+    return tuple(sorted(variant for variant in variants if variant))
+
+
+def _channel_keywords(
+    *,
+    name: str,
+    domains: tuple[str, ...],
+    scenarios: tuple[str, ...],
+    query_types: tuple[str, ...],
+    domain_hints: tuple[str, ...],
+) -> tuple[str, ...]:
+    keywords: set[str] = set()
+    for value in (*domains, *scenarios, *query_types, *domain_hints):
+        keywords.update(_keyword_variants(value))
+
+    # Keep the canonical channel id searchable even when no alias exists.
+    keywords.update(_keyword_variants(name))
+    keywords.update(_keyword_variants(name.replace("_", " ")))
+    return tuple(sorted(keywords))
+
+
+@lru_cache(maxsize=1)
+def _load_channel_route_catalog() -> tuple[ChannelRouteSpec, ...]:
+    if not _SKILLS_ROOT.is_dir():
+        return ()
+
+    specs: list[ChannelRouteSpec] = []
+    for skill_dir in sorted(path for path in _SKILLS_ROOT.iterdir() if path.is_dir()):
+        skill_path = skill_dir / "SKILL.md"
+        if not skill_path.is_file():
+            continue
+
+        try:
+            raw = skill_path.read_text(encoding="utf-8")
+            payload = _extract_frontmatter(raw, skill_path)
+        except (OSError, SkillLoadError):
+            continue
+
+        name = payload.get("name")
+        if not isinstance(name, str) or not name.strip():
+            name = skill_dir.name
+        canonical_name = _normalize_channel_name(name)
+
+        domains = tuple(
+            dict.fromkeys(
+                _normalize_domain(domain) for domain in _normalize_values(payload.get("domains"))
+            )
+        )
+        if not domains:
+            continue
+
+        scenarios = _normalize_values(payload.get("scenarios"))
+        when_to_use = payload.get("when_to_use")
+        query_types = ()
+        query_languages = ()
+        domain_hints = ()
+        if isinstance(when_to_use, dict):
+            query_types = _normalize_values(when_to_use.get("query_types"))
+            query_languages = _normalize_values(when_to_use.get("query_languages"))
+            domain_hints = _normalize_values(when_to_use.get("domain_hints"))
+
+        specs.append(
+            ChannelRouteSpec(
+                name=canonical_name,
+                domains=domains,
+                scenarios=scenarios,
+                query_types=query_types,
+                query_languages=query_languages,
+                aliases=_channel_aliases(canonical_name),
+                keywords=_channel_keywords(
+                    name=canonical_name,
+                    domains=domains,
+                    scenarios=scenarios,
+                    query_types=query_types,
+                    domain_hints=domain_hints,
+                ),
+            )
+        )
+
+    return tuple(sorted(specs, key=lambda spec: spec.name))
+
+
+def _channels_by_domain(
+    catalog: tuple[ChannelRouteSpec, ...],
+) -> dict[str, tuple[ChannelRouteSpec, ...]]:
+    mapping: dict[str, list[ChannelRouteSpec]] = defaultdict(list)
+    for spec in catalog:
+        for domain in spec.domains:
+            mapping[domain].append(spec)
+
+    return {
+        domain: tuple(sorted(specs, key=lambda spec: spec.name))
+        for domain, specs in mapping.items()
+    }
+
+
+def _has_cjk(value: str) -> bool:
+    return bool(_CJK_PATTERN.search(value))
+
+
+def _channel_match_score(spec: ChannelRouteSpec, query_lower: str) -> int:
+    alias_score = sum(3 for alias in spec.aliases if alias and alias in query_lower)
+    keyword_score = sum(
+        1
+        for keyword in spec.keywords
+        if keyword and keyword not in spec.aliases and keyword in query_lower
+    )
+    return alias_score + keyword_score
+
+
+def _language_affinity(spec: ChannelRouteSpec, *, has_cjk: bool) -> int:
+    query_languages = set(spec.query_languages)
+    if has_cjk:
+        return 1 if {"zh", "mixed"} & query_languages else 0
+    return 1 if {"en", "mixed"} & query_languages else 0
+
+
+def _domain_score(
+    domain: str,
+    *,
+    query_lower: str,
+    channels: tuple[ChannelRouteSpec, ...],
+) -> int:
+    keyword_score = sum(1 for keyword in _DOMAIN_KEYWORDS.get(domain, ()) if keyword in query_lower)
+    channel_scores = sorted(
+        (_channel_match_score(spec, query_lower) for spec in channels),
+        reverse=True,
+    )
+    metadata_score = sum(score for score in channel_scores[:2] if score > 0)
+    return keyword_score + metadata_score
 
 
 def select_channels(
@@ -112,61 +329,84 @@ def select_channels(
     mode: str = "fast",
     max_channels: int = 8,
 ) -> dict:
-    """Two-stage group-first channel selection.
-
-    Stage 1: score groups against query keywords.
-    Stage 2: collect leaf channels from matched groups.
+    """Select channels from channel SKILL metadata plus light query hints.
 
     Returns {"groups": list[str], "channels": list[str], "rationale": str}.
     """
     priority = list(channel_priority or [])
-    skip = set(channel_skip or [])
+    skip = {_normalize_channel_name(name) for name in channel_skip or []}
     limit = min(_MODE_LIMITS.get(mode, 5), max_channels)
 
-    query_lower = query.lower()
+    query_lower = _normalize_text(query)
+    has_cjk = _has_cjk(query)
+    catalog = _load_channel_route_catalog()
+    channels_by_domain = _channels_by_domain(catalog)
 
-    # Stage 1 — score groups
     scores: dict[str, int] = {}
-    for group, keywords in _GROUP_KEYWORDS.items():
-        score = sum(1 for kw in keywords if kw.lower() in query_lower)
-        if score:
-            scores[group] = score
+    for domain, specs in channels_by_domain.items():
+        score = _domain_score(domain, query_lower=query_lower, channels=specs)
+        if score > 0:
+            scores[domain] = score
 
-    top_groups = sorted(scores, key=lambda g: scores[g], reverse=True)[:3]
+    top_groups = sorted(scores, key=lambda domain: (-scores[domain], domain))[:3]
 
-    # Stage 2 — collect leaf channels
     channels: list[str] = []
     seen: set[str] = set()
 
-    # priority channels first (from clarify result)
-    for ch in priority:
-        if ch not in seen and ch not in skip:
-            channels.append(ch)
-            seen.add(ch)
+    for channel_name in priority:
+        normalized = _normalize_channel_name(channel_name)
+        if normalized and normalized not in seen and normalized not in skip:
+            channels.append(normalized)
+            seen.add(normalized)
 
-    # then fill from matched groups
-    for group in top_groups:
-        for ch in _GROUP_CHANNELS.get(group, []):
-            if ch not in seen and ch not in skip and len(channels) < limit:
-                channels.append(ch)
-                seen.add(ch)
+    ranked_specs_by_group = {
+        group: [
+            spec
+            for spec in sorted(
+                channels_by_domain.get(group, ()),
+                key=lambda spec: (
+                    -_channel_match_score(spec, query_lower),
+                    -_language_affinity(spec, has_cjk=has_cjk),
+                    spec.name,
+                ),
+            )
+            if spec.name not in skip
+        ]
+        for group in top_groups
+    }
 
-    # fallback to generic-web if nothing matched
+    while len(channels) < limit:
+        added = False
+        for group in top_groups:
+            for spec in ranked_specs_by_group.get(group, []):
+                if spec.name in seen:
+                    continue
+                channels.append(spec.name)
+                seen.add(spec.name)
+                added = True
+                break
+            if len(channels) >= limit:
+                break
+        if not added:
+            break
+
     if not channels:
-        for ch in _GROUP_CHANNELS["generic-web"]:
-            if ch not in seen and ch not in skip and len(channels) < limit:
-                channels.append(ch)
-                seen.add(ch)
-        top_groups = ["generic-web"]
+        for spec in channels_by_domain.get(_GENERIC_WEB_DOMAIN, ()):
+            if spec.name in seen or spec.name in skip or len(channels) >= limit:
+                continue
+            channels.append(spec.name)
+            seen.add(spec.name)
+        top_groups = [_GENERIC_WEB_DOMAIN]
 
     rationale = (
-        f"Groups: {top_groups or ['generic-web']}. "
+        f"Groups: {top_groups or [_GENERIC_WEB_DOMAIN]}. "
         f"Mode: {mode} (limit {limit}). "
+        "Selected from channel metadata with query-hint scoring. "
         f"Selected {len(channels)} channels."
     )
 
     return {
-        "groups": top_groups or ["generic-web"],
+        "groups": top_groups or [_GENERIC_WEB_DOMAIN],
         "channels": channels[:limit],
         "rationale": rationale,
     }

--- a/autosearch/core/channel_select.py
+++ b/autosearch/core/channel_select.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 _GROUP_KEYWORDS: dict[str, list[str]] = {
     "chinese-ugc": [
+        "Linux DO",
+        "linux do",
+        "linux.do",
+        "linuxdo",
+        "discourse",
         "小红书",
         "抖音",
         "B站",
@@ -86,7 +91,7 @@ _GROUP_KEYWORDS: dict[str, list[str]] = {
 }
 
 _GROUP_CHANNELS: dict[str, list[str]] = {
-    "chinese-ugc": ["bilibili", "xiaohongshu", "zhihu", "weibo", "douyin"],
+    "chinese-ugc": ["discourse_forum", "bilibili", "xiaohongshu", "zhihu", "weibo", "douyin"],
     "cn-tech": ["kr36", "infoq_cn", "sogou_weixin"],
     "academic": ["arxiv", "papers", "google_scholar"],
     "code-package": ["github", "package_search"],

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -100,8 +100,9 @@ def scan_channels(channels_root: Path | None = None) -> list[ChannelStatus]:
             message = f"unmet: {', '.join(unique_unmet)}"
 
         unique_unmet = list(dict.fromkeys(all_unmet))
-        tier = _compute_tier([token for method in spec.methods for token in method.requires])
-        fix = _fix_hint(unique_unmet)
+        all_requires = [token for method in spec.methods for token in method.requires]
+        tier = _resolve_tier(spec, all_requires)
+        fix = _resolve_fix_hint(spec, unique_unmet)
 
         results.append(
             ChannelStatus(
@@ -182,6 +183,14 @@ def format_report(results: list[ChannelStatus]) -> str:
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
+def _resolve_tier(spec: object, all_requires: list[str]) -> int:
+    """Resolve doctor tier from declared metadata first, then infer as fallback."""
+    declared_tier = getattr(spec, "tier", None)
+    if declared_tier is not None:
+        return declared_tier
+    return _compute_tier(all_requires)
+
+
 def _compute_tier(all_requires: list[str]) -> int:
     """Infer tier from a channel's full requires list.
 
@@ -202,6 +211,14 @@ def _compute_tier(all_requires: list[str]) -> int:
         elif kind in ("binary", "mcp"):
             return 1
     return 0
+
+
+def _resolve_fix_hint(spec: object, unmet_requires: list[str]) -> str:
+    """Resolve fix hint from declared metadata first, then infer as fallback."""
+    declared_fix_hint = getattr(spec, "fix_hint", None)
+    if isinstance(declared_fix_hint, str) and declared_fix_hint.strip():
+        return declared_fix_hint.strip()
+    return _fix_hint(unmet_requires)
 
 
 def _fix_hint(unmet_requires: list[str]) -> str:

--- a/autosearch/init/channel_status.py
+++ b/autosearch/init/channel_status.py
@@ -12,10 +12,12 @@ Status = Literal["available", "blocked", "scaffold-only"]
 TIER_ORDER: tuple[Tier, ...] = ("t0", "t1", "t2", "scaffold")
 TIER_LABELS: dict[Tier, str] = {
     "t0": "Tier 0 - always-on",
-    "t1": "Tier 1 - env-gated",
-    "t2": "Tier 2 - BYOK paid",
+    "t1": "Tier 1 - env/API gated",
+    "t2": "Tier 2 - login/cookie gated",
     "scaffold": "Scaffold-only (channel templates not shipped)",
 }
+
+_TIER2_REQUIRES_PATTERNS = ("COOKIES", "COOKIE", "SESSION", "SESSDATA", "AUTH_TOKEN")
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,6 +34,9 @@ def default_channels_root() -> Path:
 
 def infer_tier(metadata: ChannelMetadata) -> Tier:
     """Return the visibility tier for a channel based on shipped methods."""
+
+    if metadata.tier is not None:
+        return _DECLARED_TIER_MAP.get(metadata.tier, "t0")
 
     return infer_tier_from_requires(
         [method.skill_method.requires for method in shipped_methods(metadata)]
@@ -96,7 +101,7 @@ def infer_tier_from_requires(requires_by_method: list[list[str]]) -> Tier:
         return "scaffold"
     if any(not requires for requires in requires_by_method):
         return "t0"
-    if any("env:TIKHUB_API_KEY" in requires for requires in requires_by_method):
+    if any(_requires_login(tokens) for tokens in requires_by_method):
         return "t2"
     return "t1"
 
@@ -105,3 +110,17 @@ def required_env_tokens_from_requires(requires_by_method: list[list[str]]) -> li
     return sorted(
         {token for requires in requires_by_method for token in requires if token.startswith("env:")}
     )
+
+
+_DECLARED_TIER_MAP: dict[int, Tier] = {0: "t0", 1: "t1", 2: "t2"}
+
+
+def _requires_login(tokens: list[str]) -> bool:
+    for token in tokens:
+        kind, _, value = token.partition(":")
+        upper_value = value.upper()
+        if kind == "cookie":
+            return True
+        if kind == "env" and any(pattern in upper_value for pattern in _TIER2_REQUIRES_PATTERNS):
+            return True
+    return False

--- a/autosearch/skills/channels/discourse_forum/SKILL.md
+++ b/autosearch/skills/channels/discourse_forum/SKILL.md
@@ -12,6 +12,7 @@ fallback_chain: [api_search]
 when_to_use:
   query_languages: [zh, mixed]
   query_types: [community, developer, product-feedback, tech-discussion, chinese-ugc]
+  domain_hints: [linux.do, linux do, discourse, forum, claude code]
   avoid_for: [academic, consumer-lifestyle, multimedia]
 quality_hint:
   typical_yield: medium

--- a/autosearch/skills/channels/discourse_forum/SKILL.md
+++ b/autosearch/skills/channels/discourse_forum/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: discourse_forum
+description: Use for public Discourse-based community discussions, especially Linux DO, when queries need Chinese AI/dev forum posts and native operator troubleshooting.
+version: 1
+languages: [zh, mixed]
+methods:
+  - id: api_search
+    impl: methods/api_search.py
+    requires: []
+    rate_limit: {per_min: 20, per_hour: 400}
+fallback_chain: [api_search]
+when_to_use:
+  query_languages: [zh, mixed]
+  query_types: [community, developer, product-feedback, tech-discussion, chinese-ugc]
+  avoid_for: [academic, consumer-lifestyle, multimedia]
+quality_hint:
+  typical_yield: medium
+  chinese_native: true
+layer: leaf
+domains: [chinese-ugc]
+scenarios: [developer-community, ai-tools, troubleshooting, public-forum]
+model_tier: Fast
+---
+
+## Overview
+
+Public Discourse communities are a distinct forum surface: long-form troubleshooting, operator notes, product limitations, and community-native workarounds. This channel starts with Linux DO as the first built-in source.
+
+## How To Search
+
+- `api_search` — queries the site's public Discourse search endpoint and maps topic-oriented results into canonical topic URLs.
+
+## Known Quirks
+
+- Discourse search payloads can vary by site version and plugin stack.
+- Some public forums may block anonymous search or require region-specific network access.
+- v1 ships with a built-in Linux DO preset only; more Discourse communities can be added later through site presets.
+
+# Quality Bar
+
+- Evidence items have non-empty title and url.
+- Multiple posts from the same topic deduplicate to one evidence item.
+- HTTP or payload failures degrade to an empty result list.

--- a/autosearch/skills/channels/discourse_forum/methods/api_search.py
+++ b/autosearch/skills/channels/discourse_forum/methods/api_search.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import html
+import asyncio
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+
+from autosearch.core.models import Evidence, FetchedPage, SubQuery
+
+try:
+    from ddgs import DDGS
+except ImportError:  # pragma: no cover - compatibility fallback
+    from duckduckgo_search import DDGS  # type: ignore[import-not-found]
+
+LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="discourse_forum")
+
+DEFAULT_SITE_KEY = "linux_do"
+HTTP_TIMEOUT = 15.0
+MAX_RESULTS = 10
+MAX_SNIPPET_LENGTH = 300
+USER_AGENT = "AutoSearch/1.0 (+https://github.com/0xmariowu/Autosearch)"
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+JINA_READER_PREFIX = "https://r.jina.ai/"
+
+SITE_PRESETS: dict[str, dict[str, str]] = {
+    "linux_do": {
+        "base_url": "https://linux.do",
+        "search_endpoint": "/search.json",
+        "source_channel": "discourse_forum:linux_do",
+    }
+}
+
+
+def _normalize_whitespace(text: str) -> str:
+    return WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _clean_text(value: object) -> str:
+    text = HTML_TAG_RE.sub(" ", str(value or ""))
+    return _normalize_whitespace(html.unescape(text))
+
+
+def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    candidate = text[:max_length]
+    if candidate and not candidate[-1].isspace():
+        shortened = candidate.rsplit(None, 1)[0]
+        if shortened:
+            candidate = shortened
+
+    return f"{candidate.rstrip()}…"
+
+
+def _clean_site_search_title(title: str) -> str:
+    cleaned = title.strip()
+    if cleaned.endswith(" - LINUX DO"):
+        cleaned = cleaned[: -len(" - LINUX DO")].strip()
+    return cleaned
+
+
+def _reader_url(url: str) -> str:
+    return f"{JINA_READER_PREFIX}{url}"
+
+
+def _topic_url(post: Mapping[str, object], *, site: Mapping[str, str]) -> str | None:
+    topic_id = str(post.get("topic_id") or "").strip()
+    if not topic_id:
+        return None
+
+    slug = str(post.get("slug") or post.get("topic_slug") or "").strip().strip("/")
+    if slug:
+        return f"{site['base_url']}/t/{slug}/{topic_id}"
+    return f"{site['base_url']}/t/{topic_id}"
+
+
+def _to_evidence(
+    post: Mapping[str, object],
+    *,
+    site: Mapping[str, str],
+    fetched_at: datetime,
+) -> Evidence | None:
+    url = _topic_url(post, site=site)
+    if not url:
+        return None
+
+    title = (
+        _clean_text(post.get("topic_title_headline"))
+        or _clean_text(post.get("title"))
+        or _clean_text(post.get("fancy_title"))
+    )
+    if not title:
+        return None
+
+    content = _clean_text(post.get("blurb")) or None
+    snippet = (
+        _truncate_on_word_boundary(content, max_length=MAX_SNIPPET_LENGTH) if content else None
+    )
+
+    return Evidence(
+        url=url,
+        title=title,
+        snippet=snippet,
+        content=content,
+        source_channel=site["source_channel"],
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+def _site_search_query(site: Mapping[str, str], query: str) -> str:
+    domain = urlparse(site["base_url"]).netloc
+    return f"site:{domain} {query}"
+
+
+def _to_site_search_evidence(
+    result: Mapping[str, object],
+    *,
+    site: Mapping[str, str],
+    fetched_at: datetime,
+) -> Evidence | None:
+    href = str(result.get("href") or "").strip()
+    if not href.startswith(site["base_url"]):
+        return None
+    parsed = urlparse(href)
+    if "/t/" not in parsed.path:
+        return None
+
+    title = _clean_site_search_title(str(result.get("title") or "").strip())
+    if not title:
+        return None
+
+    content = _normalize_whitespace(str(result.get("body") or "").strip()) or None
+    snippet = (
+        _truncate_on_word_boundary(content, max_length=MAX_SNIPPET_LENGTH) if content else None
+    )
+
+    return Evidence(
+        url=href,
+        title=title,
+        snippet=snippet,
+        content=content,
+        source_channel=f"{site['source_channel']}:site_search",
+        fetched_at=fetched_at,
+        score=0.0,
+    )
+
+
+def _clean_jina_markdown(markdown: str) -> str:
+    cleaned = markdown.strip()
+    marker = "Markdown Content:"
+    if marker in cleaned:
+        cleaned = cleaned.split(marker, maxsplit=1)[1].strip()
+    return cleaned
+
+
+async def _fetch_topic_markdown(
+    url: str,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> str | None:
+    reader_url = _reader_url(url)
+    try:
+        if http_client is not None:
+            response = await http_client.get(reader_url, headers={"User-Agent": USER_AGENT})
+        else:
+            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
+                response = await client.get(reader_url, headers={"User-Agent": USER_AGENT})
+        response.raise_for_status()
+    except Exception:
+        return None
+
+    markdown = _clean_jina_markdown(response.text)
+    return markdown or None
+
+
+async def _enrich_evidence(
+    evidence: Evidence,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> Evidence:
+    markdown = await _fetch_topic_markdown(evidence.url, http_client=http_client)
+    if not markdown:
+        return evidence
+
+    source_page = FetchedPage(
+        url=evidence.url,
+        status_code=200,
+        markdown=markdown,
+        metadata={"reader_url": _reader_url(evidence.url), "title": evidence.title},
+    )
+    snippet = _truncate_on_word_boundary(
+        _normalize_whitespace(markdown),
+        max_length=MAX_SNIPPET_LENGTH,
+    )
+
+    return evidence.model_copy(
+        update={
+            "snippet": snippet or evidence.snippet,
+            "content": markdown,
+            "source_page": source_page,
+        }
+    )
+
+
+async def _search_site(query: SubQuery, *, site: Mapping[str, str]) -> list[Evidence]:
+    results = await asyncio.to_thread(
+        lambda: list(DDGS().text(_site_search_query(site, query.text), max_results=MAX_RESULTS))
+    )
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    seen_urls: set[str] = set()
+
+    for result in results:
+        if not isinstance(result, Mapping):
+            continue
+        evidence = _to_site_search_evidence(result, site=site, fetched_at=fetched_at)
+        if evidence is None or evidence.url in seen_urls:
+            continue
+        seen_urls.add(evidence.url)
+        evidences.append(evidence)
+        if len(evidences) >= MAX_RESULTS:
+            break
+
+    return evidences
+
+
+async def search(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    site_key: str = DEFAULT_SITE_KEY,
+) -> list[Evidence]:
+    site = SITE_PRESETS[site_key]
+    try:
+        params = {"q": query.text}
+        url = f"{site['base_url']}{site['search_endpoint']}"
+
+        if http_client is not None:
+            response = await http_client.get(
+                url,
+                params=params,
+                headers={"User-Agent": USER_AGENT},
+            )
+        else:
+            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
+                response = await client.get(
+                    url,
+                    params=params,
+                    headers={"User-Agent": USER_AGENT},
+                )
+
+        response.raise_for_status()
+        payload = response.json()
+        posts = payload.get("posts")
+        if not isinstance(posts, list):
+            raise ValueError("invalid posts payload")
+    except Exception as exc:
+        try:
+            evidences = await _search_site(query, site=site)
+        except Exception as fallback_exc:
+            LOGGER.warning(
+                "discourse_forum_search_failed",
+                reason=str(exc),
+                fallback_reason=str(fallback_exc),
+            )
+            return []
+        return await asyncio.gather(
+            *[_enrich_evidence(evidence, http_client=http_client) for evidence in evidences]
+        )
+
+    fetched_at = datetime.now(UTC)
+    evidences: list[Evidence] = []
+    seen_topic_ids: set[str] = set()
+
+    for post in posts:
+        if not isinstance(post, Mapping):
+            continue
+
+        topic_id = str(post.get("topic_id") or "").strip()
+        if topic_id and topic_id in seen_topic_ids:
+            continue
+
+        evidence = _to_evidence(post, site=site, fetched_at=fetched_at)
+        if evidence is None:
+            continue
+
+        if topic_id:
+            seen_topic_ids.add(topic_id)
+        evidences.append(evidence)
+        if len(evidences) >= MAX_RESULTS:
+            break
+
+    return await asyncio.gather(
+        *[_enrich_evidence(evidence, http_client=http_client) for evidence in evidences]
+    )

--- a/autosearch/skills/channels/discourse_forum/methods/api_search.py
+++ b/autosearch/skills/channels/discourse_forum/methods/api_search.py
@@ -121,6 +121,12 @@ def _site_search_query(site: Mapping[str, str], query: str) -> str:
     return f"site:{domain} {query}"
 
 
+def _same_origin(url: str, base_url: str) -> bool:
+    parsed_url = urlparse(url)
+    parsed_base = urlparse(base_url)
+    return parsed_url.scheme == parsed_base.scheme and parsed_url.netloc == parsed_base.netloc
+
+
 def _to_site_search_evidence(
     result: Mapping[str, object],
     *,
@@ -128,7 +134,7 @@ def _to_site_search_evidence(
     fetched_at: datetime,
 ) -> Evidence | None:
     href = str(result.get("href") or "").strip()
-    if not href.startswith(site["base_url"]):
+    if not _same_origin(href, site["base_url"]):
         return None
     parsed = urlparse(href)
     if "/t/" not in parsed.path:

--- a/autosearch/skills/loader.py
+++ b/autosearch/skills/loader.py
@@ -37,6 +37,7 @@ class MethodSpec(BaseModel):
 class WhenToUse(BaseModel):
     query_languages: list[Literal["zh", "en", "mixed"]] = Field(default_factory=list)
     query_types: list[str] = Field(default_factory=list)
+    domain_hints: list[str] = Field(default_factory=list)
     avoid_for: list[str] = Field(default_factory=list)
 
 
@@ -54,6 +55,12 @@ class SkillSpec(BaseModel):
     fallback_chain: list[str] = Field(default_factory=list)
     when_to_use: WhenToUse | None = None
     quality_hint: QualityHint | None = None
+    layer: str | None = None
+    domains: list[str] = Field(default_factory=list)
+    scenarios: list[str] = Field(default_factory=list)
+    model_tier: str | None = None
+    tier: int | None = Field(default=None, ge=0, le=2)
+    fix_hint: str | None = None
     skill_dir: Path
 
     @model_validator(mode="after")

--- a/docs/channels.mdx
+++ b/docs/channels.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Channels"
-description: "All 39 search channels — tiers, languages, and requirements"
+description: "All 40 search channels — tiers, languages, and requirements"
 ---
 
 AutoSearch organizes channels into three tiers. Run `autosearch doctor` to see live status.
 
-## Tier 0 — Always-on (26 channels)
+## Tier 0 — Always-on (27 channels)
 
 No configuration needed. Available immediately after install.
 
@@ -24,6 +24,7 @@ No configuration needed. Available immediately after install.
 | infoq_cn | zh, mixed | Chinese engineering articles from InfoQ 中文 | medium |
 | kr36 | zh, mixed | Chinese tech business news and startup funding from 36kr | medium |
 | linkedin | en, mixed | LinkedIn public company profiles and articles via Jina Reader | low |
+| discourse_forum | zh, mixed | Linux DO and Discourse-based public forum discussions | medium |
 | openalex | en, mixed | Scholarly works via OpenAlex open-access API | high |
 | package_search | en, mixed | PyPI and npm package discovery | medium |
 | papers | en, mixed | Multi-source academic search (arxiv + pubmed + biorxiv + more) | high |

--- a/docs/channels.mdx
+++ b/docs/channels.mdx
@@ -3,15 +3,16 @@ title: "Channels"
 description: "All 40 search channels — tiers, languages, and requirements"
 ---
 
-AutoSearch organizes channels into three tiers. Run `autosearch doctor` to see live status.
+AutoSearch organizes channels into three availability tiers. Run `autosearch doctor` to see live status.
 
-## Tier 0 — Always-on (27 channels)
+## Tier 0 — Always-on (28 channels)
 
 No configuration needed. Available immediately after install.
 
 | Channel | Languages | Description | Yield |
 |---|---|---|---|
 | arxiv | en | Academic preprints in CS/ML/physics | medium-high |
+| bilibili | zh, mixed | Chinese tech videos and tutorials | medium |
 | crossref | en | Cross-publisher scholarly search via DOI registry | medium |
 | dblp | en | Computer science bibliography — papers, proceedings | medium |
 | ddgs | en, mixed | DuckDuckGo web search, no auth required | medium |
@@ -39,39 +40,35 @@ No configuration needed. Available immediately after install.
 | wikidata | en, mixed | Structured entity data from Wikidata knowledge graph | medium |
 | wikipedia | en, mixed | Encyclopedia articles via Wikipedia Action API | high |
 
-## Tier 1 — Env-gated (2 channels)
+## Tier 1 — Env/API gated (10 channels)
 
-Requires a free API key or self-hosted URL.
+Requires an API key, self-hosted URL, or service token.
 
 | Channel | Languages | Setup | Yield |
 |---|---|---|---|
-| youtube | en, zh, mixed | `autosearch configure YOUTUBE_API_KEY <key>` ([get free key](https://console.cloud.google.com)) | medium |
+| douyin | zh | `autosearch configure TIKHUB_API_KEY <key>` | medium |
+| instagram | en, mixed | `autosearch configure TIKHUB_API_KEY <key>` | medium |
+| kuaishou | zh, mixed | `autosearch configure TIKHUB_API_KEY <key>` | medium |
 | searxng | en, zh, mixed | `autosearch configure SEARXNG_URL <url>` (self-hosted [SearXNG](https://docs.searxng.org)) | medium |
+| tiktok | en, mixed | `autosearch configure TIKHUB_API_KEY <key>` | medium |
+| twitter | en, mixed | `autosearch configure TIKHUB_API_KEY <key>` | medium |
+| wechat_channels | zh, mixed | `autosearch configure TIKHUB_API_KEY <key>` | medium |
+| weibo | zh, mixed | `autosearch configure TIKHUB_API_KEY <key>` | medium |
+| youtube | en, zh, mixed | `autosearch configure YOUTUBE_API_KEY <key>` ([get free key](https://console.cloud.google.com)) | medium |
+| zhihu | zh, mixed | `autosearch configure TIKHUB_API_KEY <key>` | medium-high |
 
-## Tier 2 — BYOK paid (10 channels)
+## Tier 2 — Login/cookie gated (2 channels)
 
-Requires a [TikHub](https://tikhub.io) API key for Chinese social platforms.
+Requires account cookies or login-backed setup.
 
-```bash
-autosearch configure TIKHUB_API_KEY <your-key>
-```
-
-| Channel | Languages | Description | Yield |
+| Channel | Languages | Setup | Yield |
 |---|---|---|---|
-| bilibili | zh, mixed | Chinese tech videos and tutorials | medium |
-| douyin | zh | Chinese short-video with product demos and tech reviews | medium |
-| instagram | en, mixed | Instagram public posts and reels search | medium |
-| kuaishou | zh, mixed | Chinese short-video platform | medium |
-| tiktok | en, mixed | Global short-video platform | medium |
-| twitter | en, mixed | Real-time public discourse and tech announcements | medium |
-| wechat_channels | zh, mixed | WeChat Channels (视频号) short videos | medium |
-| weibo | zh, mixed | Chinese microblog — trending topics, real-time opinion | medium |
-| xiaohongshu | zh, mixed | Chinese lifestyle notes with product/travel/food coverage | high |
-| zhihu | zh, mixed | Chinese Q&A with deep technical discussions | medium-high |
+| xiaohongshu | zh, mixed | `autosearch login xhs` or `autosearch configure XHS_A1_COOKIE <cookie>` | high |
+| xueqiu | zh, mixed | `autosearch login xueqiu` or `autosearch configure XUEQIU_COOKIES <cookie>` | medium |
 
 ## Login-based channels
 
-Some channels can be unlocked by logging in with your own account (using browser cookies):
+Some tier-2 channels can be unlocked by logging in with your own account (using browser cookies):
 
 ```bash
 autosearch login xhs        # Xiaohongshu
@@ -83,7 +80,7 @@ autosearch login instagram  # Instagram
 autosearch login linkedin   # LinkedIn
 ```
 
-**Xueqiu** (雪球, A-share/HK stock discussion) requires setting cookie env directly:
+**Xueqiu** (雪球, A-share/HK stock discussion) also supports setting cookie env directly:
 
 ```bash
 autosearch configure XUEQIU_COOKIES "<cookie-string>"

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,9 +1,9 @@
 ---
 title: "AutoSearch"
-description: "Deep research MCP server for AI developers — 39 channels, cited results, no hallucination"
+description: "Deep research MCP server for AI developers — 40 channels, cited results, no hallucination"
 ---
 
-AutoSearch is an MCP server that gives your AI agent access to 39 real search channels: academic databases, developer platforms, and Chinese social media. Every result is cited and deduplicated. No hallucination.
+AutoSearch is an MCP server that gives your AI agent access to 40 real search channels: academic databases, developer platforms, Chinese social media, and Linux DO forum coverage. Every result is cited and deduplicated. No hallucination.
 
 Works with **Claude Code**, **Cursor**, and any MCP-compatible client.
 
@@ -31,8 +31,8 @@ autosearch init
 ## What you get
 
 <CardGroup cols={2}>
-  <Card title="39 Search Channels" icon="magnifying-glass">
-    arxiv, PubMed, GitHub, Hacker News, Reddit, Xiaohongshu, Weibo, Twitter, Douyin, and more — English and Chinese, free and paid tiers.
+  <Card title="40 Search Channels" icon="magnifying-glass">
+    arxiv, PubMed, GitHub, Hacker News, Reddit, Linux DO, Xiaohongshu, Weibo, Twitter, Douyin, and more — English and Chinese, free and paid tiers.
   </Card>
   <Card title="22 MCP Tools" icon="wrench">
     `run_channel`, `delegate_subtask`, `consolidate_research`, citation management, deep research loops, and more.
@@ -63,7 +63,7 @@ run_clarify("latest transformer architectures for long-context 2026")
     Full install guide — MCP config, optional channels, troubleshooting
   </Card>
   <Card title="Channels" icon="list" href="/channels">
-    All 39 channels with tier, languages, and requirements
+    All 40 channels with tier, languages, and requirements
   </Card>
   <Card title="MCP Clients" icon="plug" href="/mcp-clients">
     Config samples for Claude Code, Cursor, and others

--- a/docs/plans/2026-04-24-channel-governance-v1-design.md
+++ b/docs/plans/2026-04-24-channel-governance-v1-design.md
@@ -1,0 +1,103 @@
+# Channel Governance V1
+
+## Goal
+
+Make channel onboarding and channel runtime governance derive from the same declared metadata instead of drifting across:
+
+- `SKILL.md` frontmatter
+- selector routing
+- doctor diagnostics
+- tiered channel docs / tables
+
+The immediate target is not a full policy engine. It is a bounded V1 that removes the highest-value sources of drift.
+
+## Problems This Change Fixes
+
+1. Channel routing membership was manually hardcoded in the selector, so adding a channel required editing code tables.
+2. `doctor` inferred capability tiers from env variable names, even when a channel had already declared its own tier and fix path.
+3. `init --check-channels` and `generate_channels_table.py` used a different tier model from `doctor`, which produced user-visible contradictions.
+4. The new `discourse_forum` channel exposed the gap between search discovery and best-effort full-content enrichment, but that behavior was not well-covered by regression tests.
+
+## V1 Decisions
+
+### 1. Skill frontmatter is the governance source of truth
+
+Channel metadata loaded into runtime now includes:
+
+- `layer`
+- `domains`
+- `scenarios`
+- `model_tier`
+- `tier`
+- `fix_hint`
+- `when_to_use.domain_hints`
+
+These fields remain declared in `SKILL.md`, then compiled into runtime metadata.
+
+### 2. Selector is metadata-driven for membership
+
+The selector no longer owns a hardcoded `group -> channels` table.
+
+Instead it:
+
+- scans channel `SKILL.md` files
+- derives domain membership from frontmatter
+- scores channels using declared `domains`, `scenarios`, `query_types`, and `domain_hints`
+- keeps a small alias / keyword layer only for query understanding, not for membership ownership
+
+This means adding a new channel to an existing domain does not require updating selector membership tables.
+
+### 3. Declared tier overrides inferred tier
+
+If a channel declares:
+
+- `tier`
+- `fix_hint`
+
+then:
+
+- `doctor`
+- `init --check-channels`
+- generated channel tables
+
+must all respect that declaration before falling back to heuristics.
+
+This is required because login-gated channels like `xueqiu` cannot be modeled correctly by generic env-name inference alone.
+
+### 4. Tier semantics are unified
+
+V1 tier meanings:
+
+- `t0`: always-on
+- `t1`: env/API gated
+- `t2`: login/cookie gated
+- `scaffold`: template exists but no shipped implementation
+
+These semantics replace the older mixed interpretation where some surfaces treated tier 2 as “paid”.
+
+### 5. Full-content enrichment is regression-covered
+
+`discourse_forum` now has explicit regression coverage for:
+
+- canonical topic URL construction
+- API failure to site-search fallback
+- fallback search to Jina reader full-content enrichment
+- populated `source_page` metadata
+
+## Non-Goals
+
+- No dynamic routing based on live success-rate telemetry yet.
+- No cost-aware policy engine yet.
+- No automatic detail-fetch policy for every channel yet.
+- No rewrite of the MCP `list_skills` catalog path yet.
+
+## Next Step
+
+V2 should add a lightweight policy layer that can consume:
+
+- declared metadata
+- recent channel health
+- cost / auth mode
+- detail-fetch capability
+
+and make routing decisions with the same vocabulary already introduced here.

--- a/docs/plans/2026-04-24-discourse-forum-design.md
+++ b/docs/plans/2026-04-24-discourse-forum-design.md
@@ -1,0 +1,89 @@
+# Discourse Forum Channel Design
+
+Date: 2026-04-24
+
+## Goal
+
+Add a reusable forum-search capability for public Discourse communities, with Linux DO as the first built-in source, and validate it with TDD before pitching the change.
+
+## Why
+
+AutoSearch already covers multiple community surfaces such as Reddit, Hacker News, Tieba, and V2EX. It does not yet cover Discourse-based communities, which are common in developer and AI product ecosystems.
+
+Linux DO is a strong first target because it contains high-signal Chinese discussions around AI tools, developer workflows, and product troubleshooting. Implementing this as a reusable Discourse capability is more valuable than a one-off Linux DO scraper.
+
+## Scope
+
+In scope:
+
+- Add a new channel at `autosearch/skills/channels/discourse_forum/`
+- Support a built-in `linux_do` site preset
+- Query the public Discourse search endpoint and map results into `Evidence`
+- Add focused channel tests and run the repo's required fast test suite
+
+Out of scope for v1:
+
+- Login-required or private Discourse forums
+- Multi-site runtime configuration
+- Ranking by likes/replies/views beyond basic result mapping
+- Live validation that depends on network paths unavailable in the current environment
+
+## Design
+
+### Channel shape
+
+Create a single new channel named `discourse_forum`.
+
+The implementation will keep a small site registry in Python, with `linux_do` as the first preset. The search method will choose the preset internally for now, keeping the external channel surface simple and compatible with the current registry model.
+
+### Search flow
+
+1. Receive `SubQuery`
+2. Build a request to the public Discourse search endpoint for the `linux.do` preset
+3. Parse topic-oriented search results from JSON
+4. If the site blocks anonymous API search, fall back to site-limited public search
+5. Normalize each item into `Evidence`
+6. Return an empty list only if both paths fail
+
+### Evidence mapping
+
+Each result should include:
+
+- Canonical topic URL on `linux.do`
+- Non-empty title
+- Snippet/body excerpt when available
+- `source_channel="discourse_forum:linux_do"`
+- Stable fetch timestamp
+
+Items missing enough information to build a canonical URL should be skipped.
+
+## Testing Strategy
+
+TDD order:
+
+1. Add failing tests for successful mapping
+2. Add failing tests for malformed payloads and transport failures
+3. Implement the minimum logic to make tests pass
+4. Run the repo's required fast unit suite
+
+Initial coverage:
+
+- Search returns evidence from a valid Discourse payload
+- Missing title falls back sensibly when possible
+- Missing URL-building fields are skipped
+- HTTP failures degrade to `[]`
+- Invalid payload shape degrades to `[]`
+
+## Risks
+
+- Discourse search payloads can vary across versions or site settings
+- The current environment may not be able to reach `linux.do` for live verification
+
+These risks are contained because the failure mode is an empty result set and the tests will lock the expected parsing behavior.
+
+## Success Criteria
+
+- New channel compiles from `SKILL.md`
+- New channel tests pass
+- Required fast unit suite passes
+- Final pitch can show: design, tests, implementation, and validation evidence

--- a/scripts/generate_channels_table.py
+++ b/scripts/generate_channels_table.py
@@ -87,6 +87,7 @@ def load_channel_rows(channels_root: Path) -> list[ChannelDocRow]:
             typical_yield = str(quality_hint.get("typical_yield", "unknown"))
 
         requires_by_method = shipped_method_requires(payload, skill_path.parent)
+        declared_tier = payload.get("tier")
         rows.append(
             ChannelDocRow(
                 name=name,
@@ -94,7 +95,7 @@ def load_channel_rows(channels_root: Path) -> list[ChannelDocRow]:
                 languages=[str(language) for language in payload.get("languages", [])],
                 required_env=required_env_tokens_from_requires(requires_by_method),
                 typical_yield=typical_yield,
-                tier=infer_tier_from_requires(requires_by_method),
+                tier=_resolve_doc_tier(declared_tier, requires_by_method),
             )
         )
 
@@ -223,6 +224,14 @@ def shipped_method_requires(payload: dict[str, Any], skill_dir: Path) -> list[li
         requires_by_method.append([str(token) for token in requires])
 
     return requires_by_method
+
+
+def _resolve_doc_tier(declared_tier: object, requires_by_method: list[list[str]]) -> str:
+    if isinstance(declared_tier, int):
+        return {0: "t0", 1: "t1", 2: "t2"}.get(
+            declared_tier, infer_tier_from_requires(requires_by_method)
+        )
+    return infer_tier_from_requires(requires_by_method)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_channels_table.py
+++ b/scripts/generate_channels_table.py
@@ -227,10 +227,14 @@ def shipped_method_requires(payload: dict[str, Any], skill_dir: Path) -> list[li
 
 
 def _resolve_doc_tier(declared_tier: object, requires_by_method: list[list[str]]) -> str:
-    if isinstance(declared_tier, int):
-        return {0: "t0", 1: "t1", 2: "t2"}.get(
-            declared_tier, infer_tier_from_requires(requires_by_method)
-        )
+    if declared_tier is None:
+        return infer_tier_from_requires(requires_by_method)
+    if isinstance(declared_tier, bool) or not isinstance(declared_tier, int):
+        raise ValueError(f"tier must be an int in 0..2, got {declared_tier!r}")
+    if declared_tier not in (0, 1, 2):
+        raise ValueError(f"tier must be in 0..2, got {declared_tier}")
+    if declared_tier in (0, 1, 2):
+        return {0: "t0", 1: "t1", 2: "t2"}[declared_tier]
     return infer_tier_from_requires(requires_by_method)
 
 

--- a/tests/channels/discourse_forum/test_api_search.py
+++ b/tests/channels/discourse_forum/test_api_search.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "autosearch"
+        / "skills"
+        / "channels"
+        / "discourse_forum"
+        / "methods"
+        / "api_search.py"
+    )
+    spec = importlib.util.spec_from_file_location("test_discourse_forum_api_search", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+search = MODULE.search
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append((event, kwargs))
+
+
+def _query() -> SubQuery:
+    return SubQuery(text="claude code", rationale="Need Linux DO and Discourse forum coverage")
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_search_maps_discourse_posts_to_evidence() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://linux.do/search.json?q=claude+code":
+            return httpx.Response(
+                200,
+                json={
+                    "posts": [
+                        {
+                            "topic_id": 1799314,
+                            "topic_title_headline": 'Claude <span class="search-highlight">Code</span> 对非官方 API 的功能限制分析',
+                            "blurb": '这里整理了 <span class="search-highlight">Claude</span> Code 与 Tool Search 的实际限制。',
+                        },
+                        {
+                            "topic_id": 1064521,
+                            "topic_title_headline": "LinuxDo 批量检索导出",
+                            "blurb": "搜索话题并批量拉取全文后导出。",
+                        },
+                    ]
+                },
+                request=request,
+            )
+        if str(request.url) == "https://r.jina.ai/https://linux.do/t/1799314":
+            return httpx.Response(
+                200,
+                text=(
+                    "Title: Claude Code 对非官方 API 的功能限制分析 - LINUX DO\n\n"
+                    "URL Source: https://linux.do/t/1799314\n\n"
+                    "Markdown Content:\n"
+                    "完整正文第一段。\n\n完整正文第二段。"
+                ),
+                request=request,
+            )
+        if str(request.url) == "https://r.jina.ai/https://linux.do/t/1064521":
+            return httpx.Response(
+                200,
+                text=(
+                    "Title: LinuxDo 批量检索导出 - LINUX DO\n\n"
+                    "URL Source: https://linux.do/t/1064521\n\n"
+                    "Markdown Content:\n"
+                    "导出帖子的完整内容。"
+                ),
+                request=request,
+            )
+        raise AssertionError(f"Unexpected URL: {request.url}")
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.url == "https://linux.do/t/1799314"
+    assert first.title == "Claude Code 对非官方 API 的功能限制分析"
+    assert first.snippet == "完整正文第一段。 完整正文第二段。"
+    assert first.content == "完整正文第一段。\n\n完整正文第二段。"
+    assert first.source_channel == "discourse_forum:linux_do"
+    assert first.source_page is not None
+    assert first.source_page.markdown == "完整正文第一段。\n\n完整正文第二段。"
+
+    second = results[1]
+    assert second.url == "https://linux.do/t/1064521"
+    assert second.title == "LinuxDo 批量检索导出"
+    assert second.content == "导出帖子的完整内容。"
+
+
+@pytest.mark.asyncio
+async def test_search_deduplicates_multiple_posts_from_same_topic() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "posts": [
+                    {
+                        "topic_id": 1799314,
+                        "topic_title_headline": "Same topic",
+                        "blurb": "First blurb",
+                    },
+                    {
+                        "topic_id": 1799314,
+                        "topic_title_headline": "Same topic duplicate",
+                        "blurb": "Second blurb",
+                    },
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://linux.do/t/1799314"
+    assert results[0].title == "Same topic"
+
+
+@pytest.mark.asyncio
+async def test_search_skips_posts_without_topic_id() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "posts": [
+                    {
+                        "topic_title_headline": "Missing topic id",
+                        "blurb": "Cannot build canonical URL",
+                    }
+                ]
+            },
+            request=request,
+        )
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+    monkeypatch.setattr(MODULE, "DDGS", lambda: (_ for _ in ()).throw(Exception("ddgs blocked")))
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": "forbidden"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events
+    assert logger.events[0][0] == "discourse_forum_search_failed"
+    assert "403" in str(logger.events[0][1]["reason"])
+    assert logger.events[0][1]["fallback_reason"] == "ddgs blocked"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_malformed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+    monkeypatch.setattr(MODULE, "DDGS", lambda: (_ for _ in ()).throw(Exception("ddgs blocked")))
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"topics": []}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert results == []
+    assert logger.events == [
+        (
+            "discourse_forum_search_failed",
+            {"reason": "invalid posts payload", "fallback_reason": "ddgs blocked"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_site_search_when_api_is_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeDDGS:
+        def text(self, query: str, *, max_results: int):
+            assert query == "site:linux.do claude code"
+            assert max_results == 10
+            return [
+                {
+                    "title": "LINUX DO - 新的理想型社区",
+                    "href": "https://linux.do/latest",
+                    "body": "This is only a topic list page and should be ignored.",
+                },
+                {
+                    "title": "Claude Code 入门 - 开发调优 - LINUX DO",
+                    "href": "https://linux.do/t/topic/1798141",
+                    "body": "整理了 Claude Code 的上手经验和限制。",
+                }
+            ]
+
+    monkeypatch.setattr(MODULE, "DDGS", _FakeDDGS)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": "forbidden"}, request=request)
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://linux.do/t/topic/1798141"
+    assert results[0].title == "Claude Code 入门 - 开发调优"
+    assert results[0].snippet == "整理了 Claude Code 的上手经验和限制。"
+    assert results[0].source_channel == "discourse_forum:linux_do:site_search"
+
+
+@pytest.mark.asyncio
+async def test_search_preserves_search_snippet_when_topic_enrichment_fails() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://linux.do/search.json?q=claude+code":
+            return httpx.Response(
+                200,
+                json={
+                    "posts": [
+                        {
+                            "topic_id": 1799314,
+                            "topic_title_headline": "Search title",
+                            "blurb": "Search summary only",
+                        }
+                    ]
+                },
+                request=request,
+            )
+        if str(request.url) == "https://r.jina.ai/https://linux.do/t/1799314":
+            return httpx.Response(403, text="forbidden", request=request)
+        raise AssertionError(f"Unexpected URL: {request.url}")
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].title == "Search title"
+    assert results[0].snippet == "Search summary only"
+    assert results[0].content == "Search summary only"
+    assert results[0].source_page is None

--- a/tests/channels/discourse_forum/test_api_search.py
+++ b/tests/channels/discourse_forum/test_api_search.py
@@ -224,7 +224,11 @@ async def test_search_uses_slug_canonical_topic_url_for_enrichment() -> None:
 async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
-    monkeypatch.setattr(MODULE, "DDGS", lambda: (_ for _ in ()).throw(Exception("ddgs blocked")))
+
+    def _ddgs_blocked() -> object:
+        raise Exception("ddgs blocked")
+
+    monkeypatch.setattr(MODULE, "DDGS", _ddgs_blocked)
 
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(403, json={"error": "forbidden"}, request=request)
@@ -245,7 +249,11 @@ async def test_search_returns_empty_on_malformed_payload(
 ) -> None:
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
-    monkeypatch.setattr(MODULE, "DDGS", lambda: (_ for _ in ()).throw(Exception("ddgs blocked")))
+
+    def _ddgs_blocked() -> object:
+        raise Exception("ddgs blocked")
+
+    monkeypatch.setattr(MODULE, "DDGS", _ddgs_blocked)
 
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"topics": []}, request=request)
@@ -275,6 +283,11 @@ async def test_search_falls_back_to_site_search_when_api_is_blocked(
                     "title": "LINUX DO - 新的理想型社区",
                     "href": "https://linux.do/latest",
                     "body": "This is only a topic list page and should be ignored.",
+                },
+                {
+                    "title": "Hostile mirror should be ignored",
+                    "href": "https://linux.do.evil.example/t/topic/999999",
+                    "body": "This should never be accepted as Linux DO evidence.",
                 },
                 {
                     "title": "Claude Code 入门 - 开发调优 - LINUX DO",

--- a/tests/channels/discourse_forum/test_api_search.py
+++ b/tests/channels/discourse_forum/test_api_search.py
@@ -106,7 +106,13 @@ async def test_search_maps_discourse_posts_to_evidence() -> None:
     assert first.content == "完整正文第一段。\n\n完整正文第二段。"
     assert first.source_channel == "discourse_forum:linux_do"
     assert first.source_page is not None
+    assert first.source_page.url == "https://linux.do/t/1799314"
+    assert first.source_page.status_code == 200
     assert first.source_page.markdown == "完整正文第一段。\n\n完整正文第二段。"
+    assert first.source_page.metadata == {
+        "reader_url": "https://r.jina.ai/https://linux.do/t/1799314",
+        "title": "Claude Code 对非官方 API 的功能限制分析",
+    }
 
     second = results[1]
     assert second.url == "https://linux.do/t/1064521"
@@ -164,6 +170,54 @@ async def test_search_skips_posts_without_topic_id() -> None:
         results = await search(_query(), http_client=http_client)
 
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_uses_slug_canonical_topic_url_for_enrichment() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://linux.do/search.json?q=claude+code":
+            return httpx.Response(
+                200,
+                json={
+                    "posts": [
+                        {
+                            "topic_id": 760680,
+                            "slug": "claude-code-shang-shou-zhi-nan",
+                            "topic_title_headline": 'Claude <span class="search-highlight">Code</span> 上手指南',
+                            "blurb": "帖子摘要。",
+                        }
+                    ]
+                },
+                request=request,
+            )
+        if (
+            str(request.url)
+            == "https://r.jina.ai/https://linux.do/t/claude-code-shang-shou-zhi-nan/760680"
+        ):
+            return httpx.Response(
+                200,
+                text=(
+                    "Title: Claude Code 上手指南 - LINUX DO\n\n"
+                    "URL Source: https://linux.do/t/claude-code-shang-shou-zhi-nan/760680\n\n"
+                    "Markdown Content:\n"
+                    "这里是完整正文。"
+                ),
+                request=request,
+            )
+        raise AssertionError(f"Unexpected URL: {request.url}")
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://linux.do/t/claude-code-shang-shou-zhi-nan/760680"
+    assert results[0].snippet == "这里是完整正文。"
+    assert results[0].content == "这里是完整正文。"
+    assert results[0].source_page is not None
+    assert results[0].source_page.metadata == {
+        "reader_url": "https://r.jina.ai/https://linux.do/t/claude-code-shang-shou-zhi-nan/760680",
+        "title": "Claude Code 上手指南",
+    }
 
 
 @pytest.mark.asyncio
@@ -226,7 +280,7 @@ async def test_search_falls_back_to_site_search_when_api_is_blocked(
                     "title": "Claude Code 入门 - 开发调优 - LINUX DO",
                     "href": "https://linux.do/t/topic/1798141",
                     "body": "整理了 Claude Code 的上手经验和限制。",
-                }
+                },
             ]
 
     monkeypatch.setattr(MODULE, "DDGS", _FakeDDGS)
@@ -242,6 +296,56 @@ async def test_search_falls_back_to_site_search_when_api_is_blocked(
     assert results[0].title == "Claude Code 入门 - 开发调优"
     assert results[0].snippet == "整理了 Claude Code 的上手经验和限制。"
     assert results[0].source_channel == "discourse_forum:linux_do:site_search"
+
+
+@pytest.mark.asyncio
+async def test_search_enriches_site_search_results_with_full_topic_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeDDGS:
+        def text(self, query: str, *, max_results: int):
+            assert query == "site:linux.do claude code"
+            assert max_results == 10
+            return [
+                {
+                    "title": "Claude Code 小白指引贴 - 文档共建 - LINUX DO",
+                    "href": "https://linux.do/t/topic/743319",
+                    "body": "搜索摘要不应该保留为最终正文。",
+                }
+            ]
+
+    monkeypatch.setattr(MODULE, "DDGS", _FakeDDGS)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://linux.do/search.json?q=claude+code":
+            return httpx.Response(403, json={"error": "forbidden"}, request=request)
+        if str(request.url) == "https://r.jina.ai/https://linux.do/t/topic/743319":
+            return httpx.Response(
+                200,
+                text=(
+                    "Title: Claude Code 小白指引贴 - 文档共建 - LINUX DO\n\n"
+                    "URL Source: https://linux.do/t/topic/743319\n\n"
+                    "Markdown Content:\n"
+                    "完整正文第一段。\n\n完整正文第二段。"
+                ),
+                request=request,
+            )
+        raise AssertionError(f"Unexpected URL: {request.url}")
+
+    async with _client(handler) as http_client:
+        results = await search(_query(), http_client=http_client)
+
+    assert len(results) == 1
+    assert results[0].url == "https://linux.do/t/topic/743319"
+    assert results[0].title == "Claude Code 小白指引贴 - 文档共建"
+    assert results[0].snippet == "完整正文第一段。 完整正文第二段。"
+    assert results[0].content == "完整正文第一段。\n\n完整正文第二段。"
+    assert results[0].source_channel == "discourse_forum:linux_do:site_search"
+    assert results[0].source_page is not None
+    assert results[0].source_page.metadata == {
+        "reader_url": "https://r.jina.ai/https://linux.do/t/topic/743319",
+        "title": "Claude Code 小白指引贴 - 文档共建",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/fixtures/skills/valid_channel/SKILL.md
+++ b/tests/fixtures/skills/valid_channel/SKILL.md
@@ -20,10 +20,17 @@ fallback_chain: [api_search, api_detail]
 when_to_use:
   query_languages: [zh, en]
   query_types: [academic-papers, literature-review]
+  domain_hints: [citations, scholarly-search]
   avoid_for: [real-time-news]
 quality_hint:
   typical_yield: medium-high
   chinese_native: false
+layer: leaf
+domains: [academic]
+scenarios: [paper-search, detail-hydration]
+model_tier: Standard
+tier: 1
+fix_hint: "autosearch configure ARXIV_TOKEN <value>"
 ---
 
 Prefer the search endpoint first, then hydrate selected records with the detail method.

--- a/tests/test_channel_select.py
+++ b/tests/test_channel_select.py
@@ -2,16 +2,7 @@
 
 from __future__ import annotations
 
-import importlib
-from pathlib import Path
-
-import pytest
-
-_MODULE_PATH = Path(__file__).resolve().parents[1] / "autosearch" / "core" / "channel_select.py"
-if not _MODULE_PATH.is_file():
-    pytest.skip("legacy channel_select runtime removed from workspace", allow_module_level=True)
-
-select_channels = importlib.import_module("autosearch.core.channel_select").select_channels
+from autosearch.core.channel_select import select_channels
 
 
 def test_chinese_query_selects_chinese_ugc():

--- a/tests/test_channel_select.py
+++ b/tests/test_channel_select.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from autosearch.core.channel_select import select_channels
+import importlib
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "autosearch" / "core" / "channel_select.py"
+if not _MODULE_PATH.is_file():
+    pytest.skip("legacy channel_select runtime removed from workspace", allow_module_level=True)
+
+select_channels = importlib.import_module("autosearch.core.channel_select").select_channels
 
 
 def test_chinese_query_selects_chinese_ugc():

--- a/tests/unit/test_channel_registry.py
+++ b/tests/unit/test_channel_registry.py
@@ -56,6 +56,52 @@ def test_compile_from_skills_method_unavailable_with_unmet_requires() -> None:
     assert "cookie:stub_cookie" in metadata.methods[0].unmet_requires
 
 
+def test_compile_from_skills_preserves_declared_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "channels"
+    _write_channel_skill(
+        root,
+        name="metadata_stub",
+        skill_text="""
+        ---
+        name: metadata_stub
+        description: "Fixture channel with declared routing metadata."
+        version: 1
+        languages: [zh, mixed]
+        methods:
+          - id: api_search
+            impl: methods/api_search.py
+            requires: [env:STUB_COOKIE]
+        fallback_chain: [api_search]
+        when_to_use:
+          query_languages: [zh, mixed]
+          query_types: [community, troubleshooting]
+          domain_hints: [linux.do, discourse]
+        quality_hint:
+          typical_yield: medium
+          chinese_native: true
+        layer: leaf
+        domains: [chinese-ugc]
+        scenarios: [developer-community, public-forum]
+        model_tier: Fast
+        tier: 2
+        fix_hint: "autosearch login metadata_stub"
+        ---
+        """,
+    )
+
+    registry = ChannelRegistry.compile_from_skills(root, Environment())
+    metadata = registry.metadata("metadata_stub")
+
+    assert metadata.layer == "leaf"
+    assert metadata.domains == ["chinese-ugc"]
+    assert metadata.scenarios == ["developer-community", "public-forum"]
+    assert metadata.model_tier == "Fast"
+    assert metadata.tier == 2
+    assert metadata.fix_hint == "autosearch login metadata_stub"
+    assert metadata.when_to_use is not None
+    assert metadata.when_to_use.domain_hints == ["linux.do", "discourse"]
+
+
 def test_compile_from_skills_impl_missing_marks_unavailable(tmp_path: Path) -> None:
     root = tmp_path / "channels"
     _write_channel_skill(

--- a/tests/unit/test_channel_select_discourse.py
+++ b/tests/unit/test_channel_select_discourse.py
@@ -8,3 +8,10 @@ def test_linux_do_query_selects_discourse_forum() -> None:
 
     assert "chinese-ugc" in result["groups"]
     assert "discourse_forum" in result["channels"]
+
+
+def test_x_alias_keeps_twitter_routing() -> None:
+    result = select_channels("X 上对 Claude Code 的讨论")
+
+    assert "social-career" in result["groups"]
+    assert "twitter" in result["channels"]

--- a/tests/unit/test_channel_select_discourse.py
+++ b/tests/unit/test_channel_select_discourse.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from autosearch.core.channel_select import select_channels
+
+
+def test_linux_do_query_selects_discourse_forum() -> None:
+    result = select_channels("Linux DO 上关于 Claude Code 的讨论多吗")
+
+    assert "chinese-ugc" in result["groups"]
+    assert "discourse_forum" in result["channels"]

--- a/tests/unit/test_channel_select_metadata.py
+++ b/tests/unit/test_channel_select_metadata.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from autosearch.core import channel_select
+from autosearch.core.channel_select import ChannelRouteSpec, select_channels
+
+
+def test_selector_prefers_channel_alias_match_within_metadata_domain() -> None:
+    result = select_channels("小红书上有没有人用 Cursor")
+
+    assert "chinese-ugc" in result["groups"]
+    assert result["channels"][0] == "xiaohongshu"
+
+
+def test_selector_uses_metadata_catalog_for_domain_membership(monkeypatch) -> None:
+    monkeypatch.setattr(
+        channel_select,
+        "_load_channel_route_catalog",
+        lambda: (
+            ChannelRouteSpec(
+                name="custom_paper",
+                domains=("academic",),
+                scenarios=("benchmark",),
+                query_types=("paper-review",),
+                query_languages=("en",),
+                aliases=("custom paper",),
+                keywords=("benchmark", "paper", "review"),
+            ),
+        ),
+    )
+
+    result = select_channels("recent paper benchmark")
+
+    assert result["groups"] == ["academic"]
+    assert result["channels"] == ["custom_paper"]
+
+
+def test_selector_mixes_domains_from_metadata_catalog() -> None:
+    result = select_channels("deep research across bilibili arxiv github", mode="deep")
+
+    assert "chinese-ugc" in result["groups"]
+    assert "academic" in result["groups"]
+    assert "code-package" in result["groups"]
+    assert "bilibili" in result["channels"]
+    assert "arxiv" in result["channels"]
+    assert "github" in result["channels"]

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -24,6 +24,7 @@ def test_all_channels_loadable() -> None:
         "dblp",
         "ddgs",
         "devto",
+        "discourse_forum",
         "dockerhub",
         "douyin",
         "github",
@@ -89,6 +90,7 @@ def test_chinese_native_channels_cover_11() -> None:
 
     assert chinese_native == {
         "bilibili",
+        "discourse_forum",
         "douyin",
         "infoq_cn",
         "kuaishou",
@@ -102,7 +104,7 @@ def test_chinese_native_channels_cover_11() -> None:
         "xueqiu",
         "zhihu",
     }
-    assert len(chinese_native) == 13
+    assert len(chinese_native) == 14
 
 
 def test_shipped_method_impls_exist_for_registry_channels() -> None:
@@ -115,6 +117,7 @@ def test_shipped_method_impls_exist_for_registry_channels() -> None:
         "dblp": ["methods/api_search.py"],
         "ddgs": ["methods/api.py"],
         "devto": ["methods/api_search.py"],
+        "discourse_forum": ["methods/api_search.py"],
         "dockerhub": ["methods/api_search.py"],
         "douyin": ["methods/via_tikhub.py"],
         "github": ["methods/search_public_repos.py"],
@@ -165,6 +168,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         "dblp",
         "ddgs",
         "devto",
+        "discourse_forum",
         "dockerhub",
         "github",
         "google_news",
@@ -195,6 +199,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             "dblp": "methods/api_search.py",
             "ddgs": "methods/api.py",
             "devto": "methods/api_search.py",
+            "discourse_forum": "methods/api_search.py",
             "dockerhub": "methods/api_search.py",
             "google_news": "methods/api_search.py",
             "hackernews": "methods/algolia.py",

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -81,7 +81,7 @@ def test_fallback_chain_matches_methods() -> None:
         assert set(spec.fallback_chain).issubset(method_ids)
 
 
-def test_chinese_native_channels_cover_11() -> None:
+def test_chinese_native_channels_cover_expected_set() -> None:
     chinese_native = {
         spec.name
         for spec in _load_specs()

--- a/tests/unit/test_channel_status.py
+++ b/tests/unit/test_channel_status.py
@@ -42,6 +42,12 @@ def _metadata(name: str, *methods: CompiledMethod) -> ChannelMetadata:
         languages=["en"],
         when_to_use=None,
         quality_hint=None,
+        layer="leaf",
+        domains=[],
+        scenarios=[],
+        model_tier="Fast",
+        tier=None,
+        fix_hint=None,
         methods=list(methods),
         fallback_chain=[method.id for method in methods],
     )
@@ -75,7 +81,7 @@ def test_infer_tier_t0_when_shipped_no_requires() -> None:
     assert infer_tier(metadata) == "t0"
 
 
-def test_infer_tier_t2_when_tikhub_required() -> None:
+def test_infer_tier_t1_when_tikhub_required() -> None:
     metadata = _metadata(
         "zhihu",
         _method(
@@ -92,7 +98,7 @@ def test_infer_tier_t2_when_tikhub_required() -> None:
         ),
     )
 
-    assert infer_tier(metadata) == "t2"
+    assert infer_tier(metadata) == "t1"
 
 
 def test_infer_tier_t1_when_env_required_not_tikhub() -> None:
@@ -107,6 +113,35 @@ def test_infer_tier_t1_when_env_required_not_tikhub() -> None:
     )
 
     assert infer_tier(metadata) == "t1"
+
+
+def test_infer_tier_t2_when_cookie_env_required() -> None:
+    metadata = _metadata(
+        "xueqiu",
+        _method(
+            method_id="api_search",
+            requires=["env:XUEQIU_COOKIES"],
+            available=False,
+            unmet_requires=["env:XUEQIU_COOKIES"],
+        ),
+    )
+
+    assert infer_tier(metadata) == "t2"
+
+
+def test_infer_tier_prefers_declared_skill_tier() -> None:
+    metadata = _metadata(
+        "declared_login",
+        _method(
+            method_id="api_search",
+            requires=["env:SERVICE_KEY"],
+            available=False,
+            unmet_requires=["env:SERVICE_KEY"],
+        ),
+    )
+    metadata.tier = 2
+
+    assert infer_tier(metadata) == "t2"
 
 
 def test_infer_tier_scaffold_when_all_methods_impl_missing() -> None:
@@ -139,8 +174,8 @@ def test_check_channels_command_groups_by_tier(monkeypatch: pytest.MonkeyPatch) 
                     unmet_requires=["env:YOUTUBE_API_KEY"],
                 ),
             ),
-            "paid": _metadata(
-                "paid",
+            "api_key_only": _metadata(
+                "api_key_only",
                 _method(
                     method_id="via_tikhub",
                     requires=["env:TIKHUB_API_KEY"],
@@ -172,8 +207,7 @@ def test_check_channels_command_groups_by_tier(monkeypatch: pytest.MonkeyPatch) 
 
     assert result.exit_code == 0
     assert "Tier 0 - always-on (1)" in result.stdout
-    assert "Tier 1 - env-gated (1)" in result.stdout
-    assert "Tier 2 - BYOK paid (1)" in result.stdout
+    assert "Tier 1 - env/API gated (2)" in result.stdout
     assert "Scaffold-only (channel templates not shipped) (1)" in result.stdout
     assert "Total: 4 channels | 1 available | 2 blocked | 1 scaffold-only" in result.stdout
 

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -9,7 +9,13 @@ from unittest.mock import patch
 from autosearch.core.doctor import format_report, scan_channels
 
 
-def _make_spec(name: str, requires: list[str]):
+def _make_spec(
+    name: str,
+    requires: list[str],
+    *,
+    tier: int | None = None,
+    fix_hint: str | None = None,
+):
     """Build a minimal SkillSpec-like object for mocking."""
     from autosearch.skills.loader import MethodSpec, SkillSpec
 
@@ -18,6 +24,8 @@ def _make_spec(name: str, requires: list[str]):
         name=name,
         description="test",
         methods=[method],
+        tier=tier,
+        fix_hint=fix_hint,
         skill_dir=Path(f"/fake/skills/channels/{name}"),
     )
 
@@ -97,3 +105,55 @@ def test_format_report_does_not_suggest_nonexistent_fix_flag(tmp_path):
 
     report = format_report(results)
     assert "doctor --fix" not in report, "report still points to the non-existent --fix flag"
+
+
+def test_scan_channels_prefers_declared_doctor_metadata(tmp_path):
+    specs = [
+        _make_spec(
+            "xueqiu",
+            ["env:XUEQIU_COOKIES"],
+            tier=2,
+            fix_hint="autosearch login xueqiu",
+        )
+    ]
+    with (
+        patch("autosearch.core.doctor.load_all", return_value=specs),
+        patch("autosearch.core.doctor._current_env_keys", return_value=set()),
+    ):
+        results = scan_channels(tmp_path)
+
+    assert results[0].tier == 2
+    assert results[0].fix_hint == "autosearch login xueqiu"
+
+
+def test_scan_channels_reads_declared_doctor_metadata_from_frontmatter(tmp_path):
+    skill_dir = tmp_path / "xueqiu"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: xueqiu",
+                "description: Finance search",
+                "methods:",
+                "  - id: api_search",
+                "    impl: methods/api_search.py",
+                "    requires: [env:XUEQIU_COOKIES]",
+                "fallback_chain: [api_search]",
+                "tier: 2",
+                'fix_hint: "autosearch login xueqiu"',
+                "---",
+                "",
+                "Body.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with patch("autosearch.core.doctor._current_env_keys", return_value=set()):
+        results = scan_channels(tmp_path)
+
+    assert results[0].channel == "xueqiu"
+    assert results[0].tier == 2
+    assert results[0].fix_hint == "autosearch login xueqiu"

--- a/tests/unit/test_generate_channels_table.py
+++ b/tests/unit/test_generate_channels_table.py
@@ -268,3 +268,88 @@ def test_generate_prefers_declared_tier_over_requires_inference(tmp_path: Path) 
         "| xueqiu | zh, mixed | env:XUEQIU_COOKIES | Login-gated finance channel | medium |"
         in rendered
     )
+
+
+def test_generate_prefers_declared_tier_without_requires(tmp_path: Path) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    skill_dir = channels_root / "declared_login"
+    (skill_dir / "methods").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: declared_login",
+                'description: "Declared login tier without env inference"',
+                "version: 1",
+                "languages: [en]",
+                "methods:",
+                "  - id: api_search",
+                "    impl: methods/api_search.py",
+                "    requires: []",
+                "fallback_chain: [api_search]",
+                "quality_hint:",
+                "  typical_yield: low",
+                "  chinese_native: false",
+                "tier: 2",
+                "---",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "methods" / "api_search.py").write_text(
+        "async def search(query):\n    return []\n",
+        encoding="utf-8",
+    )
+
+    rendered = module.render_supported_channels(channels_root)
+
+    assert "### Tier 2 - login/cookie gated (1)" in rendered
+    assert (
+        "| declared_login | en | - | Declared login tier without env inference | low |" in rendered
+    )
+
+
+def test_generate_rejects_invalid_declared_tier_type(tmp_path: Path, capsys) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    skill_dir = channels_root / "broken_tier"
+    (skill_dir / "methods").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: broken_tier",
+                'description: "Broken tier type"',
+                "version: 1",
+                "languages: [en]",
+                "methods:",
+                "  - id: api_search",
+                "    impl: methods/api_search.py",
+                "    requires: []",
+                "fallback_chain: [api_search]",
+                "quality_hint:",
+                "  typical_yield: low",
+                "  chinese_native: false",
+                "tier: true",
+                "---",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "methods" / "api_search.py").write_text(
+        "async def search(query):\n    return []\n",
+        encoding="utf-8",
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "# Demo\n\n<!-- channels-table-start -->\nstale\n<!-- channels-table-end -->\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(["--channels-root", str(channels_root), "--readme", str(readme)])
+
+    assert exit_code == 1
+    assert "tier must be an int in 0..2" in capsys.readouterr().err

--- a/tests/unit/test_generate_channels_table.py
+++ b/tests/unit/test_generate_channels_table.py
@@ -222,7 +222,49 @@ def test_generate_groups_channels_by_tier(tmp_path: Path) -> None:
     rendered = module.render_supported_channels(channels_root)
 
     assert "### Tier 0 - always-on (1)" in rendered
-    assert "### Tier 1 - env-gated (1)" in rendered
-    assert "### Tier 2 - BYOK paid (1)" in rendered
+    assert "### Tier 1 - env/API gated (2)" in rendered
+    assert "### Tier 2 - login/cookie gated (0)" in rendered
     assert "| youtube | en, mixed | env:YOUTUBE_API_KEY | Video search | high |" in rendered
     assert "| zhihu | zh, mixed | env:TIKHUB_API_KEY | Paid channel | medium-high |" in rendered
+
+
+def test_generate_prefers_declared_tier_over_requires_inference(tmp_path: Path) -> None:
+    module = _load_script_module()
+    channels_root = tmp_path / "skills" / "channels"
+    skill_dir = channels_root / "xueqiu"
+    (skill_dir / "methods").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: xueqiu",
+                'description: "Login-gated finance channel"',
+                "version: 1",
+                "languages: [zh, mixed]",
+                "methods:",
+                "  - id: api_search",
+                "    impl: methods/api_search.py",
+                "    requires: [env:XUEQIU_COOKIES]",
+                "fallback_chain: [api_search]",
+                "quality_hint:",
+                "  typical_yield: medium",
+                "  chinese_native: true",
+                "tier: 2",
+                "---",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "methods" / "api_search.py").write_text(
+        "async def search(query):\n    return []\n",
+        encoding="utf-8",
+    )
+
+    rendered = module.render_supported_channels(channels_root)
+
+    assert "### Tier 2 - login/cookie gated (1)" in rendered
+    assert (
+        "| xueqiu | zh, mixed | env:XUEQIU_COOKIES | Login-gated finance channel | medium |"
+        in rendered
+    )

--- a/tests/unit/test_list_skills.py
+++ b/tests/unit/test_list_skills.py
@@ -91,6 +91,33 @@ def test_parse_skill_md_reads_frontmatter(tmp_path: Path) -> None:
     assert summary.deprecated is False
 
 
+def test_parse_actual_discourse_forum_skill_md_exposes_governance_metadata() -> None:
+    skill_path = (
+        Path(__file__).resolve().parents[2]
+        / "autosearch"
+        / "skills"
+        / "channels"
+        / "discourse_forum"
+        / "SKILL.md"
+    )
+
+    summary = _parse_skill_md(skill_path, group="channels")
+
+    assert summary is not None
+    assert summary.name == "discourse_forum"
+    assert summary.group == "channels"
+    assert summary.layer == "leaf"
+    assert summary.domains == ["chinese-ugc"]
+    assert summary.scenarios == [
+        "developer-community",
+        "ai-tools",
+        "troubleshooting",
+        "public-forum",
+    ]
+    assert summary.model_tier == "Fast"
+    assert summary.deprecated is False
+
+
 def test_parse_skill_md_returns_none_on_missing_frontmatter(tmp_path: Path) -> None:
     skill_dir = tmp_path / "channels" / "weird"
     skill_dir.mkdir(parents=True)

--- a/tests/unit/test_list_skills.py
+++ b/tests/unit/test_list_skills.py
@@ -108,12 +108,7 @@ def test_parse_actual_discourse_forum_skill_md_exposes_governance_metadata() -> 
     assert summary.group == "channels"
     assert summary.layer == "leaf"
     assert summary.domains == ["chinese-ugc"]
-    assert summary.scenarios == [
-        "developer-community",
-        "ai-tools",
-        "troubleshooting",
-        "public-forum",
-    ]
+    assert {"developer-community", "public-forum"} <= set(summary.scenarios)
     assert summary.model_tier == "Fast"
     assert summary.deprecated is False
 

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -31,8 +31,15 @@ def test_load_valid_channel_skill() -> None:
     assert spec.fallback_chain == ["api_search", "api_detail"]
     assert spec.when_to_use is not None
     assert spec.when_to_use.query_types == ["academic-papers", "literature-review"]
+    assert spec.when_to_use.domain_hints == ["citations", "scholarly-search"]
     assert spec.quality_hint is not None
     assert spec.quality_hint.typical_yield == "medium-high"
+    assert spec.layer == "leaf"
+    assert spec.domains == ["academic"]
+    assert spec.scenarios == ["paper-search", "detail-hydration"]
+    assert spec.model_tier == "Standard"
+    assert spec.tier == 1
+    assert spec.fix_hint == "autosearch configure ARXIV_TOKEN <value>"
     assert spec.skill_dir.name == "valid_channel"
 
 


### PR DESCRIPTION
## Summary

Rebases @TsekaLuk's PR #309 onto current main (post Phase 1 Contract Repair / #310). All commit attributions preserved.

**Three logical changes** (3 commits):

1. **feat(channels): add discourse_forum search with linux.do fallback** (`17c658c`) — new channel for Discourse forums, default seeded with linux.do
2. **refactor(governance): derive channel policy from skill metadata** (`847a1ef`) — channel routing + doctor tier/fix-hint now driven by `SKILL.md` frontmatter (`tier:`, `fix_hint:`, `domains:`) instead of hardcoded heuristics. Selector, doctor, init `--check-channels`, and channels-table generator all share one source of truth.
3. **fix(review): address bot feedback on discourse governance PR** (`9ca1cdf`) — review fixes from CodeRabbit/Codex on the original #309 thread.

## Conflicts resolved during rebase

- **README.md / README.zh.md**: kept main's tagline ("Open-source deep research for coding agents... alternative to OpenAI/Perplexity") per maintainer call; updated channel count `39 → 40` to reflect the new discourse_forum channel.
- **tests/unit/test_doctor.py**: kept all four tests — #310's `test_searxng_env_requires_tier_1` and `test_format_report_does_not_suggest_nonexistent_fix_flag` plus #309's `test_scan_channels_prefers_declared_doctor_metadata` and `test_scan_channels_reads_declared_doctor_metadata_from_frontmatter`. The new metadata-first logic in `_resolve_tier`/`_resolve_fix_hint` already falls back to `_compute_tier` (which still honors `_TIER1_ENV_PATTERNS` including `SEARXNG`), so both contracts are upheld.
- **autosearch/core/doctor.py**: clean auto-merge — metadata-driven layer wraps the existing pattern-based fallback.

Closes #309.

## Verification

- `ruff check .` → clean
- `ruff format --check .` → 387 files formatted
- `pytest -x -q -m "not real_llm and not perf and not slow and not network"` → **754 passed** (731 from main + 23 new from #309)

## Test plan

- [ ] CI green
- [ ] Manual: `autosearch doctor` shows discourse_forum / linux.do
- [ ] Manual: confirm xueqiu (or any new metadata-declared channel) reads `tier:` + `fix_hint:` from its `SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)