### PR TITLE
feat(cli): autosearch diagnostics --redact — safe one-command support bundle

### DIFF
--- a/autosearch/cli/diagnostics.py
+++ b/autosearch/cli/diagnostics.py
@@ -1,0 +1,206 @@
+"""Generate a redacted diagnostics bundle for support / bug reports.
+
+Goal: turn "it doesn't work" into one copy-paste payload that surfaces enough
+state for triage (versions, paths, tool registration, channel readiness)
+WITHOUT leaking any secret value, cookie, full user query, or other PII.
+
+Two design rules:
+  1. Never include a secret VALUE — only key names (and even those only when
+     present in env, not their raw values).
+  2. Strip anything that looks like an API key / Bearer token / Cookie before
+     emitting, even from accidental sources (e.g. environment variable dumps).
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import shutil
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# Patterns that look like secrets and must never appear in the redacted bundle.
+# Conservative: match common API-key prefixes and Bearer/Cookie headers.
+_SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"sk-or-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"gho_[A-Za-z0-9]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"AIzaSy[A-Za-z0-9_-]{20,}"),
+    re.compile(r"tvly-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"exa-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"(?i)Bearer\s+[A-Za-z0-9._\-]+"),
+    re.compile(r"(?i)Cookie:\s*[^\n]+"),
+    # Generic catch for KEY=value where value looks token-shaped (>=20 chars,
+    # mix of letters/digits/dashes); prevents accidental leaks from env dumps.
+    re.compile(r"([A-Z][A-Z0-9_]+_(KEY|TOKEN|SECRET|COOKIES?))=([^\s\"']{8,})"),
+]
+
+
+def redact(text: str) -> str:
+    """Replace anything matching `_SECRET_PATTERNS` with a `[REDACTED]` marker."""
+    out = text
+    for pat in _SECRET_PATTERNS:
+        out = pat.sub(_redaction_replacer, out)
+    return out
+
+
+def _redaction_replacer(match: re.Match) -> str:
+    # If the match captured a KEY=value, preserve the key name and the `=` so
+    # the reader can see "I have OPENAI_API_KEY set" without the value.
+    if match.lastindex and match.lastindex >= 1 and match.group(1):
+        return f"{match.group(1)}=[REDACTED]"
+    return "[REDACTED]"
+
+
+@dataclass
+class DiagnosticsBundle:
+    autosearch_version: str
+    python_version: str
+    python_executable: str
+    platform_string: str
+    install_method: str
+    mcp_config_paths: dict[str, str] = field(default_factory=dict)
+    secrets_file: dict[str, object] = field(default_factory=dict)
+    runtime_experience_dir: dict[str, object] = field(default_factory=dict)
+    mcp_tool_count: int | None = None
+    mcp_required_missing: list[str] = field(default_factory=list)
+    doctor_summary: dict[str, int] = field(default_factory=dict)
+
+
+def _detect_install_method() -> str:
+    exe = sys.executable
+    if "pipx" in exe:
+        return "pipx"
+    if ".venv" in exe or "virtualenv" in exe.lower():
+        return "venv"
+    if "uv" in exe:
+        return "uv"
+    return "system"
+
+
+def _mcp_config_paths_status() -> dict[str, str]:
+    candidates = {
+        "claude": Path.home() / ".claude" / "mcp.json",
+        "cursor": Path.home() / ".cursor" / "mcp.json",
+        "zed": Path.home() / ".config" / "zed" / "settings.json",
+    }
+    out: dict[str, str] = {}
+    for name, path in candidates.items():
+        if path.is_file():
+            try:
+                size = path.stat().st_size
+                out[name] = f"present ({size}B at {path})"
+            except OSError:
+                out[name] = f"present but unreadable ({path})"
+        elif path.parent.is_dir():
+            out[name] = f"client dir exists, no config at {path}"
+        else:
+            out[name] = "not installed"
+    return out
+
+
+def _secrets_file_status() -> dict[str, object]:
+    from autosearch.core.secrets_store import load_secrets, secrets_path
+
+    path = secrets_path()
+    info: dict[str, object] = {"path": str(path), "exists": path.is_file()}
+    if path.is_file():
+        try:
+            mode = path.stat().st_mode & 0o777
+            info["permissions_octal"] = f"0o{mode:o}"
+            keys = list(load_secrets().keys())
+            info["key_count"] = len(keys)
+            # Only key NAMES, never values.
+            info["key_names"] = sorted(keys)
+        except OSError:
+            info["error"] = "stat or read failed"
+    return info
+
+
+def _runtime_experience_dir_status() -> dict[str, object]:
+    from autosearch.skills.experience import _runtime_root
+
+    root = _runtime_root()
+    info: dict[str, object] = {"path": str(root), "exists": root.is_dir()}
+    if root.is_dir():
+        try:
+            channels = (
+                [d.name for d in (root / "channels").iterdir() if d.is_dir()]
+                if (root / "channels").is_dir()
+                else []
+            )
+            info["channel_count_with_state"] = len(channels)
+            total_size = sum(f.stat().st_size for f in root.rglob("*") if f.is_file())
+            info["total_bytes"] = total_size
+        except OSError:
+            info["error"] = "could not enumerate"
+    return info
+
+
+def _mcp_surface() -> tuple[int | None, list[str]]:
+    """Try to inspect the MCP server's tool registry. Returns (count, missing).
+    On any error, returns (None, []) — never raises."""
+    try:
+        import asyncio  # noqa: PLC0415
+
+        from autosearch.cli.main import _REQUIRED_MCP_TOOLS  # noqa: PLC0415
+        from autosearch.mcp.server import create_server  # noqa: PLC0415
+
+        server = create_server()
+        tools = asyncio.run(server.list_tools())
+        names = {t.name for t in tools}
+        missing = [name for name in _REQUIRED_MCP_TOOLS if name not in names]
+        return len(names), missing
+    except Exception:
+        return None, []
+
+
+def _doctor_summary() -> dict[str, int]:
+    try:
+        from autosearch.core.doctor import scan_channels  # noqa: PLC0415
+
+        results = scan_channels()
+        summary = {"total": len(results), "ok": 0, "warn": 0, "off": 0}
+        for r in results:
+            summary[r.status] = summary.get(r.status, 0) + 1
+        return summary
+    except Exception:
+        return {}
+
+
+def build_bundle() -> DiagnosticsBundle:
+    """Collect everything needed for a support bundle. Caller is responsible
+    for redacting before printing."""
+    from autosearch import __version__  # noqa: PLC0415
+
+    tool_count, missing = _mcp_surface()
+    return DiagnosticsBundle(
+        autosearch_version=__version__,
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        python_executable=sys.executable,
+        platform_string=platform.platform(),
+        install_method=_detect_install_method(),
+        mcp_config_paths=_mcp_config_paths_status(),
+        secrets_file=_secrets_file_status(),
+        runtime_experience_dir=_runtime_experience_dir_status(),
+        mcp_tool_count=tool_count,
+        mcp_required_missing=missing,
+        doctor_summary=_doctor_summary(),
+    )
+
+
+def render_bundle(bundle: DiagnosticsBundle, *, redact_output: bool) -> str:
+    import json  # noqa: PLC0415
+
+    text = json.dumps(asdict(bundle), indent=2, ensure_ascii=False, sort_keys=True)
+    if redact_output:
+        text = redact(text)
+    return text
+
+
+# Re-export so `which autosearch-mcp` is easy to spot in the bundle.
+def autosearch_mcp_on_path() -> str | None:
+    return shutil.which("autosearch-mcp")

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -793,5 +793,44 @@ def mcp_check(
     raise typer.Exit(code=1)
 
 
+@app.command()
+def diagnostics(
+    redact_output: Annotated[
+        bool,
+        typer.Option(
+            "--redact",
+            help=(
+                "Required. Strip secrets / cookies / API key values before "
+                "printing. Without this flag the command refuses to run, so a "
+                "user copy-paste into a public issue can't accidentally leak "
+                "credentials."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Print a copy-pasteable diagnostics bundle for support / GitHub issues.
+
+    Includes: autosearch version, Python info, install method, MCP client
+    config status, secrets-file presence (key NAMES only, never values),
+    runtime experience dir size, MCP tool registry summary, doctor counts.
+
+    Excludes: secret values, raw env dumps, full user queries.
+    """
+    from autosearch.cli.diagnostics import build_bundle, render_bundle
+
+    if not redact_output:
+        typer.echo(
+            "error: refusing to run without --redact. The bundle may contain "
+            "filesystem paths, environment variable names, or other context "
+            "that should be scrubbed before posting publicly. Re-run with "
+            "`autosearch diagnostics --redact`.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    bundle = build_bundle()
+    typer.echo(render_bundle(bundle, redact_output=True))
+
+
 if __name__ == "__main__":
     app()

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,0 +1,111 @@
+"""Tests for autosearch.cli.diagnostics — the redact-by-default support bundle."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from autosearch.cli import main as cli_main
+from autosearch.cli.diagnostics import build_bundle, redact, render_bundle
+
+runner = CliRunner()
+
+
+# ── Redaction ────────────────────────────────────────────────────────────────
+
+
+def test_redact_strips_anthropic_key() -> None:
+    body = "ANTHROPIC_API_KEY=sk-ant-abcdef0123456789ABCDEFGHIJKL"
+    out = redact(body)
+    assert "sk-ant-" not in out
+    assert "ANTHROPIC_API_KEY" in out  # key name preserved
+    assert "REDACTED" in out
+
+
+def test_redact_strips_openrouter_key() -> None:
+    out = redact("OPENROUTER_API_KEY=sk-or-v1-abcdef0123456789ABCDEFG")
+    assert "sk-or-" not in out
+
+
+def test_redact_strips_github_pat() -> None:
+    out = redact("token = github_pat_11ABCDEFGH0123456789abcdefgh")
+    assert "github_pat_" not in out
+
+
+def test_redact_strips_bearer_header() -> None:
+    out = redact('"Authorization": "Bearer abcdef.ghi.jklmno"')
+    assert "Bearer abcdef" not in out
+    assert "REDACTED" in out
+
+
+def test_redact_strips_cookie_header() -> None:
+    out = redact("Cookie: SESSDATA=xxx; bili_jct=yyy")
+    assert "SESSDATA" not in out
+    assert "REDACTED" in out
+
+
+def test_redact_preserves_safe_text() -> None:
+    out = redact("Python 3.12.13 on Darwin / 39 channels available")
+    assert out == "Python 3.12.13 on Darwin / 39 channels available"
+
+
+# ── Bundle shape ─────────────────────────────────────────────────────────────
+
+
+def test_build_bundle_returns_required_top_level_fields() -> None:
+    bundle = build_bundle()
+    assert bundle.autosearch_version
+    assert bundle.python_version
+    assert bundle.python_executable
+    assert bundle.platform_string
+    assert bundle.install_method in {"pipx", "venv", "uv", "system"}
+    assert isinstance(bundle.mcp_config_paths, dict)
+    assert set(bundle.mcp_config_paths) >= {"claude", "cursor", "zed"}
+
+
+def test_render_bundle_with_redact_strips_any_planted_secret(monkeypatch) -> None:
+    """End-to-end: even if a key value somehow makes it into the bundle (e.g.
+    via an env-name containing the value), redacted render must scrub it."""
+    monkeypatch.setenv("FAKE_API_KEY", "sk-ant-fake-secret-value-do-not-leak-12345")
+    bundle = build_bundle()
+    text = render_bundle(bundle, redact_output=True)
+    assert "sk-ant-fake-secret" not in text
+
+
+def test_secrets_file_status_lists_key_names_only(tmp_path, monkeypatch) -> None:
+    """When the secrets file is present, the bundle exposes key NAMES (so
+    support knows what's configured) but never values."""
+    secrets_file = tmp_path / "ai-secrets.env"
+    secrets_file.write_text("OPENAI_API_KEY=sk-shouldnotappear\n", encoding="utf-8")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(secrets_file))
+
+    bundle = build_bundle()
+    rendered = render_bundle(bundle, redact_output=True)
+
+    assert "OPENAI_API_KEY" in rendered  # name OK
+    assert "sk-shouldnotappear" not in rendered  # value scrubbed
+
+
+# ── CLI command ──────────────────────────────────────────────────────────────
+
+
+def test_diagnostics_command_refuses_without_redact() -> None:
+    """Default-deny: prevent a user from copy-pasting a non-redacted bundle
+    into a public GitHub issue."""
+    result = runner.invoke(cli_main.app, ["diagnostics"])
+    assert result.exit_code != 0
+    combined = result.stdout + (result.stderr or "")
+    assert "--redact" in combined.lower()
+
+
+def test_diagnostics_command_emits_json_with_redact(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-secret-do-not-leak-abcd1234efgh")
+    result = runner.invoke(cli_main.app, ["diagnostics", "--redact"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    # Output must be valid JSON
+    payload = json.loads(result.stdout)
+    assert "autosearch_version" in payload
+    assert "mcp_config_paths" in payload
+    # Secret value must not appear anywhere
+    assert "sk-ant-test-secret" not in result.stdout


### PR DESCRIPTION
## Summary

Closes plan §P1 \"No Strong User-Facing Diagnostic Bundle\". For million-user support, \"it doesn't work\" must reduce to one copy-paste payload that triages quickly without leaking secrets.

### What lands

New `autosearch diagnostics --redact` command. Output (JSON) includes:

- `autosearch_version` / `python_version` / `python_executable` / `platform_string` / `install_method`
- `mcp_config_paths` — per-client (claude / cursor / zed): present? size? path?
- `secrets_file` — exists? permissions? **key NAMES only**, never values
- `runtime_experience_dir` — path + total bytes (catches \"experience pollution\" issues)
- `mcp_tool_count` + `mcp_required_missing` — same surface `mcp-check` reports
- `doctor_summary` — count by status (ok/warn/off), no env values

### Default-deny

The command refuses to run without `--redact` (exit 2). Without that gate a user could `autosearch diagnostics > issue.txt` and paste secrets into a public bug report. Redaction strips `sk-`, `sk-ant-`, `sk-or-`, `gho_`, `github_pat_`, `AIzaSy`, `tvly-`, `exa-`, `Bearer …`, `Cookie: …`, and a generic `*_KEY/_TOKEN/_SECRET/_COOKIE=…` pattern.

### Live output (this branch)

```
$ autosearch diagnostics --redact
{
  \"autosearch_version\": \"2026.4.23.9\",
  \"doctor_summary\": {\"off\": 2, \"ok\": 33, \"total\": 40, \"warn\": 5},
  \"install_method\": \"venv\",
  \"mcp_config_paths\": {
    \"claude\": \"present (185B at /Users/.../.claude/mcp.json)\",
    \"cursor\": \"not installed\",
    \"zed\": \"present (557B at /Users/.../.config/zed/settings.json)\"
  },
  \"mcp_required_missing\": [],
  \"mcp_tool_count\": 24,
  \"platform_string\": \"macOS-26.2-arm64-arm-64bit\",
  ...
}
```

## Verification

- `ruff check .` clean
- `pytest -m \"not real_llm and not perf and not slow and not network\"` → **817 passed** (806 + 11 new)
- Coverage: 6 redaction patterns + bundle shape + refuse-without-redact + JSON validity

## Out of scope

- Continue config writer (plan §P0-D listed 4 clients; Continue uses YAML with a different shape — separate PR)
- Tool surface profiles (`mcp-check --profile default|experimental`) — needs product call on which 24 tools are \"default\" vs \"experimental\"
- `--include-logs` for diagnostics — defer until structured local log exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)