### PR TITLE
fix(governance): harden discourse routing review follow-ups

### DIFF
--- a/autosearch/core/channel_select.py
+++ b/autosearch/core/channel_select.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from pathlib import Path
 import re
 
-from autosearch.skills.loader import SkillLoadError, _extract_frontmatter
+from autosearch.skills.loader import SkillLoadError, load_frontmatter
 
 _SKILLS_ROOT = Path(__file__).resolve().parents[1] / "skills" / "channels"
 _MODE_LIMITS = {"fast": 5, "deep": 8}
@@ -174,9 +174,10 @@ def _keyword_variants(value: str) -> set[str]:
     if _CJK_PATTERN.search(normalized):
         return {variant for variant in variants if variant}
 
-    for token in _WORD_PATTERN.findall(normalized):
-        if len(token) >= 3:
-            variants.add(token)
+    if " " not in normalized:
+        for token in _WORD_PATTERN.findall(normalized):
+            if len(token) >= 3:
+                variants.add(token)
 
     return {variant for variant in variants if len(variant) >= 3}
 
@@ -226,8 +227,7 @@ def _load_channel_route_catalog() -> tuple[ChannelRouteSpec, ...]:
             continue
 
         try:
-            raw = skill_path.read_text(encoding="utf-8")
-            payload = _extract_frontmatter(raw, skill_path)
+            payload = load_frontmatter(skill_path)
         except (OSError, SkillLoadError):
             continue
 
@@ -273,6 +273,9 @@ def _load_channel_route_catalog() -> tuple[ChannelRouteSpec, ...]:
         )
 
     return tuple(sorted(specs, key=lambda spec: spec.name))
+
+
+load_channel_route_catalog = _load_channel_route_catalog
 
 
 def _channels_by_domain(
@@ -362,7 +365,7 @@ def select_channels(
     query_lower = _normalize_text(query)
     query_tokens = _query_tokens(query_lower)
     has_cjk = _has_cjk(query)
-    catalog = _load_channel_route_catalog()
+    catalog = load_channel_route_catalog()
     channels_by_domain = _channels_by_domain(catalog)
 
     scores: dict[str, int] = {}

--- a/autosearch/core/channel_select.py
+++ b/autosearch/core/channel_select.py
@@ -127,6 +127,8 @@ _CHANNEL_ALIASES: dict[str, tuple[str, ...]] = {
 
 @dataclass(frozen=True, slots=True)
 class ChannelRouteSpec:
+    """Routing metadata distilled from a channel skill's frontmatter."""
+
     name: str
     domains: tuple[str, ...]
     scenarios: tuple[str, ...]
@@ -162,6 +164,7 @@ def _normalize_domain(value: str) -> str:
 
 
 def _keyword_variants(value: str) -> set[str]:
+    """Expand a routing hint into safe match variants without oversplitting phrases."""
     normalized = _normalize_text(value.replace("-", " "))
     if not normalized:
         return set()
@@ -217,6 +220,7 @@ def _channel_keywords(
 
 @lru_cache(maxsize=1)
 def _load_channel_route_catalog() -> tuple[ChannelRouteSpec, ...]:
+    """Build the cached routing catalog from channel `SKILL.md` metadata."""
     if not _SKILLS_ROOT.is_dir():
         return ()
 
@@ -301,6 +305,7 @@ def _query_tokens(query_lower: str) -> set[str]:
 
 
 def _matches_query(term: str, query_lower: str, query_tokens: set[str]) -> bool:
+    """Match short aliases on token boundaries and longer terms by substring."""
     if len(term) < 3 and term.isascii():
         return term in query_tokens
     return term in query_lower
@@ -338,6 +343,7 @@ def _domain_score(
     query_tokens: set[str],
     channels: tuple[ChannelRouteSpec, ...],
 ) -> int:
+    """Score a metadata domain from both domain keywords and member-channel matches."""
     keyword_score = sum(1 for keyword in _DOMAIN_KEYWORDS.get(domain, ()) if keyword in query_lower)
     channel_scores = sorted(
         (_channel_match_score(spec, query_lower, query_tokens) for spec in channels),

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -46,6 +46,8 @@ _TIER1_ENV_PATTERNS = ("API_KEY", "TIKHUB", "YOUTUBE", "FIRECRAWL", "OPENROUTER"
 
 @dataclass
 class ChannelStatus:
+    """Computed health state for one channel as shown by `autosearch doctor`."""
+
     channel: str
     status: str  # "ok" | "warn" | "off"
     message: str

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -190,9 +190,8 @@ def format_report(results: list[ChannelStatus]) -> str:
 
 def _resolve_tier(spec: SkillSpec, all_requires: list[str]) -> int:
     """Resolve doctor tier from declared metadata first, then infer as fallback."""
-    declared_tier = getattr(spec, "tier", None)
-    if declared_tier is not None:
-        return declared_tier
+    if spec.tier is not None:
+        return spec.tier
     return _compute_tier(all_requires)
 
 
@@ -220,9 +219,8 @@ def _compute_tier(all_requires: list[str]) -> int:
 
 def _resolve_fix_hint(spec: SkillSpec, unmet_requires: list[str]) -> str:
     """Resolve fix hint from declared metadata first, then infer as fallback."""
-    declared_fix_hint = getattr(spec, "fix_hint", None)
-    if isinstance(declared_fix_hint, str) and declared_fix_hint.strip():
-        return declared_fix_hint.strip()
+    if spec.fix_hint is not None and spec.fix_hint.strip():
+        return spec.fix_hint.strip()
     return _fix_hint(unmet_requires)
 
 

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from autosearch.skills import SkillLoadError, load_all
+
+if TYPE_CHECKING:
+    from autosearch.skills.loader import SkillSpec
 
 # Maps unmet env var names → actionable fix commands (1:1 from Agent-Reach cookie_extract.py)
 _ENV_FIX_HINTS: dict[str, str] = {
@@ -182,7 +186,7 @@ def format_report(results: list[ChannelStatus]) -> str:
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
-def _resolve_tier(spec: object, all_requires: list[str]) -> int:
+def _resolve_tier(spec: SkillSpec, all_requires: list[str]) -> int:
     """Resolve doctor tier from declared metadata first, then infer as fallback."""
     declared_tier = getattr(spec, "tier", None)
     if declared_tier is not None:
@@ -212,7 +216,7 @@ def _compute_tier(all_requires: list[str]) -> int:
     return 0
 
 
-def _resolve_fix_hint(spec: object, unmet_requires: list[str]) -> str:
+def _resolve_fix_hint(spec: SkillSpec, unmet_requires: list[str]) -> str:
     """Resolve fix hint from declared metadata first, then infer as fallback."""
     declared_fix_hint = getattr(spec, "fix_hint", None)
     if isinstance(declared_fix_hint, str) and declared_fix_hint.strip():

--- a/autosearch/skills/__init__.py
+++ b/autosearch/skills/__init__.py
@@ -6,6 +6,7 @@ from autosearch.skills.loader import (
     SkillSpec,
     WhenToUse,
     load_all,
+    load_frontmatter,
     load_skill,
 )
 
@@ -16,5 +17,6 @@ __all__ = [
     "SkillSpec",
     "WhenToUse",
     "load_all",
+    "load_frontmatter",
     "load_skill",
 ]

--- a/autosearch/skills/channels/__init__.py
+++ b/autosearch/skills/channels/__init__.py
@@ -16,6 +16,7 @@ def resolve_skill_module(
     *,
     module_name: str | None = None,
 ) -> ModuleType:
+    """Load a shipped channel module directly from the packaged skills tree."""
     module_path = _CHANNELS_ROOT / channel_name / module_relative_path
     spec = importlib.util.spec_from_file_location(
         module_name or f"{channel_name}_{module_path.stem}",

--- a/autosearch/skills/channels/__init__.py
+++ b/autosearch/skills/channels/__init__.py
@@ -17,13 +17,25 @@ def resolve_skill_module(
     module_name: str | None = None,
 ) -> ModuleType:
     """Load a shipped channel module directly from the packaged skills tree."""
-    module_path = _CHANNELS_ROOT / channel_name / module_relative_path
+    channels_root = _CHANNELS_ROOT.resolve()
+    channel_part = Path(channel_name)
+    module_part = Path(module_relative_path)
+    if channel_part.is_absolute() or module_part.is_absolute():
+        raise ValueError("channel module paths must be relative")
+
+    channel_root = (channels_root / channel_part).resolve()
+    module_path = (channel_root / module_part).resolve()
+    if not channel_root.is_relative_to(channels_root):
+        raise ValueError(f"Channel path {channel_root} escapes channels root")
+    if not module_path.is_relative_to(channel_root):
+        raise ValueError(f"Module path {module_path} escapes channel root")
+
     spec = importlib.util.spec_from_file_location(
         module_name or f"{channel_name}_{module_path.stem}",
         module_path,
     )
     if spec is None or spec.loader is None:
-        raise AssertionError(f"Failed to load module spec from {module_path}")
+        raise ImportError(f"Failed to load module spec from {module_path}")
 
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/autosearch/skills/channels/__init__.py
+++ b/autosearch/skills/channels/__init__.py
@@ -1,1 +1,29 @@
 """Packaged channel skill library shipped with autosearch."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_CHANNELS_ROOT = Path(__file__).resolve().parent
+__all__ = ["resolve_skill_module"]
+
+
+def resolve_skill_module(
+    channel_name: str,
+    module_relative_path: str,
+    *,
+    module_name: str | None = None,
+) -> ModuleType:
+    module_path = _CHANNELS_ROOT / channel_name / module_relative_path
+    spec = importlib.util.spec_from_file_location(
+        module_name or f"{channel_name}_{module_path.stem}",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load module spec from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/autosearch/skills/channels/discourse_forum/SKILL.md
+++ b/autosearch/skills/channels/discourse_forum/SKILL.md
@@ -12,7 +12,7 @@ fallback_chain: [api_search]
 when_to_use:
   query_languages: [zh, mixed]
   query_types: [community, developer, product-feedback, tech-discussion, chinese-ugc]
-  domain_hints: [linux.do, linux do, discourse, forum, claude code]
+  domain_hints: [linux.do, linux do, discourse, forum]
   avoid_for: [academic, consumer-lifestyle, multimedia]
 quality_hint:
   typical_yield: medium

--- a/autosearch/skills/channels/discourse_forum/methods/api_search.py
+++ b/autosearch/skills/channels/discourse_forum/methods/api_search.py
@@ -63,6 +63,7 @@ def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
 
 
 def _clean_site_search_title(title: str, *, site: Mapping[str, str]) -> str:
+    """Strip a site-specific forum suffix from fallback search result titles."""
     cleaned = title.strip()
     title_suffix = site.get("title_suffix", "").strip()
     if title_suffix and cleaned.endswith(title_suffix):
@@ -125,6 +126,7 @@ def _site_search_query(site: Mapping[str, str], query: str) -> str:
 
 
 def _same_origin(url: str, base_url: str) -> bool:
+    """Require exact scheme and host equality before trusting a fallback result URL."""
     parsed_url = urlparse(url)
     parsed_base = urlparse(base_url)
     return parsed_url.scheme == parsed_base.scheme and parsed_url.netloc == parsed_base.netloc
@@ -176,6 +178,7 @@ async def _fetch_topic_markdown(
     *,
     http_client: httpx.AsyncClient | None = None,
 ) -> str | None:
+    """Fetch topic markdown via the Jina reader and normalize the payload."""
     reader_url = _reader_url(url)
     try:
         if http_client is not None:
@@ -196,6 +199,7 @@ async def _enrich_evidence(
     *,
     http_client: httpx.AsyncClient | None = None,
 ) -> Evidence:
+    """Hydrate one evidence item with full topic markdown when available."""
     markdown = await _fetch_topic_markdown(evidence.url, http_client=http_client)
     if not markdown:
         return evidence
@@ -221,6 +225,7 @@ async def _enrich_evidence(
 
 
 async def _search_site(query: SubQuery, *, site: Mapping[str, str]) -> list[Evidence]:
+    """Fallback to site-limited DDGS search when the forum API is blocked."""
     results = await asyncio.to_thread(
         lambda: list(DDGS().text(_site_search_query(site, query.text), max_results=MAX_RESULTS))
     )
@@ -248,6 +253,7 @@ async def search(
     http_client: httpx.AsyncClient | None = None,
     site_key: str = DEFAULT_SITE_KEY,
 ) -> list[Evidence]:
+    """Search a public Discourse forum and enrich matched topics with full text."""
     if http_client is None:
         async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
             return await search(query, http_client=client, site_key=site_key)

--- a/autosearch/skills/channels/discourse_forum/methods/api_search.py
+++ b/autosearch/skills/channels/discourse_forum/methods/api_search.py
@@ -65,9 +65,9 @@ def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
 def _clean_site_search_title(title: str, *, site: Mapping[str, str]) -> str:
     """Strip a site-specific forum suffix from fallback search result titles."""
     cleaned = title.strip()
-    title_suffix = site.get("title_suffix", "").strip()
+    title_suffix = site.get("title_suffix", "")
     if title_suffix and cleaned.endswith(title_suffix):
-        cleaned = cleaned[: -len(title_suffix)].strip()
+        cleaned = cleaned[: -len(title_suffix)].rstrip()
     return cleaned
 
 
@@ -256,8 +256,18 @@ async def search(
     """Search a public Discourse forum and enrich matched topics with full text."""
     if http_client is None:
         async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
-            return await search(query, http_client=client, site_key=site_key)
+            return await _search_with_client(query, http_client=client, site_key=site_key)
 
+    return await _search_with_client(query, http_client=http_client, site_key=site_key)
+
+
+async def _search_with_client(
+    query: SubQuery,
+    *,
+    http_client: httpx.AsyncClient,
+    site_key: str,
+) -> list[Evidence]:
+    """Run Discourse search using a caller-owned async HTTP client."""
     site = SITE_PRESETS[site_key]
     try:
         params = {"q": query.text}

--- a/autosearch/skills/channels/discourse_forum/methods/api_search.py
+++ b/autosearch/skills/channels/discourse_forum/methods/api_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import html
 import asyncio
+from importlib import import_module
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
@@ -14,8 +15,8 @@ from autosearch.core.models import Evidence, FetchedPage, SubQuery
 
 try:
     from ddgs import DDGS
-except ImportError:  # pragma: no cover - compatibility fallback
-    from duckduckgo_search import DDGS  # type: ignore[import-not-found]
+except ImportError:
+    DDGS = import_module("duckduckgo_search").DDGS
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="discourse_forum")
 
@@ -33,6 +34,7 @@ SITE_PRESETS: dict[str, dict[str, str]] = {
         "base_url": "https://linux.do",
         "search_endpoint": "/search.json",
         "source_channel": "discourse_forum:linux_do",
+        "title_suffix": " - LINUX DO",
     }
 }
 
@@ -60,10 +62,11 @@ def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
     return f"{candidate.rstrip()}…"
 
 
-def _clean_site_search_title(title: str) -> str:
+def _clean_site_search_title(title: str, *, site: Mapping[str, str]) -> str:
     cleaned = title.strip()
-    if cleaned.endswith(" - LINUX DO"):
-        cleaned = cleaned[: -len(" - LINUX DO")].strip()
+    title_suffix = site.get("title_suffix", "").strip()
+    if title_suffix and cleaned.endswith(title_suffix):
+        cleaned = cleaned[: -len(title_suffix)].strip()
     return cleaned
 
 
@@ -140,7 +143,7 @@ def _to_site_search_evidence(
     if "/t/" not in parsed.path:
         return None
 
-    title = _clean_site_search_title(str(result.get("title") or "").strip())
+    title = _clean_site_search_title(str(result.get("title") or "").strip(), site=site)
     if not title:
         return None
 
@@ -245,24 +248,19 @@ async def search(
     http_client: httpx.AsyncClient | None = None,
     site_key: str = DEFAULT_SITE_KEY,
 ) -> list[Evidence]:
+    if http_client is None:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
+            return await search(query, http_client=client, site_key=site_key)
+
     site = SITE_PRESETS[site_key]
     try:
         params = {"q": query.text}
         url = f"{site['base_url']}{site['search_endpoint']}"
-
-        if http_client is not None:
-            response = await http_client.get(
-                url,
-                params=params,
-                headers={"User-Agent": USER_AGENT},
-            )
-        else:
-            async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=True) as client:
-                response = await client.get(
-                    url,
-                    params=params,
-                    headers={"User-Agent": USER_AGENT},
-                )
+        response = await http_client.get(
+            url,
+            params=params,
+            headers={"User-Agent": USER_AGENT},
+        )
 
         response.raise_for_status()
         payload = response.json()

--- a/autosearch/skills/loader.py
+++ b/autosearch/skills/loader.py
@@ -136,10 +136,7 @@ def load_skill(skill_dir: Path) -> SkillSpec:
     if not skill_path.is_file():
         raise SkillLoadError(f"Expected {SKILL_FILENAME} in {skill_dir}")
 
-    try:
-        payload = load_frontmatter(skill_path)
-    except SkillLoadError:
-        raise
+    payload = load_frontmatter(skill_path)
     payload["skill_dir"] = skill_dir
 
     try:

--- a/autosearch/skills/loader.py
+++ b/autosearch/skills/loader.py
@@ -19,6 +19,8 @@ class SkillLoadError(ValueError):
 
 
 class MethodSpec(BaseModel):
+    """Validated runtime metadata for a single skill method."""
+
     id: str
     impl: str
     requires: list[str] = Field(default_factory=list)
@@ -35,6 +37,8 @@ class MethodSpec(BaseModel):
 
 
 class WhenToUse(BaseModel):
+    """Query-shape hints used by routing and docs surfaces."""
+
     query_languages: list[Literal["zh", "en", "mixed"]] = Field(default_factory=list)
     query_types: list[str] = Field(default_factory=list)
     domain_hints: list[str] = Field(default_factory=list)
@@ -42,11 +46,15 @@ class WhenToUse(BaseModel):
 
 
 class QualityHint(BaseModel):
+    """Lightweight quality annotations exposed in docs and runtime metadata."""
+
     typical_yield: Literal["low", "medium", "medium-high", "high", "unknown"] = "unknown"
     chinese_native: bool = False
 
 
 class SkillSpec(BaseModel):
+    """Validated frontmatter contract for one skill directory."""
+
     name: str
     description: str
     version: int = 1
@@ -82,6 +90,7 @@ class SkillSpec(BaseModel):
 
 
 def _extract_frontmatter(raw_text: str, skill_path: Path) -> dict[str, object]:
+    """Parse YAML frontmatter from a skill file and return the mapping payload."""
     lines = raw_text.splitlines()
     start_index = next((index for index, line in enumerate(lines) if line.strip() == "---"), None)
     if start_index is None:
@@ -110,6 +119,7 @@ def _extract_frontmatter(raw_text: str, skill_path: Path) -> dict[str, object]:
 
 
 def load_frontmatter(skill_path: Path) -> dict[str, object]:
+    """Read a skill file from disk and return only its validated frontmatter."""
     skill_path = Path(skill_path)
     try:
         raw_text = skill_path.read_text(encoding="utf-8")
@@ -120,6 +130,7 @@ def load_frontmatter(skill_path: Path) -> dict[str, object]:
 
 
 def load_skill(skill_dir: Path) -> SkillSpec:
+    """Load one skill directory into a validated `SkillSpec`."""
     skill_dir = Path(skill_dir)
     skill_path = skill_dir / SKILL_FILENAME
     if not skill_path.is_file():
@@ -138,6 +149,7 @@ def load_skill(skill_dir: Path) -> SkillSpec:
 
 
 def load_all(root: Path) -> list[SkillSpec]:
+    """Load every skill directory under `root` in deterministic name order."""
     root = Path(root)
     if not root.is_dir():
         raise SkillLoadError(f"Skill root does not exist or is not a directory: {root}")

--- a/autosearch/skills/loader.py
+++ b/autosearch/skills/loader.py
@@ -109,6 +109,16 @@ def _extract_frontmatter(raw_text: str, skill_path: Path) -> dict[str, object]:
     return payload
 
 
+def load_frontmatter(skill_path: Path) -> dict[str, object]:
+    skill_path = Path(skill_path)
+    try:
+        raw_text = skill_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillLoadError(f"Failed to read {skill_path}: {exc}") from exc
+
+    return _extract_frontmatter(raw_text, skill_path)
+
+
 def load_skill(skill_dir: Path) -> SkillSpec:
     skill_dir = Path(skill_dir)
     skill_path = skill_dir / SKILL_FILENAME
@@ -116,11 +126,9 @@ def load_skill(skill_dir: Path) -> SkillSpec:
         raise SkillLoadError(f"Expected {SKILL_FILENAME} in {skill_dir}")
 
     try:
-        raw_text = skill_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise SkillLoadError(f"Failed to read {skill_path}: {exc}") from exc
-
-    payload = _extract_frontmatter(raw_text, skill_path)
+        payload = load_frontmatter(skill_path)
+    except SkillLoadError:
+        raise
     payload["skill_dir"] = skill_dir
 
     try:

--- a/docs/channels.mdx
+++ b/docs/channels.mdx
@@ -17,6 +17,7 @@ No configuration needed. Available immediately after install.
 | dblp | en | Computer science bibliography — papers, proceedings | medium |
 | ddgs | en, mixed | DuckDuckGo web search, no auth required | medium |
 | devto | en, mixed | Developer blog articles tagged by technology | medium |
+| discourse_forum | zh, mixed | Linux DO and Discourse-based public forum discussions | medium |
 | dockerhub | en | Docker image and container registry search | medium |
 | github | en | Code, issues, and repository discovery | high |
 | google_news | en, mixed | Current news headlines via Google News RSS | high |
@@ -25,7 +26,6 @@ No configuration needed. Available immediately after install.
 | infoq_cn | zh, mixed | Chinese engineering articles from InfoQ 中文 | medium |
 | kr36 | zh, mixed | Chinese tech business news and startup funding from 36kr | medium |
 | linkedin | en, mixed | LinkedIn public company profiles and articles via Jina Reader | low |
-| discourse_forum | zh, mixed | Linux DO and Discourse-based public forum discussions | medium |
 | openalex | en, mixed | Scholarly works via OpenAlex open-access API | high |
 | package_search | en, mixed | PyPI and npm package discovery | medium |
 | papers | en, mixed | Multi-source academic search (arxiv + pubmed + biorxiv + more) | high |

--- a/tests/channels/discourse_forum/test_api_search.py
+++ b/tests/channels/discourse_forum/test_api_search.py
@@ -1,31 +1,20 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
+from datetime import UTC, datetime
 
 import httpx
 import pytest
 
 from autosearch.core.models import SubQuery
+from autosearch.skills.channels import resolve_skill_module
 
 
 def _load_module():
-    module_path = (
-        Path(__file__).resolve().parents[3]
-        / "autosearch"
-        / "skills"
-        / "channels"
-        / "discourse_forum"
-        / "methods"
-        / "api_search.py"
+    return resolve_skill_module(
+        "discourse_forum",
+        "methods/api_search.py",
+        module_name="test_discourse_forum_api_search",
     )
-    spec = importlib.util.spec_from_file_location("test_discourse_forum_api_search", module_path)
-    if spec is None or spec.loader is None:
-        raise AssertionError(f"Failed to load module spec from {module_path}")
-
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 MODULE = _load_module()
@@ -46,6 +35,26 @@ def _query() -> SubQuery:
 
 def _client(handler) -> httpx.AsyncClient:
     return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_site_search_title_uses_site_specific_suffix() -> None:
+    evidence = MODULE._to_site_search_evidence(
+        {
+            "title": "Custom title - TEST FORUM",
+            "href": "https://linux.do/t/topic/1798141",
+            "body": "摘要。",
+        },
+        site={
+            "base_url": "https://linux.do",
+            "search_endpoint": "/search.json",
+            "source_channel": "discourse_forum:test_forum",
+            "title_suffix": " - TEST FORUM",
+        },
+        fetched_at=datetime.now(UTC),
+    )
+
+    assert evidence is not None
+    assert evidence.title == "Custom title"
 
 
 @pytest.mark.asyncio
@@ -359,6 +368,60 @@ async def test_search_enriches_site_search_results_with_full_topic_content(
         "reader_url": "https://r.jina.ai/https://linux.do/t/topic/743319",
         "title": "Claude Code 小白指引贴 - 文档共建",
     }
+
+
+@pytest.mark.asyncio
+async def test_search_reuses_single_client_for_search_and_enrichment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_clients = 0
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            nonlocal created_clients
+            created_clients += 1
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def get(self, url: str, *, params=None, headers=None) -> httpx.Response:
+            if url == "https://linux.do/search.json":
+                return httpx.Response(
+                    200,
+                    json={
+                        "posts": [
+                            {
+                                "topic_id": 760680,
+                                "topic_title_headline": "Claude Code 上手指南",
+                                "blurb": "帖子摘要。",
+                            }
+                        ]
+                    },
+                    request=httpx.Request("GET", url, params=params, headers=headers),
+                )
+            if url == "https://r.jina.ai/https://linux.do/t/760680":
+                return httpx.Response(
+                    200,
+                    text=(
+                        "Title: Claude Code 上手指南 - LINUX DO\n\n"
+                        "URL Source: https://linux.do/t/760680\n\n"
+                        "Markdown Content:\n"
+                        "这里是完整正文。"
+                    ),
+                    request=httpx.Request("GET", url, headers=headers),
+                )
+            raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(MODULE.httpx, "AsyncClient", _FakeAsyncClient)
+
+    results = await search(_query())
+
+    assert created_clients == 1
+    assert len(results) == 1
+    assert results[0].content == "这里是完整正文。"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_channel_select_metadata.py
+++ b/tests/unit/test_channel_select_metadata.py
@@ -1,10 +1,41 @@
 from __future__ import annotations
 
+import pytest
+
 from autosearch.core import channel_select
 from autosearch.core.channel_select import ChannelRouteSpec, select_channels
 
 
-def test_selector_prefers_channel_alias_match_within_metadata_domain() -> None:
+@pytest.fixture(autouse=True)
+def clear_channel_catalog_cache() -> None:
+    cache_clear = getattr(channel_select.load_channel_route_catalog, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()
+    yield
+    cache_clear = getattr(channel_select.load_channel_route_catalog, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()
+
+
+def test_selector_prefers_channel_alias_match_within_metadata_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        channel_select,
+        "load_channel_route_catalog",
+        lambda: (
+            ChannelRouteSpec(
+                name="xiaohongshu",
+                domains=("chinese-ugc",),
+                scenarios=("community",),
+                query_types=("developer",),
+                query_languages=("zh", "mixed"),
+                aliases=("小红书", "xhs", "rednote"),
+                keywords=("社区", "种草"),
+            ),
+        ),
+    )
+
     result = select_channels("小红书上有没有人用 Cursor")
 
     assert "chinese-ugc" in result["groups"]
@@ -14,7 +45,7 @@ def test_selector_prefers_channel_alias_match_within_metadata_domain() -> None:
 def test_selector_uses_metadata_catalog_for_domain_membership(monkeypatch) -> None:
     monkeypatch.setattr(
         channel_select,
-        "_load_channel_route_catalog",
+        "load_channel_route_catalog",
         lambda: (
             ChannelRouteSpec(
                 name="custom_paper",
@@ -34,7 +65,43 @@ def test_selector_uses_metadata_catalog_for_domain_membership(monkeypatch) -> No
     assert result["channels"] == ["custom_paper"]
 
 
-def test_selector_mixes_domains_from_metadata_catalog() -> None:
+def test_selector_mixes_domains_from_metadata_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        channel_select,
+        "load_channel_route_catalog",
+        lambda: (
+            ChannelRouteSpec(
+                name="bilibili",
+                domains=("chinese-ugc",),
+                scenarios=("video",),
+                query_types=("community",),
+                query_languages=("zh", "mixed"),
+                aliases=("bilibili", "b站"),
+                keywords=("视频",),
+            ),
+            ChannelRouteSpec(
+                name="arxiv",
+                domains=("academic",),
+                scenarios=("paper-search",),
+                query_types=("paper-review",),
+                query_languages=("en", "mixed"),
+                aliases=("arxiv",),
+                keywords=("paper", "papers"),
+            ),
+            ChannelRouteSpec(
+                name="github",
+                domains=("code-package",),
+                scenarios=("repo",),
+                query_types=("developer",),
+                query_languages=("en", "mixed"),
+                aliases=("github",),
+                keywords=("repo", "repository"),
+            ),
+        ),
+    )
+
     result = select_channels("deep research across bilibili arxiv github", mode="deep")
 
     assert "chinese-ugc" in result["groups"]
@@ -43,3 +110,27 @@ def test_selector_mixes_domains_from_metadata_catalog() -> None:
     assert "bilibili" in result["channels"]
     assert "arxiv" in result["channels"]
     assert "github" in result["channels"]
+
+
+def test_selector_does_not_promote_phrase_fragment_as_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        channel_select,
+        "load_channel_route_catalog",
+        lambda: (
+            ChannelRouteSpec(
+                name="discourse_forum",
+                domains=("chinese-ugc",),
+                scenarios=("public-forum",),
+                query_types=("community",),
+                query_languages=("zh", "mixed"),
+                aliases=("linux do", "linuxdo", "discourse"),
+                keywords=("linux do", "linuxdo", "discourse"),
+            ),
+        ),
+    )
+
+    result = select_channels("linux kernel module bug")
+
+    assert "discourse_forum" not in result["channels"]

--- a/tests/unit/test_channel_select_metadata.py
+++ b/tests/unit/test_channel_select_metadata.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from autosearch.core import channel_select
@@ -7,7 +9,7 @@ from autosearch.core.channel_select import ChannelRouteSpec, select_channels
 
 
 @pytest.fixture(autouse=True)
-def clear_channel_catalog_cache() -> None:
+def clear_channel_catalog_cache() -> Iterator[None]:
     cache_clear = getattr(channel_select.load_channel_route_catalog, "cache_clear", None)
     if callable(cache_clear):
         cache_clear()

--- a/tests/unit/test_channel_skill_module_resolver.py
+++ b/tests/unit/test_channel_skill_module_resolver.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from autosearch.skills.channels import resolve_skill_module
+
+
+def test_resolve_skill_module_rejects_absolute_paths() -> None:
+    """Absolute paths cannot bypass the packaged channel root."""
+    with pytest.raises(ValueError, match="relative"):
+        resolve_skill_module("/tmp", "methods/api_search.py")
+
+    with pytest.raises(ValueError, match="relative"):
+        resolve_skill_module("discourse_forum", "/tmp/api_search.py")
+
+
+def test_resolve_skill_module_rejects_path_traversal() -> None:
+    """Relative traversal cannot escape a channel directory."""
+    with pytest.raises(ValueError, match="escapes channel root"):
+        resolve_skill_module("discourse_forum", "../ddgs/methods/api.py")

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 import autosearch.skills.loader as loader_module
-from autosearch.skills import SkillLoadError, load_all, load_skill
+from autosearch.skills import SkillLoadError, load_all, load_frontmatter, load_skill
 
 
 def _fixture_root() -> Path:
@@ -41,6 +41,13 @@ def test_load_valid_channel_skill() -> None:
     assert spec.tier == 1
     assert spec.fix_hint == "autosearch configure ARXIV_TOKEN <value>"
     assert spec.skill_dir.name == "valid_channel"
+
+
+def test_load_frontmatter_returns_mapping() -> None:
+    payload = load_frontmatter(_fixture_root() / "valid_channel" / "SKILL.md")
+
+    assert payload["name"] == "valid_channel"
+    assert payload["tier"] == 1
 
 
 def test_load_valid_tool_skill() -> None:


### PR DESCRIPTION
## What

Hardens the discourse forum + metadata-driven channel governance work that landed via #311.

## Why

#311 rebased the original discourse/governance work into main. This follow-up keeps the scope smaller and only addresses the remaining review-risk items from that thread:

- safer metadata routing tokenization
- public frontmatter / route-catalog helper surface
- shared AsyncClient reuse for Discourse search enrichment
- site-specific title cleanup for Discourse presets
- narrower discourse domain hints
- stronger regression tests around fallback, routing, and loader behavior
- docstrings for newly exposed governance helpers

## Scope

- [ ] Search pipeline
- [x] Channel (specify: `discourse_forum`)
- [x] Skills / PROTOCOL
- [ ] CI / hooks / infra
- [x] Docs / config

## Test

- [x] `.venv/bin/python -m pytest tests/unit/ -x -q -m "not real_llm and not slow and not network"` -> `485 passed, 14 warnings`
- [x] targeted discourse/governance tests -> `42 passed`
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] New/changed code has tests

## Security Impact

- New permissions or capabilities added? `No`
- Secrets / tokens / API keys handling changed? `No`
- New outbound network calls or external endpoints? `No`
- If any Yes — risk and mitigation:

## Evidence

- [x] Failing review feedback before + passing after
- [ ] Screenshot or trace
- [ ] Perf numbers (if relevant)

## Revert

Revert these commits to restore the #311 behavior without this hardening pass:

- `7018d49`
- `7b95922`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyword matching to prevent over-splitting multi-word phrases during channel selection, ensuring more accurate routing.
  * Fixed search result title normalization to properly strip formatting artifacts from Discourse forum results.

* **Improvements**
  * Enhanced Discourse forum search performance through efficient HTTP client reuse during topic enrichment.
  * Refined Discourse forum trigger criteria by removing "claude code" from domain hints for more precise channel selection.

* **Documentation**
  * Added docstrings throughout loader and channel selection modules for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->