### PR TITLE
test(e2b): expand matrix contract to all yaml; clean v1 residue (plan §Gate F + §P1-2)

### DIFF
--- a/tests/e2b/matrix-extensions.yaml
+++ b/tests/e2b/matrix-extensions.yaml
@@ -136,7 +136,10 @@ phases:
           claude --dangerously-skip-permissions -p "/autosearch what is BM25" 2>&1 | tail -200
         expect:
           exit: 0
-          stdout_contains: "References"
+          # v2 contract: agent synthesizes from run_channel evidence; the literal
+          # "References" section was a v1 report-format artifact. We assert the
+          # query topic surfaces in the answer instead.
+          stdout_regex: "BM25|bm25"
 
   # F104 — MCP-as-tool (Claude Code invoking autosearch via MCP config)
   F104_mcp_as_tool:
@@ -175,7 +178,9 @@ phases:
         env_keys: [ANTHROPIC_API_KEY]
         cmd: |
           cd $HOME/work/autosearch
-          claude --mcp-config $HOME/.claude/mcp.json --dangerously-skip-permissions -p "Use the research tool with mode=fast to briefly summarize BM25" 2>&1 | tail -200
+          # v2 contract: the host agent calls list_skills + run_channel and
+          # synthesizes itself, instead of the deprecated single-shot research tool.
+          claude --mcp-config $HOME/.claude/mcp.json --dangerously-skip-permissions -p "List the autosearch MCP skills, then call run_channel on the arxiv channel with query 'BM25 ranking' and summarize the top results." 2>&1 | tail -200
         expect:
           exit: 0
           stdout_contains: "BM25"

--- a/tests/unit/test_e2b_matrix_contract.py
+++ b/tests/unit/test_e2b_matrix_contract.py
@@ -1,8 +1,16 @@
-"""Pin the v2 contract on the E2B matrices.
+"""Pin the v2 contract on every E2B matrix.
 
 Without this guard, a future PR can re-add `call_tool("research", ...)` or
 `stdout_contains: "References"` and silently re-resurrect the v1 expectations
 that the audit explicitly flagged as a release blocker.
+
+Scope evolution (plan §Gate F):
+- previously only matrix.yaml + matrix-release-gate.yaml were scanned;
+- now every tests/e2b/*.yaml is scanned;
+- the `autosearch query` CLI is allowed because plan §P1-2 explicitly permits
+  old query calls when they assert deprecation behavior (matrix.yaml does this
+  by pinning `stdout_contains: "deprecated"`); enforcing that pairing as
+  static yaml-parse logic would be over-engineering for the value it adds.
 
 If a real v1-style assertion is ever needed again, document it in the matrix
 file and update this test to allowlist the file/line.
@@ -17,13 +25,11 @@ import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
-MATRICES = [
-    ROOT / "tests" / "e2b" / "matrix.yaml",
-    ROOT / "tests" / "e2b" / "matrix-release-gate.yaml",
-]
+MATRIX_DIR = ROOT / "tests" / "e2b"
+ALL_MATRICES = sorted(MATRIX_DIR.glob("*.yaml"))
 
 
-@pytest.mark.parametrize("matrix_path", MATRICES, ids=lambda p: p.name)
+@pytest.mark.parametrize("matrix_path", ALL_MATRICES, ids=lambda p: p.name)
 def test_matrix_does_not_assert_v1_report_output(matrix_path: Path) -> None:
     """The deprecated `query` path used to produce a "References" / "Sources"
     section. v2 install gates must NOT assert against those strings."""
@@ -42,16 +48,24 @@ def test_matrix_does_not_assert_v1_report_output(matrix_path: Path) -> None:
         )
 
 
-@pytest.mark.parametrize("matrix_path", MATRICES, ids=lambda p: p.name)
+@pytest.mark.parametrize("matrix_path", ALL_MATRICES, ids=lambda p: p.name)
 def test_matrix_does_not_call_deprecated_research_tool(matrix_path: Path) -> None:
+    """The MCP `research` tool is being phased out (plan §P1-4). E2B prompts
+    must not steer the host agent toward it — they should drive list_skills +
+    run_clarify + run_channel directly."""
     text = matrix_path.read_text(encoding="utf-8")
     assert 'call_tool("research"' not in text, (
         f"{matrix_path.name} still invokes the deprecated `research` MCP tool; "
         "use list_skills/run_clarify/run_channel instead."
     )
+    assert "Use the research tool" not in text, (
+        f"{matrix_path.name} still tells the host agent to use the deprecated "
+        "`research` tool in its prompt; rewrite the prompt to drive the v2 "
+        "tool-supplier flow (list_skills / run_clarify / run_channel)."
+    )
 
 
-@pytest.mark.parametrize("matrix_path", MATRICES, ids=lambda p: p.name)
+@pytest.mark.parametrize("matrix_path", ALL_MATRICES, ids=lambda p: p.name)
 def test_matrix_yaml_parses(matrix_path: Path) -> None:
     """Catch YAML syntax breakage from sweeping edits."""
     data = yaml.safe_load(matrix_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Expands `tests/unit/test_e2b_matrix_contract.py` from scanning 2 matrices (matrix.yaml, matrix-release-gate.yaml) to scanning all `tests/e2b/*.yaml` (now also: matrix-extensions.yaml, matrix-w1w4-bench.yaml). Also adds a check that prompts must not include "Use the research tool" (deprecated).
- Cleans v1 residue in `tests/e2b/matrix-extensions.yaml`:
  - F103 slash command test: `stdout_contains: "References"` → `stdout_regex: "BM25|bm25"` (v1 report-format artifact replaced with topic-surface check)
  - F104 MCP-as-tool test: prompt rewritten from "Use the research tool…" to "List skills, then call run_channel on arxiv…" (drives v2 tool-supplier flow)

## Why now

Per `docs/million-user-product-readiness-plan.md` §P1-2 / §Gate F, the matrix contract test was a partial gate — extension and bench yaml could silently re-introduce v1 expectations. Now any future PR that puts `"References"` or "Use the research tool" anywhere under `tests/e2b/` produces a contract-named failure.

## Scope honesty

- `autosearch query` CLI usage **kept** in matrix.yaml (5 sites) and matrix-w1w4-bench.yaml (5 sites): plan §P1-2 explicitly allows query calls when they assert deprecation behavior. matrix.yaml's calls all pin `stdout_contains: "deprecated"`; bench's calls function as deprecated-CLI safety regression tests. Enforcing the `query` + `deprecated` pairing as static yaml-parse logic was over-engineering for the value it adds — left as plan §P1-2 manual audit territory.

## Test plan

- [x] `pytest tests/unit/test_e2b_matrix_contract.py -v` → 12/12 PASS (4 yaml × 3 contract checks)
- [x] `pytest tests/unit/ -x -q -m "not real_llm and not slow and not network"` → 540 PASS (no regression)
- [x] `rg -n 'stdout_contains: "References"|Use the research tool|call_tool\("research"' tests/e2b` → 0 matches
- [ ] Post-merge: PR 1 release-gate.sh banner can drop "Gate F partial" qualifier (follow-up commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)