### PR TITLE
fix: per-client MCP config writers — Claude/Cursor/Zed get correct schema, init gains --dry-run, mcp-check gains --client

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -185,9 +185,22 @@ def init(
             help="Replace the generated config instead of merging detected providers into it.",
         ),
     ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Print MCP client config writes that would happen without touching files.",
+        ),
+    ] = False,
 ) -> None:
     if check_channels:
         _print_channel_check()
+        return
+
+    if dry_run:
+        typer.echo("Dry-run: showing MCP client writes only (no files will be modified).\n")
+        for line in _auto_configure_mcp(dry_run=True).split("; "):
+            typer.echo(f"  {line}")
         return
 
     # ── Banner ────────────────────────────────────────────────────────────────
@@ -269,38 +282,34 @@ def init(
     typer.echo("")
 
 
-def _auto_configure_mcp() -> str:
-    """Auto-write autosearch MCP entry to Claude Code config. Returns status string."""
-    import json
-    from pathlib import Path
+def _auto_configure_mcp(dry_run: bool = False) -> str:
+    """Write the autosearch MCP entry to every supported client's config file.
 
-    mcp_config = {"command": "autosearch-mcp", "type": "stdio"}
-    config_files = [
-        Path.home() / ".claude" / "mcp.json",
-        Path.home() / ".cursor" / "mcp.json",
-    ]
+    Each client gets its own writer (Claude Code, Cursor, Zed) so the entry
+    lands under the correct namespace key — not a flat top-level dict that the
+    client cannot load. Skips clients whose config dir doesn't exist (i.e. the
+    user hasn't installed them).
+    """
+    from autosearch.cli.mcp_config_writers import write_for_clients
 
-    written: list[str] = []
-    for config_path in config_files:
-        if not config_path.parent.exists():
+    results = write_for_clients(dry_run=dry_run)
+
+    parts: list[str] = []
+    for r in results:
+        if r.status == "skipped":
             continue
-        existing: dict = {}
-        if config_path.exists():
-            try:
-                existing = json.loads(config_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                existing = {}
-        if "autosearch" not in existing:
-            existing["autosearch"] = mcp_config
-            config_path.write_text(
-                json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
-                encoding="utf-8",
-            )
-            written.append(config_path.parent.name)
+        prefix = "(dry-run) " if dry_run else ""
+        if r.status == "already-set":
+            parts.append(f"{prefix}{r.client}: already set")
+        elif r.status == "backup-and-replaced":
+            backup_note = f" (backup → {r.backup_path.name})" if r.backup_path else ""
+            parts.append(f"{prefix}{r.client}: rewritten{backup_note}")
+        else:
+            parts.append(f"{prefix}{r.client}: written")
 
-    if written:
-        return f"Config written to {', '.join(written)}"
-    return "Config already set"
+    if not parts:
+        return "no MCP clients detected (none of ~/.claude, ~/.cursor, ~/.config/zed exist)"
+    return "; ".join(parts)
 
 
 def _print_channel_check() -> None:
@@ -716,11 +725,24 @@ def doctor(
 
 
 @app.command("mcp-check")
-def mcp_check() -> None:
+def mcp_check(
+    client: Annotated[
+        str | None,
+        typer.Option(
+            "--client",
+            help="Also verify a specific MCP client's config file shape "
+            "(claude/cursor/zed). Without this flag only the server-side "
+            "tool registry is checked.",
+        ),
+    ] = None,
+) -> None:
     """Verify the MCP server registers every tool the v2 install contract requires.
 
     Creates the server in-process, lists registered tools, and exits non-zero
     when any of the required tools is missing. Performs no network I/O.
+
+    With `--client <name>`, additionally inspect that client's config file and
+    confirm the autosearch entry sits under the correct namespace key.
     """
     import asyncio
 
@@ -748,6 +770,27 @@ def mcp_check() -> None:
         typer.echo(f"FAIL: {len(missing)} required tool(s) missing: {', '.join(missing)}")
         raise typer.Exit(code=1)
     typer.echo(f"OK: all {len(_REQUIRED_MCP_TOOLS)} required tools registered.")
+
+    if client is None:
+        return
+
+    from autosearch.cli.mcp_config_writers import WRITERS
+
+    typer.echo("")
+    writer = WRITERS.get(client)
+    if writer is None:
+        typer.echo(
+            f"FAIL: unknown client {client!r}. Known: {', '.join(sorted(WRITERS))}",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    ok, message = writer.verify()
+    typer.echo(f"Client config check ({client}):")
+    if ok:
+        typer.echo(f"  ✓ {message}")
+        return
+    typer.echo(f"  ✗ {message}")
+    raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/autosearch/cli/mcp_config_writers.py
+++ b/autosearch/cli/mcp_config_writers.py
@@ -1,0 +1,205 @@
+"""Per-client MCP config writers.
+
+`autosearch init` used to dump `{"autosearch": {...}}` at the root of every MCP
+config file. Claude Code, Cursor, and Zed each expect a different shape (see
+`docs/mcp-clients.md`), so the old writer silently produced configs that the
+clients couldn't actually load — `init` would say "MCP server: ready" while the
+host agent saw nothing.
+
+This module ships one writer per supported client. Each writer:
+- knows the canonical config path for that client
+- knows the schema (e.g. Claude Code uses `mcpServers.<name>`, Zed uses
+  `context_servers.<name>`)
+- merges the autosearch entry into existing config without dropping unrelated
+  keys
+- backs up corrupt JSON to `<path>.bak.<timestamp>` instead of overwriting it
+- can verify whether autosearch is already correctly registered
+
+Adding a new client = one new subclass + one entry in `WRITERS`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+WriteStatus = Literal[
+    "written",  # newly added entry
+    "already-set",  # entry already correct, no-op
+    "skipped",  # parent dir doesn't exist (client not installed)
+    "backup-and-replaced",  # existing file was unparseable, backed up + rewritten
+]
+
+
+@dataclass(slots=True)
+class WriteResult:
+    client: str
+    path: Path
+    status: WriteStatus
+    backup_path: Path | None = None
+
+
+def _autosearch_entry(server_command: str) -> dict[str, object]:
+    """The autosearch MCP entry — same shape across `mcpServers`/`context_servers`."""
+    return {"command": server_command, "type": "stdio"}
+
+
+def _backup_corrupt_file(path: Path) -> Path:
+    """Move an unparseable JSON file to <path>.bak.<unix-ts> and return new path."""
+    suffix = f".bak.{int(time.time())}"
+    backup = path.with_suffix(path.suffix + suffix)
+    path.rename(backup)
+    return backup
+
+
+class _BaseWriter:
+    """Shared logic: load existing config, place autosearch under the right
+    namespace, write back. Subclasses customize path + namespace key."""
+
+    name: str = ""
+    namespace_key: str = ""  # e.g. "mcpServers" or "context_servers"
+
+    def default_path(self) -> Path:
+        raise NotImplementedError
+
+    def write(
+        self,
+        *,
+        server_command: str = "autosearch-mcp",
+        dry_run: bool = False,
+        path_override: Path | None = None,
+    ) -> WriteResult:
+        path = path_override or self.default_path()
+        if not path.parent.exists():
+            return WriteResult(client=self.name, path=path, status="skipped")
+
+        existing: dict[str, object] = {}
+        backup_path: Path | None = None
+        if path.exists():
+            try:
+                raw = path.read_text(encoding="utf-8").strip()
+                existing = json.loads(raw) if raw else {}
+                if not isinstance(existing, dict):
+                    raise ValueError("top-level value is not an object")
+            except (json.JSONDecodeError, ValueError, OSError):
+                if dry_run:
+                    return WriteResult(
+                        client=self.name,
+                        path=path,
+                        status="backup-and-replaced",
+                    )
+                backup_path = _backup_corrupt_file(path)
+                existing = {}
+
+        servers = existing.setdefault(self.namespace_key, {})
+        if not isinstance(servers, dict):
+            servers = {}
+            existing[self.namespace_key] = servers
+
+        target_entry = _autosearch_entry(server_command)
+        if servers.get("autosearch") == target_entry:
+            return WriteResult(
+                client=self.name,
+                path=path,
+                status="already-set",
+                backup_path=backup_path,
+            )
+
+        if dry_run:
+            status: WriteStatus = "backup-and-replaced" if backup_path else "written"
+            return WriteResult(client=self.name, path=path, status=status, backup_path=backup_path)
+
+        servers["autosearch"] = target_entry
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        return WriteResult(
+            client=self.name,
+            path=path,
+            status="backup-and-replaced" if backup_path else "written",
+            backup_path=backup_path,
+        )
+
+    def verify(
+        self,
+        *,
+        server_command: str = "autosearch-mcp",
+        path_override: Path | None = None,
+    ) -> tuple[bool, str]:
+        """Return (ok, message). ok=True when this client's config has a properly
+        shaped autosearch entry under `namespace_key`."""
+        path = path_override or self.default_path()
+        if not path.exists():
+            return False, f"{path} does not exist"
+        try:
+            data = json.loads(path.read_text(encoding="utf-8") or "{}")
+        except json.JSONDecodeError as exc:
+            return False, f"{path} is not valid JSON: {exc}"
+        if not isinstance(data, dict):
+            return False, f"{path} top-level is not an object"
+
+        servers = data.get(self.namespace_key)
+        if not isinstance(servers, dict):
+            return False, f"{path} missing `{self.namespace_key}` object"
+        entry = servers.get("autosearch")
+        if not isinstance(entry, dict):
+            return False, f"{path} has no `{self.namespace_key}.autosearch` entry"
+        if entry.get("command") != server_command:
+            return False, (
+                f"{path} `{self.namespace_key}.autosearch.command` is "
+                f"{entry.get('command')!r}, expected {server_command!r}"
+            )
+        return True, f"{path}: {self.namespace_key}.autosearch -> {entry.get('command')}"
+
+
+class ClaudeCodeWriter(_BaseWriter):
+    name = "claude"
+    namespace_key = "mcpServers"
+
+    def default_path(self) -> Path:
+        return Path.home() / ".claude" / "mcp.json"
+
+
+class CursorWriter(_BaseWriter):
+    name = "cursor"
+    namespace_key = "mcpServers"
+
+    def default_path(self) -> Path:
+        return Path.home() / ".cursor" / "mcp.json"
+
+
+class ZedWriter(_BaseWriter):
+    name = "zed"
+    namespace_key = "context_servers"
+
+    def default_path(self) -> Path:
+        return Path.home() / ".config" / "zed" / "settings.json"
+
+
+WRITERS: dict[str, _BaseWriter] = {
+    "claude": ClaudeCodeWriter(),
+    "cursor": CursorWriter(),
+    "zed": ZedWriter(),
+}
+
+
+def write_for_clients(
+    clients: list[str] | None = None,
+    *,
+    server_command: str = "autosearch-mcp",
+    dry_run: bool = False,
+) -> list[WriteResult]:
+    """Run the writer for each named client (or all known clients if None)."""
+    targets = clients if clients else list(WRITERS.keys())
+    results: list[WriteResult] = []
+    for client_name in targets:
+        writer = WRITERS.get(client_name)
+        if writer is None:
+            continue
+        results.append(writer.write(server_command=server_command, dry_run=dry_run))
+    return results

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -57,3 +57,58 @@ def test_unknown_subcommand_no_longer_silently_routes_to_query() -> None:
     # After removing the default-query fallback, the deprecation path
     # from `query` must not be triggered for unknown subcommands.
     assert "deprecated" not in combined.lower()
+
+
+def test_init_dry_run_shows_writes_without_touching_filesystem(tmp_path, monkeypatch) -> None:
+    """`init --dry-run` exits 0, prints the planned MCP writes for whichever
+    clients are detected, and creates no files. This is the safe path for
+    agent-driven installs."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".cursor").mkdir()
+
+    result = runner.invoke(cli_main.app, ["init", "--dry-run"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "Dry-run" in result.stdout
+    assert "claude" in result.stdout and "cursor" in result.stdout
+    assert not (tmp_path / ".claude" / "mcp.json").exists()
+    assert not (tmp_path / ".cursor" / "mcp.json").exists()
+
+
+def test_mcp_check_with_client_passes_when_writer_was_run(tmp_path, monkeypatch) -> None:
+    """End-to-end: write the Claude config via the writer, then `mcp-check
+    --client claude` should report the entry as present."""
+    from autosearch.cli.mcp_config_writers import ClaudeCodeWriter
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    ClaudeCodeWriter().write()
+
+    result = runner.invoke(cli_main.app, ["mcp-check", "--client", "claude"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "Client config check (claude)" in result.stdout
+    assert "mcpServers.autosearch" in result.stdout
+
+
+def test_mcp_check_with_client_fails_when_entry_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    # Write a config that has the WRONG shape (entry at root, like the old bug)
+    (tmp_path / ".claude" / "mcp.json").write_text(
+        '{"autosearch": {"command": "autosearch-mcp"}}', encoding="utf-8"
+    )
+
+    result = runner.invoke(cli_main.app, ["mcp-check", "--client", "claude"])
+    assert result.exit_code != 0
+    output = result.stdout + (result.stderr or "")
+    # Either "missing `mcpServers` object" (when namespace absent) or
+    # "missing `mcpServers.autosearch` entry" (when namespace present but no entry)
+    # — both prove verify() rejected the broken config.
+    assert "mcpServers" in output and "missing" in output
+
+
+def test_mcp_check_rejects_unknown_client(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = runner.invoke(cli_main.app, ["mcp-check", "--client", "vim"])
+    assert result.exit_code != 0
+    assert "unknown client" in (result.stdout + (result.stderr or "")).lower()

--- a/tests/unit/test_mcp_config_writers.py
+++ b/tests/unit/test_mcp_config_writers.py
@@ -1,0 +1,192 @@
+"""Tests for autosearch.cli.mcp_config_writers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autosearch.cli.mcp_config_writers import (
+    WRITERS,
+    ClaudeCodeWriter,
+    CursorWriter,
+    ZedWriter,
+    write_for_clients,
+)
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_claude_writer_uses_mcpServers_namespace(tmp_path: Path) -> None:
+    """Regression: previous writer dumped {'autosearch': ...} at root, which
+    Claude Code silently ignored. Schema must be `mcpServers.<name>`."""
+    target = tmp_path / "claude_dir" / "mcp.json"
+    target.parent.mkdir()
+
+    result = ClaudeCodeWriter().write(path_override=target)
+    assert result.status == "written"
+
+    data = _read(target)
+    assert "mcpServers" in data, "Claude Code expects mcpServers namespace"
+    assert data["mcpServers"]["autosearch"] == {
+        "command": "autosearch-mcp",
+        "type": "stdio",
+    }
+
+
+def test_cursor_writer_also_uses_mcpServers_namespace(tmp_path: Path) -> None:
+    target = tmp_path / "cursor_dir" / "mcp.json"
+    target.parent.mkdir()
+    CursorWriter().write(path_override=target)
+    assert "mcpServers" in _read(target)
+
+
+def test_zed_writer_uses_context_servers_namespace(tmp_path: Path) -> None:
+    """Zed has its own schema — `context_servers`, not `mcpServers`."""
+    target = tmp_path / "zed_dir" / "settings.json"
+    target.parent.mkdir()
+
+    result = ZedWriter().write(path_override=target)
+    assert result.status == "written"
+
+    data = _read(target)
+    assert "context_servers" in data
+    assert "mcpServers" not in data
+    assert data["context_servers"]["autosearch"]["command"] == "autosearch-mcp"
+
+
+def test_writer_preserves_unrelated_keys(tmp_path: Path) -> None:
+    """Critical: real configs contain other servers / settings the user owns.
+    Our write must merge, never clobber."""
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+    target.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "other-server": {"command": "other", "type": "stdio"},
+                },
+                "userSetting": "do-not-touch",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    ClaudeCodeWriter().write(path_override=target)
+
+    data = _read(target)
+    assert data["userSetting"] == "do-not-touch"
+    assert data["mcpServers"]["other-server"] == {"command": "other", "type": "stdio"}
+    assert data["mcpServers"]["autosearch"]["command"] == "autosearch-mcp"
+
+
+def test_writer_already_set_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+    writer = ClaudeCodeWriter()
+
+    first = writer.write(path_override=target)
+    second = writer.write(path_override=target)
+
+    assert first.status == "written"
+    assert second.status == "already-set"
+
+
+def test_writer_skipped_when_parent_dir_missing(tmp_path: Path) -> None:
+    target = tmp_path / "absent_client_dir" / "mcp.json"
+    # parent never created
+    result = ClaudeCodeWriter().write(path_override=target)
+    assert result.status == "skipped"
+    assert not target.exists()
+
+
+def test_writer_backs_up_corrupt_json_and_rewrites(tmp_path: Path) -> None:
+    """Million-user safety: never silently overwrite a user's config. If the
+    file is unparseable, move it to <name>.bak.<ts> first."""
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+    target.write_text("{this is not json", encoding="utf-8")
+
+    result = ClaudeCodeWriter().write(path_override=target)
+    assert result.status == "backup-and-replaced"
+    assert result.backup_path is not None
+    assert result.backup_path.exists()
+    assert result.backup_path.read_text(encoding="utf-8") == "{this is not json"
+
+    data = _read(target)
+    assert data["mcpServers"]["autosearch"]["command"] == "autosearch-mcp"
+
+
+def test_dry_run_does_not_modify_anything(tmp_path: Path) -> None:
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+
+    result = ClaudeCodeWriter().write(path_override=target, dry_run=True)
+    assert result.status == "written"
+    assert not target.exists(), "dry-run must not touch the filesystem"
+
+
+def test_dry_run_reports_backup_for_corrupt_file_without_renaming(tmp_path: Path) -> None:
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+    target.write_text("garbage", encoding="utf-8")
+
+    result = ClaudeCodeWriter().write(path_override=target, dry_run=True)
+    assert result.status == "backup-and-replaced"
+    # original still in place, no backup created
+    assert target.read_text(encoding="utf-8") == "garbage"
+
+
+def test_verify_returns_false_when_entry_missing(tmp_path: Path) -> None:
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+    target.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    ok, msg = ClaudeCodeWriter().verify(path_override=target)
+    assert ok is False
+    assert "no `mcpServers.autosearch` entry" in msg
+
+
+def test_verify_detects_wrong_namespace(tmp_path: Path) -> None:
+    """The exact bug the old writer caused: entry at root, no `mcpServers`
+    namespace. verify() should catch it."""
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+    target.write_text(
+        json.dumps({"autosearch": {"command": "autosearch-mcp"}}),
+        encoding="utf-8",
+    )
+    ok, msg = ClaudeCodeWriter().verify(path_override=target)
+    assert ok is False
+    assert "mcpServers" in msg
+
+
+def test_verify_passes_after_writer_runs(tmp_path: Path) -> None:
+    target = tmp_path / "claude" / "mcp.json"
+    target.parent.mkdir()
+    writer = ClaudeCodeWriter()
+    writer.write(path_override=target)
+
+    ok, msg = writer.verify(path_override=target)
+    assert ok is True
+    assert "autosearch-mcp" in msg
+
+
+def test_write_for_clients_runs_each_known_writer(tmp_path: Path, monkeypatch) -> None:
+    """The orchestrator hits every registered client (skipping those whose
+    config dir doesn't exist) without crashing."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".cursor").mkdir()
+    # zed dir intentionally missing
+
+    results = write_for_clients()
+    by_client = {r.client: r for r in results}
+    assert by_client["claude"].status == "written"
+    assert by_client["cursor"].status == "written"
+    assert by_client["zed"].status == "skipped"
+
+
+def test_writers_registry_lists_three_clients() -> None:
+    assert set(WRITERS) == {"claude", "cursor", "zed"}


### PR DESCRIPTION
## Summary

Closes plan §P0-D, the last of the four runtime-reliability P0s from the million-user audit.

### The bug

`_auto_configure_mcp` wrote `{"autosearch": {"command": "autosearch-mcp", "type": "stdio"}}` flat at the root of every config file. But Claude Code, Cursor, and Zed each look for the entry under a *namespace key*:

| Client | File | Schema key |
|---|---|---|
| Claude Code | `~/.claude/mcp.json` | `mcpServers.<name>` |
| Cursor | `~/.cursor/mcp.json` | `mcpServers.<name>` |
| Zed | `~/.config/zed/settings.json` | `context_servers.<name>` |

Since the entry never landed under those namespaces, the clients silently couldn't see it. `init` reported "MCP server: ready", users restarted Claude Code, and no autosearch tools appeared. Hours of "support drain" per million users.

(Confirmed live: my own `~/.claude/mcp.json` had `{"autosearch": {...}}` at root and Claude Code wasn't picking it up — `docs/mcp-clients.md:27-39` documents the actual expected shape.)

### The fix

New module `autosearch/cli/mcp_config_writers.py`:
- One writer per client (`ClaudeCodeWriter`, `CursorWriter`, `ZedWriter`)
- Each knows its canonical config path + namespace key + entry schema
- `merge` semantics — never clobbers unrelated keys (other MCP servers, user settings)
- Backs up corrupt JSON to `<file>.bak.<unix-ts>` instead of silently overwriting
- `verify(...)` returns `(ok, message)` — used by `mcp-check --client`
- Adding a new client = subclass `_BaseWriter` + register in `WRITERS`

Wired into:
- `_auto_configure_mcp` — now delegates to `write_for_clients(...)`, reports per-client status
- `init --dry-run` (new flag) — prints what would be written, touches no files
- `mcp-check --client claude|cursor|zed` (new flag) — server-side tool registry check + client-side schema check, both gates exit non-zero on failure

### Verification

- `ruff check .` clean / `ruff format --check .` clean (394 files)
- `pytest -q -m "not real_llm and not perf and not slow and not network"` → **795 passed** (777 baseline + 14 writer + 4 CLI)
- Fresh wheel smoke:
  ```
  $ HOME=/tmp/fakehome autosearch init
  ✅ MCP server [claude: written; cursor: written]

  $ cat /tmp/fakehome/.claude/mcp.json
  { "mcpServers": { "autosearch": { "command": "autosearch-mcp", "type": "stdio" } } }

  $ HOME=/tmp/fakehome autosearch mcp-check --client claude
  Client config check (claude):
    ✓ /tmp/fakehome/.claude/mcp.json: mcpServers.autosearch -> autosearch-mcp
  ```

## Test plan

- [ ] CI green
- [ ] Manual on real install: rerun `autosearch init` (or `init --dry-run` first), verify Claude Code now sees the autosearch tools after restart
- [ ] Manual: corrupt `~/.claude/mcp.json` deliberately, run `init`, confirm the original is preserved at `mcp.json.bak.<ts>` and a fresh valid config replaces it

🤖 Generated with [Claude Code](https://claude.com/claude-code)