### PR TITLE
ci(release): skip npm publish when derived version was already published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,15 @@ jobs:
           spec.loader.exec_module(mod)
           print(mod.derive_npm_version('$VERSION'))
           ")
+          # Intra-day pyproject bumps (YYYY.MM.DD.1 → YYYY.MM.DD.2) map to the
+          # same npm version. The npm tarball only depends on the base date,
+          # so if it's already published we skip rather than fail the whole
+          # release workflow.
+          PUBLISHED=$(npm view "autosearch-ai@$NPM_VERSION" version 2>/dev/null || echo "")
+          if [ "$PUBLISHED" = "$NPM_VERSION" ]; then
+            echo "npm already has autosearch-ai@$NPM_VERSION — skipping (intra-day pyproject bump, nothing new to publish)"
+            exit 0
+          fi
           echo "Publishing autosearch-ai@$NPM_VERSION (derived from $VERSION)"
           cd npm
           npm version "$NPM_VERSION" --no-git-tag-version --allow-same-version


### PR DESCRIPTION
## Summary

Follow-up from the v2026.04.24.2 release. The release workflow failed at the npm-publish step because `derive_npm_version(2026.04.24.2)` = `2026.4.24`, which was already published when v2026.04.24.1 shipped earlier today. PyPI + GitHub Release succeeded; only the npm step exited non-zero.

This is actually the right behavior for our mapping — intra-day pyproject bumps (`.1 → .2 → .3`) fold to the same npm version because the npm wrapper doesn't depend on the Python daily counter. But the workflow should exit 0 with a skip note, not red.

Fix: before publishing, `npm view autosearch-ai@$NPM_VERSION version` — if the response matches the target version, log a skip message and exit 0.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses clean
- Manual: `npm view autosearch-ai@2026.4.24 version` returns `2026.4.24` right now (confirming the next release will correctly skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)