### PR TITLE
fix: Batch 1 — runtime truth (secrets actually injected, doctor honest about impls, run_channel says not_configured)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -71,6 +71,13 @@ def main(
         ),
     ] = None,
 ) -> None:
+    # Push ~/.config/ai-secrets.env keys into process env so subcommands and
+    # any provider/channel that does `os.getenv("FOO_API_KEY")` actually sees
+    # what the user configured via `autosearch configure`.
+    from autosearch.core.secrets_store import inject_into_env
+
+    inject_into_env()
+
     if ctx.invoked_subcommand is None and not version:
         raise typer.Exit(code=0)
 

--- a/autosearch/core/channel_bootstrap.py
+++ b/autosearch/core/channel_bootstrap.py
@@ -40,3 +40,22 @@ def _build_channels(
     if not channels:
         return [DemoChannel()]
     return channels
+
+
+def _build_registry(
+    *,
+    channels_root: Path | None = None,
+    env: Environment | None = None,
+) -> ChannelRegistry | None:
+    """Same as `_build_channels` but exposes the full ChannelRegistry so
+    callers can ask about KNOWN-but-unavailable channels (for `not_configured`
+    semantics in `run_channel`). Returns None in dummy/demo mode where there
+    is no real registry to introspect."""
+    if os.getenv("AUTOSEARCH_LLM_MODE") == "dummy":
+        return None
+    root = channels_root or _default_channels_root()
+    if not root.is_dir():
+        return None
+    registry = ChannelRegistry.compile_from_skills(root, env or probe_environment())
+    registry.attach_health(ChannelHealth())
+    return registry

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -75,6 +75,11 @@ def scan_channels(channels_root: Path | None = None) -> list[ChannelStatus]:
         available_methods = 0
         for method in spec.methods:
             unmet = [token for token in method.requires if not _token_satisfied(token, env_keys)]
+            # A method whose impl file does not exist on disk cannot run, no
+            # matter how many env keys are satisfied. Treat it as unmet so a
+            # half-scaffolded channel never reports as available.
+            if not (spec.skill_dir / method.impl).is_file():
+                unmet.append(f"impl_missing:{method.impl}")
             if not unmet:
                 available_methods += 1
             else:

--- a/autosearch/core/secrets_store.py
+++ b/autosearch/core/secrets_store.py
@@ -74,3 +74,28 @@ def resolve_env_value(key: str, path: Path | None = None) -> str | None:
     if env_value:
         return env_value
     return load_secrets(path).get(key) or None
+
+
+def inject_into_env(path: Path | None = None) -> set[str]:
+    """Push secrets-file values into `os.environ` for any key that isn't
+    already set. Returns the set of keys that were newly injected.
+
+    This is what makes the v2 contract true end-to-end: `autosearch configure`
+    writes to `~/.config/ai-secrets.env`, but channel methods, LLM providers,
+    and external libraries (yt-dlp, firecrawl, tikhub) all read process env
+    via `os.getenv()`. Without this push, doctor sees the file but the actual
+    runtime call sees nothing.
+
+    Process env always wins — we only fill in MISSING keys, never overwrite a
+    user's explicit env var. The function is idempotent and cheap; safe to call
+    on every CLI/MCP entrypoint.
+    """
+    injected: set[str] = set()
+    for key, value in load_secrets(path).items():
+        if not value:
+            continue
+        if os.environ.get(key):
+            continue  # explicit env override stays in effect
+        os.environ[key] = value
+        injected.add(key)
+    return injected

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -304,6 +304,13 @@ def _scan_skill_catalog(
 
 
 def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
+    # Push ~/.config/ai-secrets.env keys into process env BEFORE any channel
+    # method or LLM provider is constructed — otherwise their `os.getenv()`
+    # calls miss keys the user configured via `autosearch configure`.
+    from autosearch.core.secrets_store import inject_into_env
+
+    inject_into_env()
+
     factory = pipeline_factory or _default_pipeline_factory
     server = FastMCP(
         name="autosearch",

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -43,12 +43,25 @@ class ResearchResponse(BaseModel):
 
 
 class RunChannelResponse(BaseModel):
-    """Structured MCP tool response for the run_channel tool."""
+    """Structured MCP tool response for the run_channel tool.
+
+    `status` discriminates the four meaningful outcomes a host agent must
+    distinguish:
+      - `ok`: results returned (may be empty list)
+      - `not_configured`: channel exists but its requirements (env keys,
+        cookies, etc.) are not met. `unmet_requires` and `fix_hint` tell
+        the agent exactly what to ask the user for.
+      - `unknown_channel`: the requested name is not registered at all.
+      - `channel_error`: known and configured, but the call raised.
+    """
 
     channel: str
     ok: bool
+    status: str = "ok"
     evidence: list[dict[str, object]] = Field(default_factory=list)
     reason: str | None = None
+    unmet_requires: list[str] = Field(default_factory=list)
+    fix_hint: str | None = None
     count_total: int = 0
     count_returned: int = 0
 
@@ -533,13 +546,39 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             (up to k items; each evidence is already source_page-slimmed),
             `reason` populated on failure, and `count_total / count_returned`.
         """
+        from autosearch.core.channel_bootstrap import _build_registry
+
         channels = _build_channels()
         matched = next((c for c in channels if c.name == channel_name), None)
         if matched is None:
+            # Differentiate "channel name typo" (unknown_channel) from "channel
+            # exists but its requirements aren't met" (not_configured). The
+            # latter must surface fix_hint + unmet_requires so the host agent
+            # can ask the user for the missing key instead of falling back.
+            registry = _build_registry()
+            if registry is not None and channel_name in registry._metadata:  # noqa: SLF001
+                meta = registry.metadata(channel_name)
+                unmet: list[str] = []
+                for method in meta.methods:
+                    unmet.extend(method.unmet_requires)
+                # Stable order, unique
+                unmet = list(dict.fromkeys(unmet))
+                from autosearch.core.doctor import _resolve_fix_hint
+
+                fix = _resolve_fix_hint(meta, unmet)
+                return RunChannelResponse(
+                    channel=channel_name,
+                    ok=False,
+                    status="not_configured",
+                    reason=f"not_configured: {channel_name} known but requirements unmet",
+                    unmet_requires=unmet,
+                    fix_hint=fix or None,
+                )
             available = ", ".join(sorted(c.name for c in channels))[:500]
             return RunChannelResponse(
                 channel=channel_name,
                 ok=False,
+                status="unknown_channel",
                 reason=f"unknown_channel. available: {available}",
             )
 
@@ -576,6 +615,7 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             return RunChannelResponse(
                 channel=channel_name,
                 ok=False,
+                status="channel_error",
                 reason=f"channel_error: {type(exc).__name__}: {exc}",
             )
 
@@ -603,6 +643,7 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
         return RunChannelResponse(
             channel=channel_name,
             ok=True,
+            status="ok" if returned else "no_results",
             evidence=returned,
             count_total=total,
             count_returned=len(returned),

--- a/autosearch/skills/channels/bilibili/SKILL.md
+++ b/autosearch/skills/channels/bilibili/SKILL.md
@@ -15,11 +15,7 @@ methods:
     impl: methods/api_search.py
     requires: []
     rate_limit: {per_min: 30, per_hour: 500}
-  - id: api_video_detail
-    impl: methods/api_video_detail.py
-    requires: [cookie:bilibili]
-    rate_limit: {per_min: 20, per_hour: 300}
-fallback_chain: [api_search, via_tikhub, api_video_detail]
+fallback_chain: [api_search, via_tikhub]
 when_to_use:
   query_languages: [zh, mixed]
   query_types: [tutorial-video, comparison, breakdown, tech-opinion]

--- a/autosearch/skills/channels/douyin/SKILL.md
+++ b/autosearch/skills/channels/douyin/SKILL.md
@@ -11,11 +11,7 @@ methods:
     impl: methods/via_tikhub.py
     requires: [env:TIKHUB_API_KEY]
     rate_limit: {per_min: 60, per_hour: 1000}
-  - id: via_douyin_mcp
-    impl: methods/via_douyin_mcp.py
-    requires: [mcp:douyin-mcp-server, cookie:douyin]
-    rate_limit: {per_min: 10, per_hour: 120}
-fallback_chain: [via_tikhub, via_douyin_mcp]
+fallback_chain: [via_tikhub]
 when_to_use:
   query_languages: [zh]
   query_types: [trending, short-form, product-launch, consumer-commentary, lifestyle]

--- a/autosearch/skills/channels/github/SKILL.md
+++ b/autosearch/skills/channels/github/SKILL.md
@@ -7,23 +7,11 @@ description: Use for code-level, issue-level, and repository discovery when quer
 version: 1
 languages: [en]
 methods:
-  - id: search_repositories
-    impl: methods/search_repos.py
-    requires: [env:GITHUB_TOKEN]
-    rate_limit: {per_min: 30, per_hour: 5000}
-  - id: search_issues
-    impl: methods/search_issues.py
-    requires: [env:GITHUB_TOKEN]
-    rate_limit: {per_min: 30, per_hour: 5000}
-  - id: search_code
-    impl: methods/search_code.py
-    requires: [env:GITHUB_TOKEN]
-    rate_limit: {per_min: 10, per_hour: 5000}
   - id: search_public_repos
     impl: methods/search_public_repos.py
     requires: []
     rate_limit: {per_min: 10, per_hour: 60}
-fallback_chain: [search_repositories, search_issues, search_code, search_public_repos]
+fallback_chain: [search_public_repos]
 when_to_use:
   query_languages: [en, mixed]
   query_types: [code, library, implementation, debugging, tooling]

--- a/autosearch/skills/channels/twitter/SKILL.md
+++ b/autosearch/skills/channels/twitter/SKILL.md
@@ -11,11 +11,7 @@ methods:
     impl: methods/via_tikhub.py
     requires: [env:TIKHUB_API_KEY]
     rate_limit: {per_min: 60, per_hour: 1000}
-  - id: api_search
-    impl: methods/api_search.py
-    requires: [env:TWITTER_BEARER_TOKEN]
-    rate_limit: {per_min: 10, per_hour: 100}
-fallback_chain: [via_tikhub, api_search]
+fallback_chain: [via_tikhub]
 when_to_use:
   query_languages: [en, mixed]
   query_types: [current-events, product-launch, breaking-news, developer-announcement]

--- a/autosearch/skills/channels/xiaohongshu/SKILL.md
+++ b/autosearch/skills/channels/xiaohongshu/SKILL.md
@@ -15,15 +15,7 @@ methods:
     impl: methods/via_tikhub.py
     requires: [env:TIKHUB_API_KEY]
     rate_limit: {per_min: 60, per_hour: 1000}
-  - id: via_mcporter
-    impl: methods/via_mcporter.py
-    requires: [mcp:mcporter, cookie:xiaohongshu]
-    rate_limit: {per_min: 5, per_hour: 60}
-  - id: via_xhs_cli
-    impl: methods/via_xhs_cli.py
-    requires: [binary:xhs-cli, cookie:xiaohongshu]
-    rate_limit: {per_min: 5, per_hour: 60}
-fallback_chain: [via_signsrv, via_tikhub, via_mcporter, via_xhs_cli]
+fallback_chain: [via_signsrv, via_tikhub]
 when_to_use:
   query_languages: [zh, mixed]
   query_types: [product-review, experience-report, lifestyle, consumer, travel]

--- a/autosearch/skills/channels/zhihu/SKILL.md
+++ b/autosearch/skills/channels/zhihu/SKILL.md
@@ -11,15 +11,7 @@ methods:
     impl: methods/via_tikhub.py
     requires: [env:TIKHUB_API_KEY]
     rate_limit: {per_min: 60, per_hour: 1000}
-  - id: api_search
-    impl: methods/api_search.py
-    requires: []
-    rate_limit: {per_min: 30, per_hour: 500}
-  - id: api_answer_detail
-    impl: methods/api_answer.py
-    requires: [cookie:zhihu]
-    rate_limit: {per_min: 20, per_hour: 300}
-fallback_chain: [via_tikhub, api_search, api_answer_detail]
+fallback_chain: [via_tikhub]
 when_to_use:
   query_languages: [zh, mixed]
   query_types: [technical, experience-report, product-review, tutorial, comparison]

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -223,15 +223,13 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         if spec.name == "github":
             methods = {method.id: method for method in metadata.methods}
 
+            # Only the no-token public-repo search ships with an impl. The
+            # token-gated search_repositories/issues/code declarations were
+            # removed because their impl files never existed (see plan §P0-2).
             assert [method.id for method in metadata.available_methods()] == ["search_public_repos"]
             assert methods["search_public_repos"].available is True
             assert methods["search_public_repos"].unmet_requires == []
-            assert methods["search_repositories"].available is False
-            assert methods["search_repositories"].unmet_requires == ["impl_missing"]
-            assert methods["search_issues"].available is False
-            assert methods["search_issues"].unmet_requires == ["impl_missing"]
-            assert methods["search_code"].available is False
-            assert methods["search_code"].unmet_requires == ["impl_missing"]
+            assert set(methods.keys()) == {"search_public_repos"}
             continue
         if spec.name == "devto":
             assert len(metadata.methods) == 1
@@ -259,23 +257,16 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             assert metadata.available_methods() == []
             assert methods["via_tikhub"].available is False
             assert methods["via_tikhub"].unmet_requires == ["env:TIKHUB_API_KEY"]
-            assert methods["api_search"].available is False
-            assert methods["api_search"].unmet_requires == ["impl_missing"]
-            assert methods["api_answer_detail"].available is False
-            assert methods["api_answer_detail"].unmet_requires == ["impl_missing"]
+            assert set(methods.keys()) == {"via_tikhub"}
             continue
         if spec.name == "xiaohongshu":
             methods = {method.id: method for method in metadata.methods}
 
             assert metadata.available_methods() == []
-            # via_signsrv requires 3 env vars — none set in test env
             assert methods["via_signsrv"].available is False
             assert methods["via_tikhub"].available is False
             assert methods["via_tikhub"].unmet_requires == ["env:TIKHUB_API_KEY"]
-            assert methods["via_mcporter"].available is False
-            assert methods["via_mcporter"].unmet_requires == ["impl_missing"]
-            assert methods["via_xhs_cli"].available is False
-            assert methods["via_xhs_cli"].unmet_requires == ["impl_missing"]
+            assert set(methods.keys()) == {"via_signsrv", "via_tikhub"}
             continue
         if spec.name == "twitter":
             methods = {method.id: method for method in metadata.methods}
@@ -283,8 +274,7 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
             assert metadata.available_methods() == []
             assert methods["via_tikhub"].available is False
             assert methods["via_tikhub"].unmet_requires == ["env:TIKHUB_API_KEY"]
-            assert methods["api_search"].available is False
-            assert methods["api_search"].unmet_requires == ["impl_missing"]
+            assert set(methods.keys()) == {"via_tikhub"}
             continue
         if spec.name == "tiktok":
             methods = {method.id: method for method in metadata.methods}

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -15,23 +15,37 @@ def _make_spec(
     *,
     tier: int | None = None,
     fix_hint: str | None = None,
+    skill_root: Path | None = None,
 ):
-    """Build a minimal SkillSpec-like object for mocking."""
+    """Build a minimal SkillSpec-like object for mocking.
+
+    Creates a real impl file under `skill_root/<name>/methods/api_search.py`
+    when `skill_root` is provided so the new impl-missing check (which now
+    treats absent files as unmet) doesn't downgrade these synthetic specs to
+    'off'. Existing tests that don't care about the impl check pre-patch
+    `is_file` via the helper below.
+    """
     from autosearch.skills.loader import MethodSpec, SkillSpec
 
     method = MethodSpec(id="api_search", impl="methods/api_search.py", requires=requires)
+    if skill_root is not None:
+        skill_dir = skill_root / name
+        (skill_dir / "methods").mkdir(parents=True, exist_ok=True)
+        (skill_dir / "methods" / "api_search.py").write_text("", encoding="utf-8")
+    else:
+        skill_dir = Path(f"/fake/skills/channels/{name}")
     return SkillSpec(
         name=name,
         description="test",
         methods=[method],
         tier=tier,
         fix_hint=fix_hint,
-        skill_dir=Path(f"/fake/skills/channels/{name}"),
+        skill_dir=skill_dir,
     )
 
 
 def test_scan_channels_ok_when_all_env_set(tmp_path):
-    specs = [_make_spec("mychann", ["env:MY_API_KEY"])]
+    specs = [_make_spec("mychann", ["env:MY_API_KEY"], skill_root=tmp_path)]
     with (
         patch("autosearch.core.doctor.load_all", return_value=specs),
         patch("autosearch.core.doctor._current_env_keys", return_value={"MY_API_KEY"}),
@@ -61,11 +75,15 @@ def test_scan_channels_warn_when_partial(tmp_path):
 
     m1 = MethodSpec(id="free", impl="methods/free.py", requires=[])
     m2 = MethodSpec(id="paid", impl="methods/paid.py", requires=["env:PAID_KEY"])
+    skill_dir = tmp_path / "hybrid"
+    (skill_dir / "methods").mkdir(parents=True)
+    (skill_dir / "methods" / "free.py").write_text("", encoding="utf-8")
+    (skill_dir / "methods" / "paid.py").write_text("", encoding="utf-8")
     spec = SkillSpec(
         name="hybrid",
         description="test",
         methods=[m1, m2],
-        skill_dir=Path("/fake/skills/channels/hybrid"),
+        skill_dir=skill_dir,
     )
     with (
         patch("autosearch.core.doctor.load_all", return_value=[spec]),

--- a/tests/unit/test_doctor_impl_availability.py
+++ b/tests/unit/test_doctor_impl_availability.py
@@ -1,0 +1,89 @@
+"""Plan §P0-2: a method whose impl file is missing must NEVER count as
+available, even if all its declared env requirements are satisfied.
+
+Before this contract, doctor read `requires:` from SKILL.md and ignored whether
+the impl file actually existed on disk — so half-scaffolded channels reported
+`ok` and users configured keys that ran nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from autosearch.core.doctor import scan_channels
+
+
+def _write_skill(
+    root: Path,
+    name: str,
+    *,
+    method_id: str = "api_search",
+    impl_filename: str = "api_search.py",
+    create_impl: bool,
+    requires: list[str] | None = None,
+) -> None:
+    skill = root / name
+    (skill / "methods").mkdir(parents=True, exist_ok=True)
+    requires_yaml = "[]" if not requires else "[" + ", ".join(requires) + "]"
+    (skill / "SKILL.md").write_text(
+        dedent(
+            f"""
+            ---
+            name: {name}
+            description: "fixture"
+            version: 1
+            languages: [en]
+            methods:
+              - id: {method_id}
+                impl: methods/{impl_filename}
+                requires: {requires_yaml}
+            fallback_chain: [{method_id}]
+            ---
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    if create_impl:
+        (skill / "methods" / impl_filename).write_text(
+            "async def search(q): return []\n", encoding="utf-8"
+        )
+
+
+def test_missing_impl_marks_channel_off_even_when_requires_are_satisfied(tmp_path):
+    """The smoking gun: zero requires, no env at all, but impl file missing —
+    must not be 'ok'."""
+    root = tmp_path / "channels"
+    _write_skill(root, "ghost_chan", create_impl=False, requires=[])
+
+    results = {r.channel: r for r in scan_channels(root)}
+    assert "ghost_chan" in results
+    assert results["ghost_chan"].status == "off"
+    assert any("impl_missing" in u for u in results["ghost_chan"].unmet_requires)
+
+
+def test_existing_impl_with_no_requires_is_ok(tmp_path):
+    root = tmp_path / "channels"
+    _write_skill(root, "real_chan", create_impl=True, requires=[])
+    results = {r.channel: r for r in scan_channels(root)}
+    assert results["real_chan"].status == "ok"
+    assert not any("impl_missing" in u for u in results["real_chan"].unmet_requires)
+
+
+def test_real_repo_has_no_silent_missing_impls():
+    """Static integrity: every channel skill that ships with this package must
+    have its declared method impl files on disk. If this fires, either commit
+    the impl, mark the method as planned/disabled, or remove it from SKILL.md."""
+    from autosearch.skills import load_all
+
+    root = Path(__file__).resolve().parents[2] / "autosearch" / "skills" / "channels"
+    missing: list[tuple[str, str, str]] = []
+    for spec in load_all(root):
+        for method in spec.methods:
+            if not (spec.skill_dir / method.impl).is_file():
+                missing.append((spec.name, method.id, method.impl))
+
+    assert not missing, "channels declare methods whose impl files do not exist:\n" + "\n".join(
+        f"  {name}.{mid} -> {impl}" for name, mid, impl in missing
+    )

--- a/tests/unit/test_mcp_run_channel_not_configured.py
+++ b/tests/unit/test_mcp_run_channel_not_configured.py
@@ -1,0 +1,77 @@
+"""Plan §P0-3: a known-but-unconfigured channel must return `not_configured`,
+NOT `unknown_channel`.
+
+Without this contract, the host agent gets an "unknown channel — available: ..."
+error and either gives up or routes to the wrong channel, instead of asking
+the user to configure the missing key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime(tmp_path, monkeypatch):
+    """Keep the test's writes out of the user's home and out of the package tree."""
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path / "experience"))
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(tmp_path / "missing-secrets.env"))
+
+
+def _call_run_channel(channel_name: str):
+    from autosearch.mcp.server import create_server
+
+    server = create_server()
+    return asyncio.run(
+        server._tool_manager.call_tool(  # noqa: SLF001
+            "run_channel", {"channel_name": channel_name, "query": "test", "k": 1}
+        )
+    )
+
+
+def _payload(result) -> dict:
+    """Extract the structured RunChannelResponse from FastMCP's wrapper."""
+    if hasattr(result, "structured_content") and result.structured_content:
+        return result.structured_content
+    if hasattr(result, "content"):
+        for c in result.content:
+            if hasattr(c, "text"):
+                import json
+
+                return json.loads(c.text)
+    return result.model_dump() if hasattr(result, "model_dump") else dict(result)
+
+
+def test_youtube_without_key_returns_not_configured_not_unknown(monkeypatch):
+    """The smoking gun: YOUTUBE_API_KEY is unset, the secrets file is empty,
+    youtube is a real channel — must surface `not_configured` + the env it
+    needs, not `unknown_channel`."""
+    monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+
+    payload = _payload(_call_run_channel("youtube"))
+
+    assert payload["ok"] is False
+    assert payload["status"] == "not_configured", (
+        f"expected not_configured, got {payload['status']}: {payload}"
+    )
+    assert any("YOUTUBE_API_KEY" in u for u in payload["unmet_requires"]), (
+        f"unmet_requires must surface YOUTUBE_API_KEY: {payload['unmet_requires']}"
+    )
+    # fix_hint should help the agent ask the user for the right command
+    fix_hint = payload.get("fix_hint") or ""
+    assert "YOUTUBE_API_KEY" in fix_hint or "configure" in fix_hint.lower(), (
+        f"fix_hint must point to the configure command: {fix_hint!r}"
+    )
+
+
+def test_typo_channel_name_returns_unknown_channel():
+    """Genuinely unknown name still gets unknown_channel — but with the new
+    `status` field so the agent can branch on it cleanly."""
+    payload = _payload(_call_run_channel("not-a-real-channel-xyz"))
+
+    assert payload["ok"] is False
+    assert payload["status"] == "unknown_channel"
+    # unknown_channel must NOT include unmet_requires (nothing meaningful to say)
+    assert payload["unmet_requires"] == []

--- a/tests/unit/test_runtime_secrets_contract.py
+++ b/tests/unit/test_runtime_secrets_contract.py
@@ -1,0 +1,102 @@
+"""End-to-end contract: a key in ~/.config/ai-secrets.env must be visible to
+the actual runtime — channel methods, LLM providers, and any code that does
+`os.getenv()` — not just to `doctor` and the environment probe.
+
+Plan §P0-1 reproduction: before this contract holds, a user can run
+`autosearch configure YOUTUBE_API_KEY xxx`, see `doctor` report `youtube ok`,
+and then have the YouTube channel return empty results because `data_api_v3.py`
+called `os.environ.get("YOUTUBE_API_KEY")` and got None.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from autosearch.core.secrets_store import inject_into_env
+
+
+@pytest.fixture
+def isolated_secrets_file(tmp_path, monkeypatch):
+    """Point AUTOSEARCH_SECRETS_FILE at a controlled tmp file and clear any
+    process-env values that might mask file precedence."""
+    secrets_file = tmp_path / "ai-secrets.env"
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(secrets_file))
+    return secrets_file
+
+
+def test_inject_pushes_missing_keys_from_file_into_env(isolated_secrets_file, monkeypatch):
+    isolated_secrets_file.write_text(
+        "RUNTIME_CONTRACT_TEST_KEY=from-file-value\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("RUNTIME_CONTRACT_TEST_KEY", raising=False)
+
+    injected = inject_into_env()
+
+    assert "RUNTIME_CONTRACT_TEST_KEY" in injected
+    assert os.environ.get("RUNTIME_CONTRACT_TEST_KEY") == "from-file-value"
+
+
+def test_inject_does_not_overwrite_explicit_env(isolated_secrets_file, monkeypatch):
+    """Process env always wins — an explicit env override is a deliberate user
+    choice and the file must not silently clobber it."""
+    isolated_secrets_file.write_text("RUNTIME_CONTRACT_OVERRIDE_KEY=from-file\n", encoding="utf-8")
+    monkeypatch.setenv("RUNTIME_CONTRACT_OVERRIDE_KEY", "from-process")
+
+    injected = inject_into_env()
+
+    assert "RUNTIME_CONTRACT_OVERRIDE_KEY" not in injected
+    assert os.environ.get("RUNTIME_CONTRACT_OVERRIDE_KEY") == "from-process"
+
+
+def test_inject_skips_empty_values(isolated_secrets_file, monkeypatch):
+    isolated_secrets_file.write_text("RUNTIME_CONTRACT_EMPTY=\n", encoding="utf-8")
+    monkeypatch.delenv("RUNTIME_CONTRACT_EMPTY", raising=False)
+
+    injected = inject_into_env()
+    assert "RUNTIME_CONTRACT_EMPTY" not in injected
+
+
+def test_inject_is_idempotent(isolated_secrets_file, monkeypatch):
+    isolated_secrets_file.write_text("RUNTIME_CONTRACT_IDEMPOTENT=once\n", encoding="utf-8")
+    monkeypatch.delenv("RUNTIME_CONTRACT_IDEMPOTENT", raising=False)
+
+    first = inject_into_env()
+    second = inject_into_env()
+    assert "RUNTIME_CONTRACT_IDEMPOTENT" in first
+    assert "RUNTIME_CONTRACT_IDEMPOTENT" not in second  # already set
+    assert os.environ.get("RUNTIME_CONTRACT_IDEMPOTENT") == "once"
+
+
+def test_mcp_create_server_pushes_secrets_to_env(isolated_secrets_file, monkeypatch):
+    """The Plan §P0-1 acceptance: when the MCP server starts, secrets-file
+    keys must already be visible to subsequent `os.getenv()` calls."""
+    isolated_secrets_file.write_text("MCP_STARTUP_SECRET_TEST=hello-from-file\n", encoding="utf-8")
+    monkeypatch.delenv("MCP_STARTUP_SECRET_TEST", raising=False)
+    # Force a dummy LLM mode so create_server doesn't try to instantiate a
+    # real provider that needs a key we haven't stubbed.
+    monkeypatch.setenv("AUTOSEARCH_LLM_MODE", "dummy")
+
+    from autosearch.mcp.server import create_server
+
+    create_server()
+    assert os.environ.get("MCP_STARTUP_SECRET_TEST") == "hello-from-file"
+
+
+def test_cli_callback_pushes_secrets_to_env(isolated_secrets_file, monkeypatch):
+    """The CLI entrypoint must push secrets too — otherwise `autosearch doctor`
+    in a new shell where the user just ran `autosearch configure` won't see the
+    new key (CLI doesn't go through MCP startup)."""
+    isolated_secrets_file.write_text("CLI_STARTUP_SECRET_TEST=from-cli-startup\n", encoding="utf-8")
+    monkeypatch.delenv("CLI_STARTUP_SECRET_TEST", raising=False)
+
+    from typer.testing import CliRunner
+
+    from autosearch.cli import main as cli_main
+
+    runner = CliRunner()
+    # Any subcommand triggers the callback.
+    runner.invoke(cli_main.app, ["doctor", "--json"])
+
+    assert os.environ.get("CLI_STARTUP_SECRET_TEST") == "from-cli-startup"


### PR DESCRIPTION
## Summary

Closes plan §P0-1, §P0-2, §P0-3 — the three "doctor says ok but the actual call doesn't work" gaps that the `2026.04.24.1` audit caught.

### P0-1. `autosearch configure KEY value` reaches the actual code path

`secrets_store` got plumbed into `doctor` and `environment_probe` in #312, but every channel method and LLM provider still called `os.getenv()` directly — `youtube/data_api_v3.py:31`, `tikhub_client.py:160`, `llm/providers/{openai,anthropic,gemini}.py`, etc. So a configured `YOUTUBE_API_KEY` was visible to `doctor` (which uses `secrets_store`) but invisible to the YouTube channel call (which uses `os.getenv`).

Fix: add `secrets_store.inject_into_env()` and call it from MCP `create_server` and the CLI `app` callback. Process env always wins (explicit override stays in effect); only missing keys get filled. Universal — no per-consumer migration needed.

Pinned by `tests/unit/test_runtime_secrets_contract.py` (6 tests including the Plan §P0-1 reproduction).

### P0-2. Doctor must reject channels whose impl file doesn't exist

Pre-fix `scan_channels` looked at `requires:` only — a method declared in SKILL.md without its impl file on disk could report `ok` if env keys were satisfied. Plan listed 10 such ghost methods.

Fix:
- `doctor.scan_channels` now appends `impl_missing:<path>` to unmet when the file is absent
- Removed the 10 ghost method declarations from `bilibili / douyin / github / twitter / xiaohongshu / zhihu` SKILL.md (each channel still has at least one working method)
- New static integrity test asserts every shipped channel's declared impls exist

Pinned by `tests/unit/test_doctor_impl_availability.py`.

### P0-3. `run_channel` distinguishes not_configured from unknown_channel

Pre-fix: `run_channel("youtube")` without `YOUTUBE_API_KEY` returned `unknown_channel` because `_build_channels()` filtered out unavailable channels — the agent saw "channel doesn't exist" for a channel that's just unconfigured. Doctor said "off + fix_hint", run_channel said "unknown" — contradictory.

Fix:
- New `RunChannelResponse` fields: `status`, `unmet_requires`, `fix_hint`. Status is one of `ok | no_results | not_configured | unknown_channel | channel_error`.
- New `_build_registry()` helper returns the full ChannelRegistry (not just `available()`) so the handler can introspect known-but-off channels and surface their unmet requires + fix hint.
- `unknown_channel` only fires for genuinely unregistered names.

Pinned by `tests/unit/test_mcp_run_channel_not_configured.py`.

## Verification

- `ruff check .` clean
- `pytest -q -m "not real_llm and not perf and not slow and not network"` → **829 passed** (818 baseline + 11 new across the three contracts)
- Existing scaffold/integrity tests updated to match the cleaned method declarations

## Out of scope (next batches)

- §P0-4 MCP error message redaction (Batch 2)
- §P0-5 ChannelHealth lifecycle (recreated per call) (Batch 3)
- §P0-6 rate limit enforcement (Batch 3)
- §P1 docs / configure prompt / research-tool default visibility (Batch 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)