### PR TITLE
fix: v2 secrets + experience runtime contract — configured keys take effect, no writes into installed package

### DIFF
--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -8,7 +8,6 @@ Tier system (1:1 from Agent-Reach doctor.py):
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -263,7 +262,9 @@ def _token_satisfied(token: str, env_keys: set[str]) -> bool:
 
 
 def _current_env_keys() -> set[str]:
-    return {key for key, val in os.environ.items() if val}
+    from autosearch.core.secrets_store import available_env_keys
+
+    return available_env_keys()
 
 
 def _default_channels_root() -> Path:

--- a/autosearch/core/environment_probe.py
+++ b/autosearch/core/environment_probe.py
@@ -1,13 +1,13 @@
 # Self-written, plan autosearch-0418-channels-and-skills.md § F003
 from __future__ import annotations
 
-import os
 from collections.abc import Iterable
 from pathlib import Path
 
 import structlog
 
 from autosearch.channels.base import Environment
+from autosearch.core.secrets_store import available_env_keys
 from autosearch.skills import SkillLoadError, load_all
 
 LOGGER = structlog.get_logger(__name__).bind(component="environment_probe")
@@ -63,7 +63,8 @@ def probe_environment(
         if env_keys_to_check is not None
         else _discover_env_keys_from_skills(_default_channels_root()) | KNOWN_ENV_KEYS
     )
-    env_keys = {key for key in keys_to_check if os.environ.get(key)}
+    available = available_env_keys()
+    env_keys = keys_to_check & available
 
     root = (cookies_dir or Path("~/.autosearch/cookies")).expanduser()
     cookies = {path.stem for path in root.glob("*.json")} if root.is_dir() else set()

--- a/autosearch/core/experience_compact.py
+++ b/autosearch/core/experience_compact.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from autosearch.skills.experience import _find_skill_dir, _parse_datetime
+from autosearch.skills.experience import _parse_datetime, _runtime_skill_dir
 
 
 @dataclass
@@ -63,11 +63,11 @@ def _read_events(patterns_path: Path) -> list[dict[str, Any]]:
 def compact(skill_name: str) -> bool:
     """Promote recurring raw experience events into a compact skill digest."""
     try:
-        skill_dir = _find_skill_dir(skill_name)
-        if skill_dir is None:
+        runtime_dir = _runtime_skill_dir(skill_name)
+        if runtime_dir is None:
             return False
 
-        patterns_path = skill_dir / "experience" / "patterns.jsonl"
+        patterns_path = runtime_dir / "experience" / "patterns.jsonl"
         if not patterns_path.is_file():
             return False
 
@@ -186,7 +186,7 @@ def compact(skill_name: str) -> bool:
             ]
         )
 
-        digest_path = skill_dir / "experience.md"
+        digest_path = runtime_dir / "experience.md"
         digest_path.write_text("\n".join(lines[:120]), encoding="utf-8")
         return True
     except Exception:

--- a/autosearch/core/secrets_store.py
+++ b/autosearch/core/secrets_store.py
@@ -1,0 +1,76 @@
+"""Secrets file loader for ~/.config/ai-secrets.env.
+
+`autosearch configure` and `autosearch login` write KEY=value pairs to this file
+so they survive across shells and GUI-launched MCP clients (which do not inherit
+the developer's interactive shell environment). The runtime — doctor, channel
+probes, MCP server startup — must read the same file, otherwise users configure
+keys that no code path actually picks up.
+
+Lookup order:
+
+1. process environment (`os.environ`) — explicit override wins
+2. `~/.config/ai-secrets.env` (or `$AUTOSEARCH_SECRETS_FILE` if set)
+
+Values are never printed or logged. Only key presence is exposed via
+`available_env_keys()`.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+
+
+def secrets_path() -> Path:
+    """Return the configured secrets-file path (env override or default)."""
+    override = os.environ.get("AUTOSEARCH_SECRETS_FILE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "ai-secrets.env"
+
+
+def load_secrets(path: Path | None = None) -> dict[str, str]:
+    """Parse the secrets file into a dict. Returns {} if missing or unreadable.
+
+    Format mirrors what `autosearch configure` writes (shell-sourceable):
+      KEY=value
+      KEY='quoted value'
+      # comments and blank lines are ignored
+    """
+    target = path or secrets_path()
+    try:
+        text = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+
+    result: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key or not key.replace("_", "").isalnum():
+            continue
+        try:
+            tokens = shlex.split(value)
+        except ValueError:
+            continue
+        result[key] = tokens[0] if tokens else ""
+    return result
+
+
+def available_env_keys(path: Path | None = None) -> set[str]:
+    """Return the set of keys with non-empty values in env OR the secrets file."""
+    keys = {key for key, val in os.environ.items() if val}
+    keys.update(k for k, v in load_secrets(path).items() if v)
+    return keys
+
+
+def resolve_env_value(key: str, path: Path | None = None) -> str | None:
+    """Return the value for `key`: process env first, then secrets file."""
+    env_value = os.environ.get(key)
+    if env_value:
+        return env_value
+    return load_secrets(path).get(key) or None

--- a/autosearch/skills/experience.py
+++ b/autosearch/skills/experience.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -10,11 +11,37 @@ _SKILL_GROUPS = ("channels", "tools", "meta")
 
 
 def _find_skill_dir(skill_name: str) -> Path | None:
+    """Locate the bundled (read-only) skill directory shipped inside the package."""
     for group in _SKILL_GROUPS:
         skill_dir = _SKILLS_ROOT / group / skill_name
         if skill_dir.is_dir():
             return skill_dir
     return None
+
+
+def _runtime_root() -> Path:
+    """Return the per-user, writable experience root.
+
+    Resolution order:
+      1. `$AUTOSEARCH_EXPERIENCE_DIR` (test/CI override)
+      2. `$XDG_DATA_HOME/autosearch/experience`
+      3. `~/.local/share/autosearch/experience`
+    """
+    override = os.environ.get("AUTOSEARCH_EXPERIENCE_DIR")
+    if override:
+        return Path(override).expanduser()
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".local" / "share"
+    return base / "autosearch" / "experience"
+
+
+def _runtime_skill_dir(skill_name: str) -> Path | None:
+    """Return the writable runtime directory for a skill, or None if unknown."""
+    bundled = _find_skill_dir(skill_name)
+    if bundled is None:
+        return None
+    group = bundled.parent.name  # channels / tools / meta
+    return _runtime_root() / group / skill_name
 
 
 def _parse_datetime(value: Any) -> datetime | None:
@@ -54,16 +81,15 @@ def _last_compacted_at(experience_md: Path) -> datetime | None:
 
 
 def append_event(skill_name: str, event: dict) -> None:
-    """Append one event to a skill's raw experience log.
+    """Append one event to a skill's raw experience log under the user's data dir.
 
-    This helper is intentionally best-effort. Experience capture should never
-    break the caller's primary channel execution path.
+    Best-effort: capture failures must never break the caller's channel call.
     """
     try:
-        skill_dir = _find_skill_dir(skill_name)
-        if skill_dir is None:
+        runtime_dir = _runtime_skill_dir(skill_name)
+        if runtime_dir is None:
             return
-        experience_dir = skill_dir / "experience"
+        experience_dir = runtime_dir / "experience"
         experience_dir.mkdir(parents=True, exist_ok=True)
         patterns_path = experience_dir / "patterns.jsonl"
         with patterns_path.open("a", encoding="utf-8") as handle:
@@ -73,17 +99,22 @@ def append_event(skill_name: str, event: dict) -> None:
 
 
 def load_experience_digest(skill_name: str) -> str | None:
-    """Return the compact experience digest for a skill, if present."""
-    skill_dir = _find_skill_dir(skill_name)
-    if skill_dir is None:
-        return None
-    try:
-        digest_path = skill_dir / "experience.md"
-        if not digest_path.is_file():
-            return None
-        return digest_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
+    """Return the compact experience digest. Runtime-compacted version wins;
+    falls back to the bundled read-only seed shipped with the package."""
+    runtime_dir = _runtime_skill_dir(skill_name)
+    candidates = []
+    if runtime_dir is not None:
+        candidates.append(runtime_dir / "experience.md")
+    bundled = _find_skill_dir(skill_name)
+    if bundled is not None:
+        candidates.append(bundled / "experience.md")
+    for digest_path in candidates:
+        try:
+            if digest_path.is_file():
+                return digest_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+    return None
 
 
 def should_compact(
@@ -92,18 +123,22 @@ def should_compact(
     size_threshold_bytes: int = 65536,
 ) -> bool:
     """Return whether a skill's raw experience log should be compacted."""
-    skill_dir = _find_skill_dir(skill_name)
-    if skill_dir is None:
+    runtime_dir = _runtime_skill_dir(skill_name)
+    if runtime_dir is None:
         return False
 
-    patterns_path = skill_dir / "experience" / "patterns.jsonl"
+    patterns_path = runtime_dir / "experience" / "patterns.jsonl"
     try:
         if not patterns_path.is_file():
             return False
         if patterns_path.stat().st_size >= size_threshold_bytes:
             return True
 
-        compacted_at = _last_compacted_at(skill_dir / "experience.md")
+        compacted_at = _last_compacted_at(runtime_dir / "experience.md")
+        if compacted_at is None:
+            bundled = _find_skill_dir(skill_name)
+            if bundled is not None:
+                compacted_at = _last_compacted_at(bundled / "experience.md")
         new_events = 0
         with patterns_path.open(encoding="utf-8") as handle:
             for line in handle:

--- a/tests/e2e/test_experience_accumulation.py
+++ b/tests/e2e/test_experience_accumulation.py
@@ -39,6 +39,7 @@ async def test_experience_accumulates_and_compacts(tmp_path, monkeypatch):
     skill_dir.mkdir(parents=True)
     monkeypatch.setattr(exp_mod, "_SKILLS_ROOT", tmp_path)
     monkeypatch.setenv("AUTOSEARCH_LLM_MODE", "dummy")
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path))
 
     with (
         patch("autosearch.mcp.server._build_channels", return_value=[_MockArxiv()]),
@@ -124,6 +125,7 @@ async def test_experience_not_injected_before_first_run(tmp_path, monkeypatch):
     skill_dir.mkdir(parents=True)
     monkeypatch.setattr(exp_mod, "_SKILLS_ROOT", tmp_path)
     monkeypatch.setenv("AUTOSEARCH_LLM_MODE", "dummy")
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path))
 
     captured = []
 

--- a/tests/integration/test_avo_evolution_cycle.py
+++ b/tests/integration/test_avo_evolution_cycle.py
@@ -45,6 +45,7 @@ def _setup_skill_dir(tmp_path: Path, channel: str, monkeypatch) -> Path:
     skill_dir = tmp_path / "channels" / channel
     skill_dir.mkdir(parents=True)
     monkeypatch.setattr(exp_mod, "_SKILLS_ROOT", tmp_path)
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path))
     return skill_dir
 
 

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -7,10 +7,17 @@ from autosearch.skills import experience
 
 
 def _make_skill_root(tmp_path, monkeypatch, skill_name: str = "demo"):
+    """Set up both bundled (read-only) skill_dir and runtime experience root.
+
+    Bundled root is needed so `_find_skill_dir` can derive the skill group;
+    runtime root is where `append_event` / `compact` actually write.
+    Pointing both at the same path keeps test assertions straightforward.
+    """
     root = tmp_path / "skills"
     skill_dir = root / "channels" / skill_name
     skill_dir.mkdir(parents=True)
     monkeypatch.setattr(experience, "_SKILLS_ROOT", root)
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(root))
     return skill_dir
 
 

--- a/tests/test_run_channel_experience.py
+++ b/tests/test_run_channel_experience.py
@@ -41,6 +41,7 @@ def _make_skill_dir(tmp_path, monkeypatch, skill_name: str = "bilibili"):
     skill_dir = root / "channels" / skill_name
     skill_dir.mkdir(parents=True)
     monkeypatch.setattr(experience, "_SKILLS_ROOT", root)
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(root))
     return skill_dir
 
 

--- a/tests/unit/test_experience_runtime_isolation.py
+++ b/tests/unit/test_experience_runtime_isolation.py
@@ -1,0 +1,88 @@
+"""Guard rail: runtime experience writes must NEVER touch the installed package tree.
+
+Without this contract a deployed wheel becomes "dirty" the moment an MCP host
+calls run_channel — patterns.jsonl gets written into site-packages, causing
+read-only-FS failures, build artifact pollution, and cross-user data leaks
+on shared installs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autosearch.core.experience_compact import compact
+from autosearch.skills import experience as exp_mod
+
+
+def _bundled_arxiv_dir() -> Path:
+    return exp_mod._SKILLS_ROOT / "channels" / "arxiv"
+
+
+def test_append_event_writes_to_runtime_root_not_package(monkeypatch, tmp_path):
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(runtime_root))
+
+    bundled = _bundled_arxiv_dir()
+    bundled_patterns = bundled / "experience" / "patterns.jsonl"
+    bundled_size_before = bundled_patterns.stat().st_size if bundled_patterns.exists() else None
+
+    exp_mod.append_event("arxiv", {"query": "isolation test", "outcome": "success"})
+
+    runtime_patterns = runtime_root / "channels" / "arxiv" / "experience" / "patterns.jsonl"
+    assert runtime_patterns.exists(), "event must land under the runtime root"
+    body = runtime_patterns.read_text(encoding="utf-8")
+    assert "isolation test" in body
+
+    if bundled_size_before is None:
+        assert not bundled_patterns.exists(), (
+            "append_event must not create patterns.jsonl in the installed package tree"
+        )
+    else:
+        assert bundled_patterns.stat().st_size == bundled_size_before, (
+            "append_event must not modify the bundled patterns.jsonl"
+        )
+
+
+def test_compact_writes_digest_to_runtime_root_not_package(monkeypatch, tmp_path):
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(runtime_root))
+
+    runtime_patterns = runtime_root / "channels" / "arxiv" / "experience" / "patterns.jsonl"
+    runtime_patterns.parent.mkdir(parents=True)
+    runtime_patterns.write_text(
+        '{"ts": "2026-04-22T00:00:00+00:00", "outcome": "success", '
+        '"winning_pattern": "site:arxiv.org abstract", "good_query": "rag eval"}\n' * 4,
+        encoding="utf-8",
+    )
+
+    bundled_digest = _bundled_arxiv_dir() / "experience.md"
+    bundled_text_before = (
+        bundled_digest.read_text(encoding="utf-8") if bundled_digest.exists() else None
+    )
+
+    assert compact("arxiv") is True
+
+    runtime_digest = runtime_root / "channels" / "arxiv" / "experience.md"
+    assert runtime_digest.exists(), "compact() must write the digest under the runtime root"
+
+    if bundled_text_before is None:
+        assert not bundled_digest.exists(), (
+            "compact() must not create experience.md inside the installed package"
+        )
+    else:
+        assert bundled_digest.read_text(encoding="utf-8") == bundled_text_before, (
+            "compact() must not modify the bundled experience.md seed"
+        )
+
+
+def test_load_digest_falls_back_to_bundled_seed(monkeypatch, tmp_path):
+    """When the user has no compacted digest yet, callers should still get the
+    seed digest shipped with the package so the agent has prior knowledge."""
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path / "empty-runtime"))
+
+    digest = exp_mod.load_experience_digest("arxiv")
+    bundled = _bundled_arxiv_dir() / "experience.md"
+    if bundled.exists():
+        assert digest == bundled.read_text(encoding="utf-8")
+    else:
+        assert digest is None

--- a/tests/unit/test_secrets_store.py
+++ b/tests/unit/test_secrets_store.py
@@ -1,0 +1,114 @@
+"""Tests for autosearch.core.secrets_store."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autosearch.core.secrets_store import (
+    available_env_keys,
+    load_secrets,
+    resolve_env_value,
+    secrets_path,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_secrets_path_honors_override(monkeypatch, tmp_path):
+    custom = tmp_path / "custom.env"
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(custom))
+    assert secrets_path() == custom
+
+
+def test_load_secrets_returns_empty_when_file_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(tmp_path / "nope.env"))
+    assert load_secrets() == {}
+
+
+def test_load_secrets_parses_kv_with_quotes_and_skips_comments(monkeypatch, tmp_path):
+    f = tmp_path / "ai-secrets.env"
+    _write(
+        f,
+        "\n".join(
+            [
+                "# top comment",
+                "",
+                "OPENAI_API_KEY=sk-plain",
+                "TIKHUB_API_KEY='quoted secret'",
+                'WEIBO_COOKIES="double quoted"',
+                "  # indented comment",
+                "MALFORMED_LINE_WITHOUT_EQUALS",
+                "=missing_key",
+            ]
+        )
+        + "\n",
+    )
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(f))
+
+    result = load_secrets()
+    assert result == {
+        "OPENAI_API_KEY": "sk-plain",
+        "TIKHUB_API_KEY": "quoted secret",
+        "WEIBO_COOKIES": "double quoted",
+    }
+
+
+def test_available_env_keys_unions_env_and_file(monkeypatch, tmp_path):
+    f = tmp_path / "ai-secrets.env"
+    _write(f, "FROM_FILE_KEY=value1\n")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(f))
+    monkeypatch.setenv("FROM_PROCESS_KEY", "value2")
+
+    keys = available_env_keys()
+    assert "FROM_FILE_KEY" in keys
+    assert "FROM_PROCESS_KEY" in keys
+
+
+def test_available_env_keys_skips_empty_file_values(monkeypatch, tmp_path):
+    f = tmp_path / "ai-secrets.env"
+    _write(f, "EMPTY_KEY=\nGOOD_KEY=present\n")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(f))
+
+    keys = available_env_keys()
+    assert "GOOD_KEY" in keys
+    assert "EMPTY_KEY" not in keys
+
+
+def test_resolve_env_value_prefers_process_env_over_file(monkeypatch, tmp_path):
+    f = tmp_path / "ai-secrets.env"
+    _write(f, "OVERRIDE_ME=from_file\n")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(f))
+    monkeypatch.setenv("OVERRIDE_ME", "from_process")
+
+    assert resolve_env_value("OVERRIDE_ME") == "from_process"
+
+
+def test_resolve_env_value_falls_back_to_file_when_env_unset(monkeypatch, tmp_path):
+    f = tmp_path / "ai-secrets.env"
+    _write(f, "FILE_ONLY=in_file\n")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(f))
+    monkeypatch.delenv("FILE_ONLY", raising=False)
+
+    assert resolve_env_value("FILE_ONLY") == "in_file"
+
+
+def test_resolve_env_value_returns_none_when_absent(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(tmp_path / "missing.env"))
+    monkeypatch.delenv("DEFINITELY_NOT_SET", raising=False)
+    assert resolve_env_value("DEFINITELY_NOT_SET") is None
+
+
+def test_doctor_picks_up_key_from_secrets_file(monkeypatch, tmp_path):
+    """Integration: a key written to ai-secrets.env should be visible to doctor's
+    `_current_env_keys`, so a configured channel actually shows as available."""
+    from autosearch.core import doctor
+
+    f = tmp_path / "ai-secrets.env"
+    _write(f, "TIKHUB_API_KEY=test-token\n")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(f))
+    monkeypatch.delenv("TIKHUB_API_KEY", raising=False)
+
+    keys = doctor._current_env_keys()
+    assert "TIKHUB_API_KEY" in keys


### PR DESCRIPTION
## Summary

Closes two P0 contract gaps surfaced in the million-user readiness audit (`docs/million-user-product-readiness-plan.md` §P0-A/B/C). Without these, `autosearch configure ... → autosearch doctor` is a lie — and `run_channel` quietly pollutes `site-packages` on every call.

### A+B. Configured keys actually take effect

`autosearch configure KEY value` (and `autosearch login`) write to `~/.config/ai-secrets.env`, but doctor + channel probes only read process env. So a user runs `autosearch configure TIKHUB_API_KEY <key>`, runs `doctor` again, and it still says "未配置". Fix:

- new `autosearch.core.secrets_store` — single shared loader with `secrets_path()`, `load_secrets()`, `available_env_keys()`, `resolve_env_value()`
- process env always wins (explicit override); secrets file is the durable fallback
- `~/.config/ai-secrets.env` location can be overridden with `$AUTOSEARCH_SECRETS_FILE` (test/CI)
- values are never printed or logged — only key presence is exposed
- `doctor._current_env_keys` and `environment_probe.probe_environment` rewired to use the union

End-to-end check (fresh wheel):

```bash
$ echo "SEARXNG_URL=http://test.local:8080" > /tmp/secrets.env
$ AUTOSEARCH_SECRETS_FILE=/tmp/secrets.env autosearch doctor --json \
    | python3 -c "import json,sys; s=[c for c in json.load(sys.stdin) if c['channel']=='searxng'][0]; print(s['status'], s['tier'])"
ok 1
```

Before this PR that same command would print `off 1` even with the key written.

### C. Runtime experience writes leave the package alone

`run_channel` calls `append_event` which wrote to `autosearch/skills/channels/<name>/experience/patterns.jsonl`. That path resolves to **site-packages after install** — every MCP query mutates the installed package, breaks read-only deploys, contaminates wheels, and (during dev) is the reason `bilibili/experience.md` and `xhs/patterns.jsonl` show up dirty in every session.

Fix:

- new `_runtime_root()` resolution: `$AUTOSEARCH_EXPERIENCE_DIR` → `$XDG_DATA_HOME/autosearch/experience` → `~/.local/share/autosearch/experience`
- `append_event`, `should_compact`, and `experience_compact.compact()` write under `<runtime_root>/<group>/<skill>/...`
- `load_experience_digest()` prefers the runtime-compacted digest, falls back to the bundled read-only seed shipped with the package
- bundled `experience.md` files remain seeds; the package tree is read-only at runtime

New regression: `tests/unit/test_experience_runtime_isolation.py` asserts the bundled `arxiv` directory is byte-identical before/after `append_event` and `compact`.

## Out of scope

Plan §P0-D (per-client MCP config writer schema), P0-E (`PermanentError` unreachable), P0-F (circuit breaker not wired), and P1-G (NPM/Python version drift) are tracked separately — see plan for cuts.

## Verification

- `ruff check . && ruff format --check .` → clean
- `pytest -x -q -m "not real_llm and not perf and not slow and not network"` → **766 passed** (754 + 12 new)
- Fresh wheel build + install: `SEARXNG_URL` planted in secrets file is seen by `doctor` (`status=ok`); `append_event` writes to `$AUTOSEARCH_EXPERIENCE_DIR`, package tree untouched

## Test plan

- [ ] CI green
- [ ] Manual: `autosearch configure SEARXNG_URL http://...` then `autosearch doctor` shows searxng available without restarting shell
- [ ] Manual: install wheel into a venv, `chmod -R a-w` site-packages/autosearch, run any `run_channel` — no PermissionError

🤖 Generated with [Claude Code](https://claude.com/claude-code)