### PR TITLE
ci(release): release.yml runs version validator + release-gate.sh; npm version derivation uses shared helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,15 @@ jobs:
           fi
           echo "Verified: pyproject.toml version = $VERSION"
 
+      - name: Verify all version files agree (pyproject + plugin + marketplace + CHANGELOG + npm)
+        run: python scripts/validate/check_version_consistency.py
+
+      - name: Install autosearch (for release-gate CLI surface checks)
+        run: pip install -e ".[dev]"
+
+      - name: Run release-gate.sh --quick (version + lint + CLI surface)
+        run: bash scripts/release-gate.sh --quick
+
       - name: Install build backend
         run: pip install build twine
 
@@ -123,16 +132,21 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          # Convert CalVer YYYY.MM.DD.N → npm semver YYYY.MMDD.N
-          YEAR=$(echo "$VERSION" | cut -d. -f1)
-          MONTH=$(echo "$VERSION" | cut -d. -f2 | sed 's/^0*//')
-          DAY=$(echo "$VERSION" | cut -d. -f3 | sed 's/^0*//')
-          SEQ=$(echo "$VERSION" | cut -d. -f4)
-          MMDD=$(( MONTH * 100 + DAY ))
-          NPM_VERSION="$YEAR.$MMDD.$SEQ"
-          echo "Publishing autosearch-ai@$NPM_VERSION"
+          # Single source of truth for the pyproject→npm mapping lives in
+          # scripts/validate/check_version_consistency.py:derive_npm_version
+          # so a publish here matches what npm/package.json on disk should hold.
+          NPM_VERSION=$(python -c "
+          import importlib.util
+          spec = importlib.util.spec_from_file_location(
+              'cv', 'scripts/validate/check_version_consistency.py'
+          )
+          mod = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(mod)
+          print(mod.derive_npm_version('$VERSION'))
+          ")
+          echo "Publishing autosearch-ai@$NPM_VERSION (derived from $VERSION)"
           cd npm
-          npm version "$NPM_VERSION" --no-git-tag-version
+          npm version "$NPM_VERSION" --no-git-tag-version --allow-same-version
           npm publish --access public
 
       - name: Summary

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -41,15 +41,27 @@ if [ -x "$REPO_ROOT/.venv/bin/python" ]; then
   PYTHON="$REPO_ROOT/.venv/bin/python"
 elif command -v python3.12 >/dev/null 2>&1; then
   PYTHON=$(command -v python3.12)
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON=$(command -v python3)
 else
-  echo "FAIL: no Python 3.12 found (need .venv/bin/python or python3.12 on PATH)" >&2
+  echo "FAIL: no Python found (need .venv/bin/python, python3.12, or python3 on PATH)" >&2
   exit 1
 fi
 
-# Resolve adjacent CLI tools so we don't depend on $PATH in the venv.
-RUFF="$REPO_ROOT/.venv/bin/ruff"
-PYTEST="$REPO_ROOT/.venv/bin/pytest"
-AUTOSEARCH="$REPO_ROOT/.venv/bin/autosearch"
+# Resolve adjacent CLI tools — prefer the project venv, fall back to PATH so
+# this script works in CI runners where deps land in system Python.
+_resolve_tool() {
+  local venv_path="$REPO_ROOT/.venv/bin/$1"
+  if [ -x "$venv_path" ]; then
+    printf '%s' "$venv_path"
+  else
+    command -v "$1" 2>/dev/null || true
+  fi
+}
+
+RUFF=$(_resolve_tool ruff)
+PYTEST=$(_resolve_tool pytest)
+AUTOSEARCH=$(_resolve_tool autosearch)
 
 step() { printf "\n==> %s\n" "$1"; }
 pass() { printf "PASS: %s\n" "$1"; }

--- a/tests/unit/test_release_gate_script.py
+++ b/tests/unit/test_release_gate_script.py
@@ -34,3 +34,15 @@ def test_release_gate_script_supports_quick_and_help_flags() -> None:
 
     bad = subprocess.run([str(SCRIPT), "--no-such-flag"], capture_output=True, text=True)
     assert bad.returncode != 0
+
+
+def test_release_workflow_invokes_release_gate_and_validator() -> None:
+    """release.yml must run both `check_version_consistency.py` and
+    `release-gate.sh` so a tag push can't silently publish a drifted release.
+    Pin the wiring textually so a refactor that drops one of them shows up
+    in code review."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "check_version_consistency.py" in workflow, (
+        "release workflow no longer runs check_version_consistency.py"
+    )
+    assert "release-gate.sh" in workflow, "release workflow no longer runs release-gate.sh"


### PR DESCRIPTION
## Summary

Closes the loop on the release-engineering work in #314 / #316. Three fixes in one PR:

1. **release.yml now runs `check_version_consistency.py`** before build. Previously a tag push could publish a release where pyproject said `2026.04.23.9` but `npm/package.json` said something else entirely — the existing tag-vs-pyproject check caught only one slice.

2. **release.yml now runs `release-gate.sh --quick`** as a final independent gate before publish (version + lint + CLI surface). Belt-and-suspenders with the per-PR CI that already runs the same checks.

3. **NPM version derivation centralized** — release.yml's hand-written shell math (`MMDD=$(( MONTH * 100 + DAY ))`) used `YYYY.MMDD.N` (e.g. `2026.423.9`), while `check_version_consistency.py` (introduced in #314) said the canonical mapping is `YYYY.M.DD` (e.g. `2026.4.23`). They contradicted each other — release would publish one shape, validator would reject the other. Now release.yml imports `derive_npm_version` from the validator so both stay in sync from a single definition.

### Side fix

`release-gate.sh` was hard-coded to look for tools in `$REPO_ROOT/.venv/bin/...` only — fine for local dev but unusable in a fresh CI runner. Refactored to fall back to `$PATH` when the venv binary is missing, so the same script works on a developer laptop and inside `release.yml`.

### New regression

`tests/unit/test_release_gate_script.py::test_release_workflow_invokes_release_gate_and_validator` reads `release.yml` and asserts the two scripts are still wired in. Drops them and you get a red test, not a silent regression.

## Verification

- `pytest -q -m "not real_llm and not perf and not slow and not network"` → **818 passed** (817 + 1 wiring test)
- `scripts/release-gate.sh --quick` still passes locally
- `python scripts/validate/check_version_consistency.py` still passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)