### PR TITLE
chore: bump version to 2026.04.24.1 — million-user readiness release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.23.9"
+  "version": "2026.04.24.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.23.9",
+  "version": "2026.04.24.1",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026.04.24.1 — 2026-04-24
+
+The "make a fresh install actually work" release. After running `autosearch init`,
+the v2 contract is now honest end-to-end: configured keys take effect, the MCP
+client really sees the tools, runtime writes don't pollute the installed
+package, and one command tells you what's wrong.
+
+- **`autosearch doctor` and `autosearch mcp-check` are first-class CLI commands** — `doctor` tier-groups channels and tells you the exact one-liner to fix each blocked one; `mcp-check` proves all 10 required v2 MCP tools are registered. `--json` emits machine-readable output. Unknown subcommands now error instead of silently routing to the deprecated `query` path.
+- **`autosearch configure KEY value` actually takes effect** — runtime now reads `~/.config/ai-secrets.env` (the file `configure` writes to), so a fresh `doctor` run reflects keys you just added without a shell restart. Process env still overrides the file.
+- **`autosearch init` writes the right MCP config shape per client** — Claude Code and Cursor get `mcpServers.autosearch`, Zed gets `context_servers.autosearch` (and the writer respects Zed's JSONC so your existing font/theme settings survive). `init --dry-run` previews writes without touching files. Backs up corrupt JSON instead of silently overwriting.
+- **`autosearch mcp-check --client claude|cursor|zed`** — verifies the named client's config file is shaped correctly, in addition to the server-side tool registry.
+- **`autosearch diagnostics --redact`** — copy-pasteable JSON support bundle (version, install method, MCP config presence, tool count, doctor summary). Refuses to run without `--redact`; scrubs API keys, Bearer tokens, cookies, and secret values before printing.
+- **Runtime writes leave the installed package alone** — channel experience and compaction now write to `~/.autosearch/experience/` (or `$XDG_DATA_HOME/autosearch/experience` if set), never to `site-packages`. Bundled `experience.md` files remain read-only seeds.
+- **Discourse forum search added (linux.do channel)** — bringing the channel count from 39 to 40.
+- **Channel routing + doctor tier/fix-hint now driven by `SKILL.md` metadata** — `tier:` and `fix_hint:` declared in a channel's frontmatter take precedence over inferred defaults; selectors and channels-table generator share the same source of truth.
+- **Circuit breaker is wired into runtime** — `_build_channels` now attaches `ChannelHealth`, so cooldown / failure-rate tracking actually fires and `available()` filters out cooled-down channels. `PermanentError` propagates correctly (was unreachable due to exception ordering).
+- **OpenAI provider honors `OPENAI_BASE_URL`** — point any OpenAI-compatible backend at the provider without code changes.
+- **One-command release gate** — `scripts/release-gate.sh` runs version consistency + lint/format + tests + CLI surface in one shot; release.yml uses it before publishing, and pyproject↔npm version mapping comes from a single shared helper.
+- **`pytest` / `ruff` moved out of runtime dependencies** — installed wheels no longer pull in dev tools. CI installs with `pip install -e ".[dev]"`.
+
 ## 2026.04.23.9 — 2026-04-24
 
 - `npx autosearch-ai` is now the one-command installer — auto-installs and shows init screen on any machine

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,8 +1,14 @@
 {
   "name": "autosearch-ai",
-  "version": "2026.4.23",
+  "version": "2026.4.24",
   "description": "AutoSearch — deep research MCP server for AI developers",
-  "keywords": ["autosearch", "mcp", "ai", "research", "claude"],
+  "keywords": [
+    "autosearch",
+    "mcp",
+    "ai",
+    "research",
+    "claude"
+  ],
   "homepage": "https://github.com/0xmariowu/Autosearch",
   "repository": {
     "type": "git",
@@ -13,7 +19,9 @@
   "bin": {
     "autosearch-ai": "./bin/autosearch-ai.js"
   },
-  "files": ["bin"],
+  "files": [
+    "bin"
+  ],
   "engines": {
     "node": ">=18"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.23.9"
+version = "2026.04.24.1"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -59,7 +59,7 @@ import json, sys
 path, new_version = sys.argv[1], sys.argv[2]
 with open(path) as f: d = json.load(f)
 d['version'] = new_version
-with open(path, 'w') as f: json.dump(d, f, indent=2); f.write('\n')
+with open(path, 'w') as f: json.dump(d, f, indent=2, ensure_ascii=False); f.write('\n')
 PY
   echo "  updated $path"
 }
@@ -97,7 +97,7 @@ with open(path) as f: d = json.load(f)
 if d.get('version') == npm_version:
     raise SystemExit(0)
 d['version'] = npm_version
-with open(path, 'w') as f: json.dump(d, f, indent=2); f.write('\n')
+with open(path, 'w') as f: json.dump(d, f, indent=2, ensure_ascii=False); f.write('\n')
 print(npm_version)
 PY
   echo "  updated $path (derived from $new_version)"


### PR DESCRIPTION
## Summary

Version bump for the million-user readiness release. Rolls up 11 PRs (#310 → #322) closing every plan §"Release Blockers" P0 plus a few high-value P1s.

See `CHANGELOG.md` for the user-facing list.

## Verification

- `python scripts/validate/check_version_consistency.py` → OK on 2026.04.24.1 (npm derived to 2026.4.24)
- `pytest -q -m "not real_llm and not perf and not slow and not network"` → 818 passed
- `ruff check .` clean
- `bash scripts/release-gate.sh` → all gates pass

## Side fix

`scripts/bump-version.sh` was emitting `—` for em-dashes in JSON files because `json.dump` defaulted to `ensure_ascii=True`. Pass `ensure_ascii=False` so the literal char survives.

## Next step (after merge)

Tag and push:
```
git tag v2026.04.24.1
git push --tags
```
That triggers `release.yml` → version validator + release-gate + build + PyPI publish + npm publish + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `autosearch doctor` and `autosearch mcp-check` commands with JSON output support
  * Configuration changes now persist across fresh runs
  * `autosearch init` now supports `--dry-run` with safer JSON backup behavior
  * Added `autosearch diagnostics --redact` for machine-readable redacted reporting
  * Improved channel validation and error handling for unknown subcommands
  * OpenAI provider now respects base URL configuration

* **Chores**
  * Version bumped to 2026.04.24.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->