### PR TITLE
chore: bump version to 2026.04.24.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.24.2"
+  "version": "2026.04.24.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.24.2",
+  "version": "2026.04.24.3",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.04.24.3 — 2026-04-24
+
+The "tighten the install path and the release gate" release. Closes the
+remaining million-user-readiness items where the v2 contract was correct in
+code but not enforced at the install / release boundary.
+
+- **`npm install -g autosearch-ai` no longer silently downloads and runs a remote install script.** The `postinstall` hook is removed. `npx autosearch-ai` (the recommended one-line install) still works, but now prints the URL it's about to fetch and waits for `y` to confirm — pass `--yes` (or `-y`) for non-interactive automation. In a non-TTY environment without `--yes`, it refuses rather than installing silently.
+- **Release gate now runs named contract checks even in `--quick` mode.** `scripts/release-gate.sh` adds an explicit "contract gates" step that lists each plan §Gate A-G (plus the P0-5/6 invariants) by name. A regression in secrets visibility, MCP redaction, channel availability, runtime health persistence, rate-limit enforcement, or wheel content now produces a contract-named failure banner instead of blending into the 800-test default suite. Gate E (docs contract) deferred pending the narrative refresh.
+- **E2B matrix contract test scans every `tests/e2b/*.yaml`**, not just the main matrix. Cleaned residual v1 expectations in `matrix-extensions.yaml`: `stdout_contains: "References"` → topic-surface check, "Use the research tool" prompt → list_skills + run_channel flow.
+- **New `tests/unit/test_package_contents.py` gate** — fails the release if runtime dependencies pull in `pytest` / `ruff` / etc., if the setuptools package-data glob would ship `*.jsonl`, if the cross-file version pins drift, or if a built wheel ships runtime `patterns.jsonl`.
+
 ## 2026.04.24.2 — 2026-04-24
 
 The "runtime actually does what doctor says" release. Fixes audit findings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.24.2"
+version = "2026.04.24.3"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bumps to **2026.04.24.3** packaging the three release-readiness PRs merged today:

- #330 — release-gate.sh wires plan §Gate A-G + P0-5/6 as a named "contract gates" step (Gate G = new `test_package_contents.py`)
- #331 — npm `postinstall` removed; `npx autosearch-ai` requires explicit consent before remote install
- #332 — e2b matrix contract scans every yaml; cleaned v1 residue in `matrix-extensions.yaml`

After merge, push tag `v2026.04.24.3` to trigger PyPI + npm + GitHub Release via `release.yml`.

## Plan acceptance bar (after this release)

7 of 9 plan §Final Acceptance Bar red lines now satisfied. Only outstanding item: red line 7 (docs no longer describe deprecated `query`/`research` as the happy path) — held per "叙事不改" directive, to be revisited when the narrative refresh is unblocked.

## Test plan

- [x] `./scripts/release-gate.sh --quick` → 38 contract tests + lint + version + CLI all PASS
- [x] CHANGELOG entry filled in (no empty version section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)