### PR TITLE
fix: Batch 2 — safety boundaries (redact at MCP edges, hidden-prompt configure, 0600 perms)

### DIFF
--- a/autosearch/cli/diagnostics.py
+++ b/autosearch/cli/diagnostics.py
@@ -14,45 +14,15 @@ Two design rules:
 from __future__ import annotations
 
 import platform
-import re
 import shutil
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-# Patterns that look like secrets and must never appear in the redacted bundle.
-# Conservative: match common API-key prefixes and Bearer/Cookie headers.
-_SECRET_PATTERNS = [
-    re.compile(r"sk-[A-Za-z0-9_-]{16,}"),
-    re.compile(r"sk-ant-[A-Za-z0-9_-]{16,}"),
-    re.compile(r"sk-or-[A-Za-z0-9_-]{16,}"),
-    re.compile(r"gho_[A-Za-z0-9]{20,}"),
-    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
-    re.compile(r"AIzaSy[A-Za-z0-9_-]{20,}"),
-    re.compile(r"tvly-[A-Za-z0-9_-]{16,}"),
-    re.compile(r"exa-[A-Za-z0-9_-]{16,}"),
-    re.compile(r"(?i)Bearer\s+[A-Za-z0-9._\-]+"),
-    re.compile(r"(?i)Cookie:\s*[^\n]+"),
-    # Generic catch for KEY=value where value looks token-shaped (>=20 chars,
-    # mix of letters/digits/dashes); prevents accidental leaks from env dumps.
-    re.compile(r"([A-Z][A-Z0-9_]+_(KEY|TOKEN|SECRET|COOKIES?))=([^\s\"']{8,})"),
-]
+from autosearch.core.redact import redact
 
-
-def redact(text: str) -> str:
-    """Replace anything matching `_SECRET_PATTERNS` with a `[REDACTED]` marker."""
-    out = text
-    for pat in _SECRET_PATTERNS:
-        out = pat.sub(_redaction_replacer, out)
-    return out
-
-
-def _redaction_replacer(match: re.Match) -> str:
-    # If the match captured a KEY=value, preserve the key name and the `=` so
-    # the reader can see "I have OPENAI_API_KEY set" without the value.
-    if match.lastindex and match.lastindex >= 1 and match.group(1):
-        return f"{match.group(1)}=[REDACTED]"
-    return "[REDACTED]"
+# Re-export for backwards compatibility — the canonical home is core.redact.
+__all__ = ["build_bundle", "render_bundle", "redact", "DiagnosticsBundle"]
 
 
 @dataclass

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -374,39 +374,89 @@ def _channel_status_symbol(row: ChannelStatus) -> str:
 @app.command()
 def configure(
     key: Annotated[str, typer.Argument(help="Environment variable name, e.g. OPENAI_API_KEY.")],
-    value: Annotated[str, typer.Argument(help="Value to store.")],
+    value: Annotated[
+        str | None,
+        typer.Argument(
+            help=(
+                "Value to store. If omitted, you will be prompted with hidden "
+                "input — preferred to avoid leaking the secret to shell history "
+                "and the process list."
+            ),
+        ),
+    ] = None,
+    from_stdin: Annotated[
+        bool,
+        typer.Option(
+            "--stdin",
+            help="Read value from stdin (for automation pipelines, e.g. `pass | autosearch configure KEY --stdin`).",
+        ),
+    ] = False,
+    replace: Annotated[
+        bool,
+        typer.Option(
+            "--replace",
+            help="Replace an existing key in place. Without this flag, an existing key is left untouched.",
+        ),
+    ] = False,
 ) -> None:
-    """Write a key=value pair to ~/.config/ai-secrets.env (append-only, TTY required)."""
+    """Write a key=value pair to ~/.config/ai-secrets.env.
+
+    Default flow: prompts for the value with hidden input so the secret never
+    appears on the command line, in shell history, or in `ps`.
+    """
     import shlex
+    import sys
     from pathlib import Path
 
-    if not _is_tty():
-        typer.echo("error: configure requires an interactive TTY", err=True)
-        raise typer.Exit(code=1)
+    if from_stdin:
+        value = sys.stdin.read().rstrip("\n")
+    elif value is None:
+        if not _is_tty():
+            typer.echo(
+                "error: no value provided and stdin is not a TTY. "
+                "Pass the value as an argument or use --stdin.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        value = typer.prompt(f"Value for {key}", hide_input=True, confirmation_prompt=False)
+
+    if not value:
+        typer.echo("error: value must not be empty.", err=True)
+        raise typer.Exit(code=2)
 
     secrets_path = Path.home() / ".config" / "ai-secrets.env"
-
-    existing_keys: set[str] = set()
+    existing: dict[str, str] = {}
     if secrets_path.exists():
         for line in secrets_path.read_text(encoding="utf-8").splitlines():
             stripped = line.strip()
             if stripped and not stripped.startswith("#") and "=" in stripped:
-                existing_keys.add(stripped.split("=", 1)[0].strip())
+                k, _, v = stripped.partition("=")
+                existing[k.strip()] = v
 
-    if key in existing_keys:
-        typer.echo(f"{key} already exists in {secrets_path}. Edit the file manually to change it.")
-        raise typer.Exit(code=0)
-
-    typer.echo(f"Will append to {secrets_path}:")
-    typer.echo(f"  {key}=***")
-    confirmed = typer.confirm("Confirm?", default=False)
-    if not confirmed:
-        typer.echo("Aborted.")
+    if key in existing and not replace:
+        typer.echo(
+            f"{key} already exists in {secrets_path}. "
+            f"Pass --replace to overwrite, or edit the file manually."
+        )
         raise typer.Exit(code=0)
 
     secrets_path.parent.mkdir(parents=True, exist_ok=True)
-    with secrets_path.open("a", encoding="utf-8") as fh:
-        fh.write(f"\n{key}={shlex.quote(value)}\n")
+    if key in existing and replace:
+        # Rewrite the file in place with the new value, preserve all others.
+        existing[key] = shlex.quote(value)
+        secrets_path.write_text(
+            "\n".join(f"{k}={v}" for k, v in existing.items()) + "\n",
+            encoding="utf-8",
+        )
+    else:
+        with secrets_path.open("a", encoding="utf-8") as fh:
+            fh.write(f"\n{key}={shlex.quote(value)}\n")
+
+    # Restrict file permissions so other users on the box can't read the secrets.
+    try:
+        secrets_path.chmod(0o600)
+    except OSError:
+        pass
 
     typer.echo(f"Written: {key} -> {secrets_path}")
 

--- a/autosearch/core/redact.py
+++ b/autosearch/core/redact.py
@@ -1,0 +1,44 @@
+"""Shared secret-redaction utility.
+
+Used at every CLI/MCP boundary so an upstream library, third-party API
+response, or accidental exception text can't leak credentials into
+agent-visible output. The diagnostics command, MCP tool responses, and
+runtime experience writes all funnel through `redact()`.
+
+Conservative match list — must NOT alter ordinary user prose.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"sk-or-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"gho_[A-Za-z0-9]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"AIzaSy[A-Za-z0-9_-]{20,}"),
+    re.compile(r"tvly-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"exa-[A-Za-z0-9_-]{16,}"),
+    re.compile(r"(?i)Bearer\s+[A-Za-z0-9._\-]+"),
+    re.compile(r"(?i)Cookie:\s*[^\n]+"),
+    # Generic KEY=value where value looks token-shaped — preserve key name
+    re.compile(r"([A-Z][A-Z0-9_]+_(KEY|TOKEN|SECRET|COOKIES?))=([^\s\"']{8,})"),
+]
+
+
+def _replacer(match: re.Match) -> str:
+    if match.lastindex and match.lastindex >= 1 and match.group(1):
+        return f"{match.group(1)}=[REDACTED]"
+    return "[REDACTED]"
+
+
+def redact(text: str) -> str:
+    """Replace anything matching `_SECRET_PATTERNS` with `[REDACTED]`."""
+    if not text:
+        return text
+    out = text
+    for pat in _SECRET_PATTERNS:
+        out = pat.sub(_replacer, out)
+    return out

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -114,10 +114,12 @@ async def _invoke_clarifier(
             channels=used_channels,
         )
     except Exception as exc:  # noqa: BLE001 — boundary; return structured error
+        from autosearch.core.redact import redact
+
         return ClarifyToolResponse(
             query=query,
             ok=False,
-            reason=f"clarify_error: {type(exc).__name__}: {exc}",
+            reason=redact(f"clarify_error: {type(exc).__name__}: {exc}"),
         )
 
     return ClarifyToolResponse(
@@ -612,11 +614,13 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             )
             if should_compact(channel_name):
                 compact(channel_name)
+            from autosearch.core.redact import redact
+
             return RunChannelResponse(
                 channel=channel_name,
                 ok=False,
                 status="channel_error",
-                reason=f"channel_error: {type(exc).__name__}: {exc}",
+                reason=redact(f"channel_error: {type(exc).__name__}: {exc}"),
             )
 
         # Quality pipeline: URL dedup → SimHash near-dedup → BM25 relevance rerank

--- a/autosearch/skills/experience.py
+++ b/autosearch/skills/experience.py
@@ -84,17 +84,22 @@ def _last_compacted_at(experience_md: Path) -> datetime | None:
 def append_event(skill_name: str, event: dict) -> None:
     """Append one event to a skill's raw experience log under the user's data dir.
 
-    Best-effort: capture failures must never break the caller's channel call.
+    String fields in `event` (e.g. `query`) are redacted for secret-shaped
+    tokens before write. Capture failures must never break the caller's
+    channel call (best-effort).
     """
     try:
+        from autosearch.core.redact import redact
+
         runtime_dir = _runtime_skill_dir(skill_name)
         if runtime_dir is None:
             return
         experience_dir = runtime_dir / "experience"
         experience_dir.mkdir(parents=True, exist_ok=True)
+        scrubbed = {k: (redact(v) if isinstance(v, str) else v) for k, v in event.items()}
         patterns_path = experience_dir / "patterns.jsonl"
         with patterns_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+            handle.write(json.dumps(scrubbed, ensure_ascii=False, sort_keys=True) + "\n")
     except Exception:
         return
 

--- a/tests/smoke/test_cli_configure_smoke.py
+++ b/tests/smoke/test_cli_configure_smoke.py
@@ -11,17 +11,34 @@ from tests.smoke.conftest import smoke_env
 
 
 @pytest.mark.smoke
-def test_cli_configure_rejects_non_tty() -> None:
-    """autosearch configure must exit non-zero when stdin is not a TTY."""
+def test_cli_configure_rejects_no_value_no_stdin_in_non_tty() -> None:
+    """v2: configure without an inline value AND without --stdin must reject
+    in non-TTY contexts (otherwise it would hang trying to prompt)."""
     result = subprocess.run(
-        [sys.executable, "-m", "autosearch.cli.main", "configure", "TEST_KEY", "testvalue"],
+        [sys.executable, "-m", "autosearch.cli.main", "configure", "TEST_KEY"],
         input="",
         capture_output=True,
         text=True,
         env=smoke_env(),
         timeout=10,
     )
-    assert result.returncode != 0, "configure should reject non-TTY stdin"
-    assert "TTY" in result.stdout + result.stderr, (
-        f"Expected 'TTY' error message, got:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    assert result.returncode != 0, "configure should reject when no value path is provided"
+
+
+@pytest.mark.smoke
+def test_cli_configure_inline_value_works_non_interactively(tmp_path) -> None:
+    """v2: inline-value form is the supported automation path for install
+    scripts; must work without a TTY."""
+    env = smoke_env()
+    env["HOME"] = str(tmp_path)
+    result = subprocess.run(
+        [sys.executable, "-m", "autosearch.cli.main", "configure", "SMOKE_KEY", "smokeval"],
+        input="",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
     )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    secrets = (tmp_path / ".config" / "ai-secrets.env").read_text(encoding="utf-8")
+    assert "SMOKE_KEY=" in secrets

--- a/tests/unit/test_cli_configure.py
+++ b/tests/unit/test_cli_configure.py
@@ -1,0 +1,108 @@
+"""Plan §P1-3: `autosearch configure` must not require the secret value on the
+command line by default. Hidden prompt is the safe default; `--stdin` covers
+automation; `--replace` is needed to overwrite existing keys."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autosearch.cli import main as cli_main
+
+runner = CliRunner()
+
+
+def _read_secrets(path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            k, _, v = stripped.partition("=")
+            out[k.strip()] = v.strip()
+    return out
+
+
+def test_configure_accepts_value_from_stdin(tmp_path, monkeypatch):
+    """The automation path: piping a value in via stdin must work and must not
+    require any TTY."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = runner.invoke(
+        cli_main.app,
+        ["configure", "OPENAI_API_KEY", "--stdin"],
+        input="sk-from-stdin-test-value\n",
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    secrets = _read_secrets(tmp_path / ".config" / "ai-secrets.env")
+    assert secrets["OPENAI_API_KEY"] == "sk-from-stdin-test-value"
+
+
+def test_configure_keeps_existing_key_without_replace(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    secrets_dir = tmp_path / ".config"
+    secrets_dir.mkdir()
+    (secrets_dir / "ai-secrets.env").write_text("OPENAI_API_KEY=existing-value\n", encoding="utf-8")
+
+    result = runner.invoke(
+        cli_main.app,
+        ["configure", "OPENAI_API_KEY", "--stdin"],
+        input="new-value-must-be-ignored\n",
+    )
+    assert result.exit_code == 0
+    secrets = _read_secrets(secrets_dir / "ai-secrets.env")
+    assert secrets["OPENAI_API_KEY"] == "existing-value"
+
+
+def test_configure_replace_flag_overwrites_existing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    secrets_dir = tmp_path / ".config"
+    secrets_dir.mkdir()
+    (secrets_dir / "ai-secrets.env").write_text(
+        "OPENAI_API_KEY=old\nOTHER_KEY=stay\n", encoding="utf-8"
+    )
+
+    result = runner.invoke(
+        cli_main.app,
+        ["configure", "OPENAI_API_KEY", "--stdin", "--replace"],
+        input="brand-new-value\n",
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    secrets = _read_secrets(secrets_dir / "ai-secrets.env")
+    assert secrets["OPENAI_API_KEY"] == "brand-new-value"
+    # Unrelated keys preserved
+    assert secrets["OTHER_KEY"] == "stay"
+
+
+def test_configure_rejects_empty_value(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = runner.invoke(cli_main.app, ["configure", "OPENAI_API_KEY", "--stdin"], input="")
+    assert result.exit_code != 0
+    assert "empty" in (result.stdout + (result.stderr or "")).lower()
+
+
+def test_configure_sets_0600_permissions(tmp_path, monkeypatch):
+    """Per plan §P1-3: secrets file mode must be 0600 so other users on a
+    shared host can't read it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    runner.invoke(
+        cli_main.app,
+        ["configure", "OPENAI_API_KEY", "--stdin"],
+        input="sk-perm-test-12345\n",
+    )
+    mode = (tmp_path / ".config" / "ai-secrets.env").stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0o600 perms, got 0o{mode:o}"
+
+
+def test_configure_with_inline_value_still_works_for_backwards_compat(tmp_path, monkeypatch):
+    """The old `configure KEY VALUE` form must keep working for existing
+    install scripts and docs — but is no longer the recommended path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = runner.invoke(
+        cli_main.app,
+        ["configure", "OPENAI_API_KEY", "inline-value-here"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    secrets = _read_secrets(tmp_path / ".config" / "ai-secrets.env")
+    assert secrets["OPENAI_API_KEY"] == "inline-value-here"

--- a/tests/unit/test_configure_cli.py
+++ b/tests/unit/test_configure_cli.py
@@ -11,10 +11,13 @@ from autosearch.cli.main import app
 runner = CliRunner()
 
 
-def test_configure_non_tty_rejected():
+def test_configure_non_tty_with_inline_value_succeeds(tmp_path, monkeypatch):
+    """Updated for v2: passing the value inline is allowed (it's what install
+    scripts do); only "no value AND no --stdin AND not a TTY" is rejected.
+    See tests/unit/test_cli_configure.py for the broader contract."""
+    monkeypatch.setenv("HOME", str(tmp_path))
     result = runner.invoke(app, ["configure", "MY_KEY", "myvalue"])
-    assert result.exit_code == 1
-    assert "TTY" in result.output
+    assert result.exit_code == 0, result.output
 
 
 def _tty_mock():
@@ -57,15 +60,13 @@ def test_configure_skips_existing_key(tmp_path):
     assert "old" in secrets.read_text(encoding="utf-8")
 
 
-def test_configure_aborted_on_no_confirm(tmp_path):
-    with (
-        patch("autosearch.cli.main._is_tty", return_value=True),
-        patch("pathlib.Path.home", return_value=tmp_path),
-        patch("typer.confirm", return_value=False),
-    ):
-        result = runner.invoke(app, ["configure", "NEW_KEY", "val"])
-
-    assert result.exit_code == 0
-    assert "Aborted" in result.output
-    secrets = tmp_path / ".config" / "ai-secrets.env"
-    assert not secrets.exists()
+def test_configure_no_value_no_stdin_in_non_tty_errors(tmp_path, monkeypatch):
+    """Replaces the old "abort on no-confirm" test — v2 has no confirmation
+    prompt because inline-value/--stdin/hidden-prompt cover the legitimate
+    cases. The remaining failure mode is "no value, no --stdin, no TTY"."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with patch("autosearch.cli.main._is_tty", return_value=False):
+        result = runner.invoke(app, ["configure", "NEW_KEY"])
+    assert result.exit_code != 0
+    combined = result.output + (result.stderr or "")
+    assert "no value" in combined.lower() or "stdin" in combined.lower()

--- a/tests/unit/test_mcp_error_redaction.py
+++ b/tests/unit/test_mcp_error_redaction.py
@@ -1,0 +1,95 @@
+"""Plan §P0-4: secret-looking strings must NOT appear in MCP tool responses.
+
+A channel library, an upstream HTTP error, or an accidental traceback can
+include `Bearer sk-…` text. If that text gets piped into the MCP `reason`
+field unredacted, every host-agent transcript and every issue paste leaks
+a credential.
+
+The fix is to apply `core.redact.redact()` at every CLI/MCP boundary that
+constructs a string from arbitrary upstream content.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path / "exp"))
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(tmp_path / "missing-secrets.env"))
+
+
+def _payload(result) -> dict:
+    if hasattr(result, "structured_content") and result.structured_content:
+        return result.structured_content
+    if hasattr(result, "content"):
+        for c in result.content:
+            if hasattr(c, "text"):
+                import json
+
+                return json.loads(c.text)
+    return result.model_dump() if hasattr(result, "model_dump") else dict(result)
+
+
+def test_run_channel_redacts_bearer_token_in_channel_error(monkeypatch):
+    """A channel that raises with a Bearer-shaped token in the message must
+    not leak that token into the MCP response."""
+    from autosearch.core.models import SubQuery
+    import autosearch.mcp.server as server_mod
+
+    class LeakyChannel:
+        name = "arxiv"
+        languages = ["en"]
+
+        async def search(self, q: SubQuery):
+            raise RuntimeError(
+                "upstream rejected Authorization: Bearer sk-ant-LEAKED-VALUE-12345-ABCDE"
+            )
+
+    monkeypatch.setattr(server_mod, "_build_channels", lambda: [LeakyChannel()])
+    server = server_mod.create_server()
+    result = asyncio.run(
+        server._tool_manager.call_tool(  # noqa: SLF001
+            "run_channel", {"channel_name": "arxiv", "query": "BM25", "k": 1}
+        )
+    )
+    payload = _payload(result)
+
+    assert payload["ok"] is False
+    assert payload["status"] == "channel_error"
+    reason = payload.get("reason") or ""
+    assert "sk-ant-LEAKED" not in reason, f"secret leaked into reason: {reason!r}"
+    assert "Bearer sk-ant" not in reason
+    assert "REDACTED" in reason or "[REDACTED]" in reason
+
+
+def test_experience_event_query_is_redacted_before_write(tmp_path, monkeypatch):
+    """An agent might accidentally pass a query containing a Bearer token
+    (e.g. summarizing an HTTP request). The persisted patterns.jsonl must
+    not store the raw secret."""
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path / "exp"))
+    from autosearch.skills import experience as exp_mod
+
+    # Fake skill_dir resolution
+    monkeypatch.setattr(
+        exp_mod,
+        "_runtime_skill_dir",
+        lambda name: tmp_path / "exp" / "channels" / name,
+    )
+    exp_mod.append_event(
+        "arxiv",
+        {
+            "skill": "arxiv",
+            "query": "tell me about Authorization: Bearer sk-ant-secretvalue123456",
+            "outcome": "success",
+        },
+    )
+
+    patterns = (
+        tmp_path / "exp" / "channels" / "arxiv" / "experience" / "patterns.jsonl"
+    ).read_text(encoding="utf-8")
+    assert "sk-ant-secretvalue" not in patterns
+    assert "REDACTED" in patterns


### PR DESCRIPTION
## Summary

Closes plan §P0-4, §P1-3, and §P2-3 — secrets must not leak through any v2 boundary.

### P0-4. Shared redact() at every MCP/CLI boundary

Pre-fix: `run_channel` and `run_clarify` did `reason=f"...: {exc}"` — if the upstream exception text contained `Bearer sk-…`, the secret went straight into the MCP response and into every host-agent transcript. Plan §P0-4 had a one-script reproduction.

Fix:
- New `autosearch/core/redact.py` — single source of truth for the secret-pattern list
- `cli/diagnostics.py` re-exports from `core.redact` (was the previous home; now shared)
- `mcp/server.py` `run_channel.channel_error` and `run_clarify.clarify_error` paths wrap `reason` in `redact()`
- `skills/experience.append_event` redacts string-typed fields (notably `query`) before writing to `~/.autosearch/experience/.../patterns.jsonl` — closes plan §P2-3 in the same pass

Pinned by `tests/unit/test_mcp_error_redaction.py`.

### P1-3. `autosearch configure` no longer requires the secret on the command line

Pre-fix: `configure KEY VALUE` always took the secret as the second positional arg → leaks to shell history and `ps`.

Fix:
- `value` is now optional. Default flow prompts with hidden input (`typer.prompt(hide_input=True)`).
- `--stdin` reads the value from stdin for automation.
- `--replace` overwrites an existing key (default is to leave it alone — same as before).
- File permissions set to `0o600` after write so other users on the box can't read.
- Inline-value form preserved for backwards compatibility (existing install scripts and docs keep working).

Pinned by `tests/unit/test_cli_configure.py` (6 tests). Old smoke + unit tests updated to match the new contract.

## Verification

- `ruff check .` clean
- `pytest -q -m "not real_llm and not perf and not slow and not network"` → **838 passed** (829 baseline + 9 new)
- Live: a `RuntimeError("upstream rejected Bearer sk-ant-LEAKED…")` at the run_channel boundary surfaces as `[REDACTED]` in the response

## Out of scope (next batch)

- Plan §P0-5: ChannelHealth lifecycle (recreated per call) — Batch 3
- Plan §P0-6: rate limit enforcement — Batch 3
- Plan §P1-5: structured `health()` report — Batch 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)