### PR TITLE
fix(mcp): ZedWriter handles JSONC — stops nuking user font/theme settings

### DIFF
--- a/autosearch/cli/mcp_config_writers.py
+++ b/autosearch/cli/mcp_config_writers.py
@@ -21,6 +21,7 @@ Adding a new client = one new subclass + one entry in `WRITERS`.
 from __future__ import annotations
 
 import json
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -57,13 +58,28 @@ def _backup_corrupt_file(path: Path) -> Path:
 
 class _BaseWriter:
     """Shared logic: load existing config, place autosearch under the right
-    namespace, write back. Subclasses customize path + namespace key."""
+    namespace, write back. Subclasses customize path + namespace key, and may
+    override `_parse_text` and `_serialize` to support non-strict-JSON formats."""
 
     name: str = ""
     namespace_key: str = ""  # e.g. "mcpServers" or "context_servers"
 
     def default_path(self) -> Path:
         raise NotImplementedError
+
+    def _parse_text(self, raw: str) -> dict:
+        """Parse the existing config file. Default: strict JSON. Raises on
+        anything else."""
+        if not raw.strip():
+            return {}
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError("top-level value is not an object")
+        return data
+
+    def _serialize(self, existing: dict, original_text: str | None) -> str:
+        """Render the new file body. Default: pretty-printed JSON."""
+        return json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
 
     def write(
         self,
@@ -77,13 +93,12 @@ class _BaseWriter:
             return WriteResult(client=self.name, path=path, status="skipped")
 
         existing: dict[str, object] = {}
+        original_text: str | None = None
         backup_path: Path | None = None
         if path.exists():
             try:
-                raw = path.read_text(encoding="utf-8").strip()
-                existing = json.loads(raw) if raw else {}
-                if not isinstance(existing, dict):
-                    raise ValueError("top-level value is not an object")
+                original_text = path.read_text(encoding="utf-8")
+                existing = self._parse_text(original_text)
             except (json.JSONDecodeError, ValueError, OSError):
                 if dry_run:
                     return WriteResult(
@@ -93,6 +108,7 @@ class _BaseWriter:
                     )
                 backup_path = _backup_corrupt_file(path)
                 existing = {}
+                original_text = None
 
         servers = existing.setdefault(self.namespace_key, {})
         if not isinstance(servers, dict):
@@ -114,10 +130,7 @@ class _BaseWriter:
 
         servers["autosearch"] = target_entry
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
+        path.write_text(self._serialize(existing, original_text), encoding="utf-8")
         return WriteResult(
             client=self.name,
             path=path,
@@ -137,9 +150,9 @@ class _BaseWriter:
         if not path.exists():
             return False, f"{path} does not exist"
         try:
-            data = json.loads(path.read_text(encoding="utf-8") or "{}")
-        except json.JSONDecodeError as exc:
-            return False, f"{path} is not valid JSON: {exc}"
+            data = self._parse_text(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError) as exc:
+            return False, f"{path} is not parseable: {exc}"
         if not isinstance(data, dict):
             return False, f"{path} top-level is not an object"
 
@@ -173,12 +186,124 @@ class CursorWriter(_BaseWriter):
         return Path.home() / ".cursor" / "mcp.json"
 
 
+def _strip_jsonc(text: str) -> str:
+    """Strip `// line` and `/* block */` comments + trailing commas before `}` / `]`.
+
+    Naive — does not understand `//` inside string literals — but Zed
+    `settings.json` rarely embeds those, and getting it wrong only means we
+    fall back to the corrupt-file backup path, never silent data loss.
+    """
+    text = re.sub(r"(?m)//[^\n]*", "", text)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    text = re.sub(r",(\s*[}\]])", r"\1", text)
+    return text
+
+
+def _find_top_object_close(text: str) -> int | None:
+    """Return the index of the `}` that closes the top-level JSON object, or
+    None if the brace structure is broken. Aware of strings + JSONC comments."""
+    depth = 0
+    in_string = False
+    escape = False
+    in_line_comment = False
+    in_block_comment = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if escape:
+            escape = False
+            i += 1
+            continue
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_string:
+            if ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
 class ZedWriter(_BaseWriter):
+    """Zed uses JSONC (JSON with // comments and trailing commas).
+
+    The base writer's strict-JSON parser would reject a perfectly normal Zed
+    settings file as "corrupt" and back it up — wiping the user's editor
+    preferences. This subclass parses JSONC for read, and uses a surgical
+    text insert when adding `context_servers` for the first time so existing
+    comments and formatting survive untouched.
+    """
+
     name = "zed"
     namespace_key = "context_servers"
 
     def default_path(self) -> Path:
         return Path.home() / ".config" / "zed" / "settings.json"
+
+    def _parse_text(self, raw: str) -> dict:
+        if not raw.strip():
+            return {}
+        data = json.loads(_strip_jsonc(raw))
+        if not isinstance(data, dict):
+            raise ValueError("top-level value is not an object")
+        return data
+
+    def _serialize(self, existing: dict, original_text: str | None) -> str:
+        # Best path: surgical insert preserves comments + user formatting.
+        # Triggered only when the original file did NOT already contain a
+        # `context_servers` block — otherwise we don't know how to merge into
+        # the existing JSONC structure without parsing it, so we re-emit clean
+        # JSON (Zed still parses that, just loses comments).
+        target_entry = _autosearch_entry(existing[self.namespace_key]["autosearch"]["command"])
+        if original_text is not None and '"context_servers"' not in original_text:
+            close_idx = _find_top_object_close(original_text)
+            if close_idx is not None:
+                before = original_text[:close_idx].rstrip()
+                # Add a comma if the last non-whitespace char isn't already one
+                separator = "" if before.endswith(("{", ",")) else ","
+                block = (
+                    f"{separator}\n"
+                    f'  "context_servers": {{\n'
+                    f'    "autosearch": {{\n'
+                    f'      "command": {json.dumps(target_entry["command"])},\n'
+                    f'      "type": {json.dumps(target_entry["type"])}\n'
+                    f"    }}\n"
+                    f"  }}\n"
+                )
+                tail = original_text[close_idx:]
+                return before + block + tail
+        # Fallback: re-emit as plain JSON (loses any comments).
+        return json.dumps(existing, indent=2, ensure_ascii=False) + "\n"
 
 
 WRITERS: dict[str, _BaseWriter] = {

--- a/tests/unit/test_mcp_config_writers.py
+++ b/tests/unit/test_mcp_config_writers.py
@@ -190,3 +190,84 @@ def test_write_for_clients_runs_each_known_writer(tmp_path: Path, monkeypatch) -
 
 def test_writers_registry_lists_three_clients() -> None:
     assert set(WRITERS) == {"claude", "cursor", "zed"}
+
+
+# ── Zed JSONC handling ──────────────────────────────────────────────────────
+
+
+def test_zed_writer_does_not_treat_jsonc_settings_as_corrupt(tmp_path: Path) -> None:
+    """Regression: Zed ships `settings.json` as JSONC (// comments + trailing
+    commas). The original writer parsed it as strict JSON, called it corrupt,
+    backed it up, and wrote a fresh file — nuking the user's font/theme
+    settings. The Zed-specific writer must treat this file as parseable."""
+    target = tmp_path / "zed" / "settings.json"
+    target.parent.mkdir()
+    target.write_text(
+        """// Zed settings — preamble comment
+
+{
+  "ui_font_size": 16,
+  "buffer_font_size": 15,
+  "theme": {
+    "mode": "system",
+    "light": "One Light",
+    "dark": "One Dark",
+  },
+}
+""",
+        encoding="utf-8",
+    )
+
+    result = ZedWriter().write(path_override=target)
+    assert result.status == "written", "JSONC must be accepted, not backed up as corrupt"
+    assert result.backup_path is None, "no backup file should be created for valid JSONC"
+
+    new_text = target.read_text(encoding="utf-8")
+    # User's existing settings + comments must survive
+    assert "ui_font_size" in new_text
+    assert "buffer_font_size" in new_text
+    assert "Zed settings — preamble comment" in new_text, "comments must be preserved"
+    # And the new context_servers block must be present
+    assert '"context_servers"' in new_text
+    assert '"autosearch"' in new_text
+    assert '"autosearch-mcp"' in new_text
+
+
+def test_zed_writer_falls_back_to_plain_json_when_context_servers_already_present(
+    tmp_path: Path,
+) -> None:
+    """If the file already has a `context_servers` block we don't try to
+    surgically merge into it — re-emit as plain JSON. Comments are lost in
+    this case but data is preserved (Zed still reads JSON fine)."""
+    target = tmp_path / "zed" / "settings.json"
+    target.parent.mkdir()
+    target.write_text(
+        json.dumps(
+            {
+                "ui_font_size": 16,
+                "context_servers": {"other-server": {"command": "x", "type": "stdio"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = ZedWriter().write(path_override=target)
+    assert result.status == "written"
+    data = json.loads(target.read_text(encoding="utf-8"))
+    # Both servers preserved, autosearch added
+    assert data["context_servers"]["other-server"]["command"] == "x"
+    assert data["context_servers"]["autosearch"]["command"] == "autosearch-mcp"
+    assert data["ui_font_size"] == 16
+
+
+def test_zed_writer_idempotent_on_jsonc_file(tmp_path: Path) -> None:
+    target = tmp_path / "zed" / "settings.json"
+    target.parent.mkdir()
+    target.write_text(
+        '{ "ui_font_size": 16, } // trailing comma + comment',
+        encoding="utf-8",
+    )
+    writer = ZedWriter()
+    writer.write(path_override=target)
+    second = writer.write(path_override=target)
+    assert second.status == "already-set"


### PR DESCRIPTION
## Summary

Hot-fix on top of #315. While verifying #315 against my own machine I caught a real data-loss bug: `ZedWriter` treated valid JSONC files as "corrupt JSON", backed them up, and wrote a fresh empty config — wiping the user's font sizes / theme / and any other Zed preferences in the process.

### Root cause

Zed ships `~/.config/zed/settings.json` as **JSONC** — JSON with `// comments` and trailing commas. The base `_BaseWriter._parse_text` is strict `json.loads`, which raises on either. The strict failure dropped into the "back up corrupt file" path, the original was renamed to `settings.json.bak.<ts>`, and the writer emitted a fresh `{"context_servers": {"autosearch": ...}}` — no `ui_font_size`, no `theme`, nothing the user had configured.

This bug is in #315 and is live on main right now.

### Fix

- Refactor `_BaseWriter` to expose two override hooks: `_parse_text` and `_serialize` (reads + writes), so format-specific subclasses can plug in
- `ZedWriter._parse_text` calls a tiny JSONC stripper (`//` line comments + `/* block */` + trailing commas before `}` or `]`) before `json.loads`
- `ZedWriter._serialize`: when the original file did NOT contain `context_servers`, do a **surgical text insert** — find the closing `}` of the top-level object (brace-matching that's aware of strings + JSONC comments), splice the new block in just before it. Original comments + formatting + every other setting survive byte-for-byte
- When `context_servers` is already present we fall back to plain `json.dumps` (loses comments — acceptable, Zed still reads JSON fine)
- `verify(...)` rewired to use `_parse_text` so it accepts JSONC too (was rejecting valid Zed configs as "not valid JSON")

### Verification

- `ruff check . && ruff format --check .` clean
- `pytest -m "not real_llm and not perf and not slow and not network"` → **800 passed** (797 + 3 new Zed JSONC tests)
- New regressions:
  - `test_zed_writer_does_not_treat_jsonc_settings_as_corrupt` — JSONC file with comments + trailing commas survives + comments preserved
  - `test_zed_writer_falls_back_to_plain_json_when_context_servers_already_present`
  - `test_zed_writer_idempotent_on_jsonc_file`

## Notes

I already manually restored my own `~/.config/zed/settings.json` from the backup that #315's run created and re-added `context_servers.autosearch` by hand. Anyone who ran `autosearch init` between #315 and this PR landing should check `~/.config/zed/settings.json.bak.*` for their original settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)