### PR TITLE
fix(npm): drop postinstall + require explicit consent (plan §P1-8)

### DIFF
--- a/npm/bin/autosearch-ai.js
+++ b/npm/bin/autosearch-ai.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 "use strict";
 
+// Plan §P1-8: this launcher must NEVER be triggered by `npm install` (the
+// postinstall hook is removed in package.json). It runs only when the user
+// types `npx autosearch-ai` or invokes the installed binary explicitly. Even
+// then, an unattended remote `curl | bash` requires explicit confirmation —
+// either an interactive y/N prompt or `--yes` / `-y` on the command line.
+
 const { execSync, spawnSync } = require("child_process");
+const readline = require("readline");
+
 const args = process.argv.slice(2);
 
 const INSTALL_SCRIPT =
@@ -16,14 +24,63 @@ function hasAutosearch() {
   }
 }
 
-if (!hasAutosearch()) {
-  // Download and run install.sh — handles uv/pipx/pip + shows init screen
-  const result = spawnSync("bash", ["-c", `curl -fsSL ${INSTALL_SCRIPT} | bash`], {
-    stdio: "inherit",
+function popFlag(name) {
+  const i = args.indexOf(name);
+  if (i === -1) return false;
+  args.splice(i, 1);
+  return true;
+}
+
+function confirm(prompt) {
+  return new Promise((resolve) => {
+    if (!process.stdin.isTTY) {
+      resolve(false);
+      return;
+    }
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stderr,
+    });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
   });
+}
+
+async function main() {
+  const yes = popFlag("--yes") || popFlag("-y");
+
+  if (!hasAutosearch()) {
+    if (!yes) {
+      const ok = await confirm(
+        `\nautosearch is not installed.\n` +
+          `This will download and execute a remote install script:\n` +
+          `  ${INSTALL_SCRIPT}\n` +
+          `Proceed? [y/N] `,
+      );
+      if (!ok) {
+        console.error(
+          `\nAborted. To install non-interactively re-run with --yes,\n` +
+            `or install AutoSearch directly via your package manager:\n` +
+            `  pip install autosearch && autosearch init\n` +
+            `  pipx install autosearch && autosearch init\n` +
+            `  curl -fsSL ${INSTALL_SCRIPT} | bash`,
+        );
+        process.exit(1);
+      }
+    }
+    const result = spawnSync(
+      "bash",
+      ["-c", `curl -fsSL ${INSTALL_SCRIPT} | bash`],
+      { stdio: "inherit" },
+    );
+    process.exit(result.status ?? 0);
+  }
+
+  const cmd = args.length > 0 ? args : ["init"];
+  const result = spawnSync("autosearch", cmd, { stdio: "inherit" });
   process.exit(result.status ?? 0);
 }
 
-const cmd = args.length > 0 ? args : ["init"];
-const result = spawnSync("autosearch", cmd, { stdio: "inherit" });
-process.exit(result.status ?? 0);
+main();

--- a/npm/package.json
+++ b/npm/package.json
@@ -24,8 +24,5 @@
   ],
   "engines": {
     "node": ">=18"
-  },
-  "scripts": {
-    "postinstall": "node bin/autosearch-ai.js"
   }
 }


### PR DESCRIPTION
## Summary

- Drops `postinstall` hook from `npm/package.json` so `npm install -g autosearch-ai` no longer silently downloads and executes a remote install script
- Refactors `npm/bin/autosearch-ai.js` so when `npx autosearch-ai` (or the installed binary) needs to bootstrap AutoSearch, it requires explicit consent: interactive y/N prompt, `--yes` / `-y` to bypass for automation, refuses to proceed in non-interactive (non-TTY) environments without `--yes`

## Why now

Plan §P1-8 — `npm install -g autosearch-ai` triggering an unattended `curl … | bash` was a supply-chain risk for a million-user distribution. Public users could install AutoSearch without ever seeing the URL being fetched. The deprecated `postinstall` flow is removed entirely; the `npx` path is preserved (it remains the recommended one-line install in docs) but now always shows the URL and waits for consent.

## Scope honesty

- README / install.md not touched per "叙事不改" hold. The npx-based one-line install instruction in install.md still works correctly; users now see one extra prompt before the remote script runs, which is the entire point.
- Update flow (`npm install -g autosearch-ai`) for already-installed users still works to refresh the npm package; it just no longer auto-runs `autosearch init` afterwards.

## Test plan

- [x] `cd npm && npm pack && tar -xzOf autosearch-ai-*.tgz package/package.json` → no `scripts.postinstall` key
- [x] `node --check npm/bin/autosearch-ai.js` → syntax OK
- [x] `./scripts/release-gate.sh --quick` → all gates PASS
- [ ] Manual smoke (post-merge): `npm install --ignore-scripts -g autosearch-ai@<this-tag>` then verify `which autosearch-ai` works but no remote curl executed during install

🤖 Generated with [Claude Code](https://claude.com/claude-code)