### PR TITLE
ci(release-gate): wire plan §Gate A-G as named contract step

### DIFF
--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # scripts/release-gate.sh — single command to verify v2 install contract before cutting a release.
 #
-# Composes the four checks that prove a fresh user install will work:
+# Composes the checks that prove a fresh user install will work:
 #   1. version files agree (pyproject / plugin.json / marketplace.json / CHANGELOG / npm)
 #   2. lint + format clean
-#   3. unit + smoke test suite green
+#   3a. contract gates (plan §Gate A-G + P0 invariants) — always runs, even in --quick
+#   3b. full unit + smoke test suite (skipped in --quick)
 #   4. CLI surface honest:
 #        - `autosearch doctor --json` returns the expected channel count
 #        - `autosearch mcp-check` reports all 10 required v2 tools registered
@@ -13,8 +14,8 @@
 # first failure and reports which gate blocked. No network access required.
 #
 # Usage:
-#   scripts/release-gate.sh                # run all gates
-#   scripts/release-gate.sh --quick        # skip the full pytest run (lint + version + CLI only)
+#   scripts/release-gate.sh                # run all gates including full suite
+#   scripts/release-gate.sh --quick        # skip the full default suite; contract gates still run
 
 set -euo pipefail
 
@@ -85,7 +86,50 @@ else
   echo "skip: ruff not found at $RUFF (install with .venv pip install ruff)"
 fi
 
-# ── Gate 3: tests ────────────────────────────────────────────────────────────
+# ── Gate 3a: contract gates (per docs/million-user-product-readiness-plan.md) ─
+# Always runs (even in --quick mode) — these are the named contracts that prove
+# the v2 install promise hasn't silently regressed. Listing them explicitly
+# (rather than letting them blend into the default suite) makes a contract
+# breakage produce a contract-named failure banner.
+#
+# Gate names follow plan §"Release Gate Upgrades":
+#   A — secrets file → runtime visibility
+#   B — missing-impl integrity (covered by test_doctor_impl_availability.py;
+#       plan named it test_channel_impl_integrity.py but real coverage is the
+#       static integrity check inside doctor_impl_availability)
+#   C — MCP error redaction
+#   D — known-off vs unknown channel semantics
+#   E — docs contract DEFERRED: README / install.md / mcp-clients.md still
+#       describe v1 happy path per owner directive ("叙事不改"). Re-enable when
+#       the narrative hold lifts.
+#   F — e2b matrix contract PARTIAL: only matrix.yaml + matrix-release-gate.yaml
+#       scanned today; matrix-extensions.yaml + matrix-w1w4-bench.yaml cleanup
+#       pending separate PR.
+#   G — published package contents (runtime dep isolation, no jsonl in wheel,
+#       version sync)
+# Plus two P0-era invariants surfaced as named gates:
+#   P0-5 — ChannelRuntime singleton persists health across MCP tool calls
+#   P0-6 — declared rate_limit metadata is enforced at runtime
+step "contract gates (plan §Gate A-G + P0 invariants)"
+if [ -x "$PYTEST" ]; then
+  CONTRACT_TESTS=(
+    "tests/unit/test_runtime_secrets_contract.py"        # Gate A
+    "tests/unit/test_doctor_impl_availability.py"        # Gate B (see banner)
+    "tests/unit/test_mcp_error_redaction.py"             # Gate C
+    "tests/unit/test_mcp_run_channel_not_configured.py"  # Gate D
+    # Gate E deferred (see banner)
+    "tests/unit/test_e2b_matrix_contract.py"             # Gate F (partial, see banner)
+    "tests/unit/test_package_contents.py"                # Gate G
+    "tests/unit/test_mcp_runtime_health_persistence.py"  # P0-5 invariant
+    "tests/unit/test_channel_rate_limit.py"              # P0-6 invariant
+  )
+  "$PYTEST" -x -q "${CONTRACT_TESTS[@]}" || fail "contract gates"
+  pass "all contract gates green"
+else
+  echo "skip: pytest not found at $PYTEST"
+fi
+
+# ── Gate 3b: full unit + smoke suite ─────────────────────────────────────────
 if [ "$QUICK" = false ]; then
   step "unit + smoke tests"
   if [ -x "$PYTEST" ]; then

--- a/tests/unit/test_package_contents.py
+++ b/tests/unit/test_package_contents.py
@@ -1,0 +1,96 @@
+"""Plan §Gate G: published package contents match intentional policy.
+
+Three checks at the policy layer (cheap, run on every release-gate invocation):
+
+1. runtime dependencies must not pull in test/lint tools — those belong in the
+   `dev` optional extra. A misplaced `pytest` or `ruff` bloats every install.
+2. the setuptools package-data glob must not include `*.jsonl` — accumulated
+   skill `experience/patterns.jsonl` is runtime state, not seed data, and
+   shipping it leaks every author's prior search history into the wheel.
+3. the cross-file version pins agree (single source of truth: pyproject;
+   mirrored to plugin.json, marketplace.json, CHANGELOG, npm).
+
+A best-effort artifact check also runs against the latest built wheel in
+`dist/` if one exists — it skips when no wheel has been built so this test
+stays fast in --quick mode.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def _read_pyproject() -> str:
+    return PYPROJECT.read_text(encoding="utf-8")
+
+
+def test_runtime_deps_exclude_test_and_lint_tools() -> None:
+    text = _read_pyproject()
+    match = re.search(
+        r"^\s*dependencies\s*=\s*\[(?P<body>.*?)\]",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match, "[project].dependencies block not found in pyproject.toml"
+    runtime_block = match.group("body").lower()
+    forbidden = ("pytest", "ruff", "black", "mypy", "pyright")
+    leaked = [tool for tool in forbidden if tool in runtime_block]
+    assert not leaked, (
+        "runtime dependencies must not contain dev/test tools "
+        f"(found: {leaked}); move them to [project.optional-dependencies].dev"
+    )
+
+
+def test_package_data_excludes_runtime_jsonl() -> None:
+    text = _read_pyproject()
+    match = re.search(
+        r"\[tool\.setuptools\.package-data\](?P<body>.*?)(?=^\[|\Z)",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match, "[tool.setuptools.package-data] section not found"
+    body = match.group("body")
+    assert ".jsonl" not in body, (
+        "package-data must not glob *.jsonl — accumulated runtime "
+        "patterns.jsonl files would leak into the wheel"
+    )
+
+
+def test_version_files_consistent() -> None:
+    script = ROOT / "scripts" / "validate" / "check_version_consistency.py"
+    assert script.is_file(), f"version check script missing: {script}"
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    assert result.returncode == 0, (
+        "version files drifted across pyproject / plugin.json / "
+        "marketplace.json / CHANGELOG / npm:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_built_wheel_does_not_ship_runtime_patterns_jsonl() -> None:
+    dist = ROOT / "dist"
+    wheels = sorted(dist.glob("autosearch-*.whl"))
+    if not wheels:
+        pytest.skip("no built wheel in dist/ — run `uv build --wheel` first")
+    latest = wheels[-1]
+    with zipfile.ZipFile(latest) as zf:
+        names = zf.namelist()
+    leaked = [n for n in names if n.endswith("patterns.jsonl")]
+    assert not leaked, (
+        f"{latest.name} ships runtime patterns.jsonl files (must be excluded "
+        "from package-data):\n" + "\n".join(f"  {n}" for n in leaked)
+    )


### PR DESCRIPTION
## Summary

- Adds `tests/unit/test_package_contents.py` (plan §Gate G — runtime dep isolation, package-data globs reject `*.jsonl`, version files in sync, wheel artifact best-effort check)
- Wires a new "contract gates" step in `scripts/release-gate.sh` that explicitly lists Gates A/B/C/D/F/G + P0-5/6 invariants — always runs, even in `--quick`. A regression now produces a contract-named failure banner instead of blending into the 800+ default suite

## Why now

Per `docs/million-user-product-readiness-plan.md` §"Release Gate Upgrades", these contracts existed as test files but the release gate didn't enforce them as a named step. A future PR could silently flip P0-1 (secrets visibility) or P0-4 (MCP redaction) without anyone noticing until production.

## Scope honesty

- **Gate B** named `test_channel_impl_integrity.py` in plan, but real coverage already lives in `test_doctor_impl_availability.py::test_real_repo_has_no_silent_missing_impls`. Wired the existing test rather than rename for cosmetic alignment.
- **Gate E (docs contract)** deferred — README / install.md / mcp-clients.md still describe v1 happy path per owner directive ("叙事不改"). Re-enable when narrative hold lifts.
- **Gate F (e2b matrix)** partial — only `matrix.yaml` + `matrix-release-gate.yaml` scanned; `matrix-extensions.yaml` + `matrix-w1w4-bench.yaml` cleanup pending separate PR.

## Test plan

- [x] `./scripts/release-gate.sh --quick` → 32 contract tests + lint + version + CLI all PASS
- [x] `./scripts/release-gate.sh` (full) → 32 contract + 851 default suite + CLI all PASS
- [x] `pytest tests/unit/test_package_contents.py -v` → 4/4 PASS (incl. wheel artifact check against existing dist/2026.4.24.1.whl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)