### PR TITLE
docs: fix v1 contract bugs (narrative kept per owner directive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ Run `autosearch doctor` to check the status of every channel:
 ```
 AutoSearch Channel Status
 ==========================================
-Always-on (21/21)   ✅ arxiv  ✅ github  ✅ hackernews ...
-Env-gated  (0/1)    ○  youtube  →  set YOUTUBE_API_KEY
-Login      (0/15)   ○  xiaohongshu  →  autosearch login xhs
+Always-on (27/27)   ✅ arxiv  ✅ github  ✅ hackernews ...
+API-key   (0/11)    ○  youtube  →  set YOUTUBE_API_KEY
+                    ○  bilibili →  set TIKHUB_API_KEY
+Login     (0/2)     ○  xiaohongshu  →  autosearch login xhs
+                    ○  xueqiu       →  autosearch login xueqiu
 ```
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -88,11 +88,13 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 运行 `autosearch doctor` 查看每个渠道的状态：
 
 ```
-AutoSearch Channel Status
+AutoSearch 渠道状态
 ==========================================
-Always-on (21/21)   ✅ arxiv  ✅ github  ✅ hackernews ...
-Env-gated  (0/1)    ○  youtube  →  set YOUTUBE_API_KEY
-Login      (0/15)   ○  xiaohongshu  →  autosearch login xhs
+开箱即用 (27/27)    ✅ arxiv  ✅ github  ✅ hackernews ...
+API key   (0/11)   ○  youtube      →  set YOUTUBE_API_KEY
+                   ○  bilibili     →  set TIKHUB_API_KEY
+需登录    (0/2)    ○  xiaohongshu  →  autosearch login xhs
+                   ○  xueqiu       →  autosearch login xueqiu
 ```
 
 ---

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosear
 
 ### Goal
 
-Install AutoSearch and configure the MCP server so the user's agent has access to 39 search channels across academic papers, developer platforms, Chinese social media, and more.
+Install AutoSearch and configure the MCP server so the user's agent has access to 40 search channels across academic papers, developer platforms, Chinese social media, and more.
 
 ### ⚠️ Boundaries
 
@@ -40,7 +40,7 @@ pip install autosearch && autosearch init
 pipx install autosearch && autosearch init
 ```
 
-> npx and curl options run `autosearch init` automatically.
+> The curl option runs `autosearch init` automatically. The npx option prints the install URL it's about to fetch and waits for `y` to confirm — pass `--yes` (or `-y`) to skip the prompt for non-interactive automation.
 
 This will:
 - Detect available LLM providers (Anthropic, OpenAI, Gemini, claude CLI)
@@ -58,21 +58,22 @@ You'll see a tiered report:
 ```
 AutoSearch Channel Status
 ==========================================
-Always-on (21/21)
-  ✅ arxiv              ready
-  ✅ pubmed             ready
-  ✅ ddgs               ready
-  ... 18 more
+Always-on (27/27)
+  ✅ arxiv              1/1 methods available
+  ✅ pubmed             1/1 methods available
+  ✅ ddgs               1/1 methods available
+  ... 24 more
 
-Env-gated (0/1)
-  ○  youtube            set YOUTUBE_API_KEY to enable
+API-key (0/11)
+  ○  youtube            autosearch configure YOUTUBE_API_KEY <your-key>
+  ○  bilibili           autosearch configure TIKHUB_API_KEY <your-key>
+  ... 9 more
 
-Login required (0/15)
-  ○  xiaohongshu        run: autosearch login xhs
-  ○  twitter            run: autosearch login twitter
-  ... 13 more
+Login required (0/2)
+  ○  xiaohongshu        autosearch login xhs
+  ○  xueqiu             autosearch login xueqiu
 
-Status: 21/37 channels ready
+Status: 27/40 channels ready
 ```
 
 ---

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -5,7 +5,7 @@ description: "Install AutoSearch as an MCP server in Claude Code, Cursor, and ot
 
 # AutoSearch as an MCP Server
 
-AutoSearch ships a standard [Model Context Protocol](https://modelcontextprotocol.io) stdio server that exposes two tools — `research` (the main deep-research entry point) and `health` (a liveness probe) — to any MCP client. Because the protocol is client-agnostic, the same server binary plugs into Claude Code, Cursor, Zed, Continue, and any other MCP-speaking surface without recompilation.
+AutoSearch ships a standard [Model Context Protocol](https://modelcontextprotocol.io) stdio server that exposes the v2 tool-supplier toolkit — `list_skills`, `list_channels`, `run_clarify`, `select_channels_tool`, `run_channel`, plus `citation_create` / `citation_add` / `citation_export`, `doctor`, and `health` — to any MCP client. The host agent calls these tools and synthesizes the final answer itself; AutoSearch does not return a pre-baked report. Because the protocol is client-agnostic, the same server binary plugs into Claude Code, Cursor, Zed, Continue, and any other MCP-speaking surface without recompilation.
 
 This page shows the config format for each supported client plus a one-minute verification routine.
 
@@ -42,7 +42,7 @@ Claude Code reads `~/.claude/mcp.json` globally and `<project>/.mcp.json` per-pr
 You can also point the CLI at a specific config for one invocation:
 
 ```bash
-claude --mcp-config /path/to/mcp.json -p "Use the research tool to summarize RAG evaluation methods"
+claude --mcp-config /path/to/mcp.json -p "List autosearch skills, then call run_channel on arxiv to find RAG evaluation papers and summarize the top results"
 ```
 
 AutoSearch additionally ships a Claude Code slash command at `commands/autosearch.md`; drop it into `~/.claude/commands/` to get `/autosearch <topic>`.
@@ -64,7 +64,7 @@ Cursor reads `~/.cursor/mcp.json`. Same schema:
 }
 ```
 
-After saving the file, restart Cursor. Open the MCP panel — `autosearch` should appear with the `research` tool listed. Prompting the agent with something like "use the research tool to survey vector database options" will invoke it.
+After saving the file, restart Cursor. Open the MCP panel — `autosearch` should appear with the v2 tools listed (`list_skills`, `list_channels`, `run_channel`, the citation helpers, etc.). Prompting the agent with something like "list autosearch skills, then run_channel on arxiv to survey vector database options" drives the v2 flow.
 
 ### Using OpenAI or Gemini instead of Anthropic
 
@@ -126,59 +126,76 @@ Continue uses `~/.continue/config.json`:
 }
 ```
 
-## The `research` tool
+## The v2 MCP tools
 
-Input schema:
+The host agent drives a tool-supplier flow: discover skills, optionally clarify the user's intent, pick channels, run them, and synthesize the answer. The 10 required v2 tools:
+
+| Tool | Purpose |
+|---|---|
+| `list_skills` | Catalog of channel skills the agent can pick from. |
+| `list_channels` | Per-channel availability (status, methods, language, requires). |
+| `run_clarify` | Optional one-shot clarification turn before search starts. |
+| `select_channels_tool` | Helper that ranks candidate channels for a query. |
+| `run_channel` | Run one channel for one query; returns `status` (`ok` / `no_results` / `not_configured` / `unknown_channel` / `channel_error` / `rate_limited`), `evidence`, `unmet_requires`, `fix_hint`. The core retrieval call. |
+| `citation_create` | Open a citation collection for the current task. |
+| `citation_add` | Append a source URL + supporting evidence. |
+| `citation_export` | Export citations as `[N]`-numbered Markdown references. |
+| `doctor` | Channel-status snapshot (same data as the CLI, JSON-shaped). |
+| `health` | Structured liveness snapshot — version, tool counts, channel counts by status, secrets-file presence (key NAMES only, never values), runtime cooldown snapshot. |
+
+Beyond these, the server registers helpers like `consolidate_research`, `delegate_subtask`, `list_modes`, `select_channels_tool`, citation hardening (`citation_merge`), context controls (`context_retention_policy`), and several loop / planning helpers. The deprecated `research` tool is still registered for v1 callers but returns a deprecation response — new integrations should not depend on it.
+
+`run_channel` schema:
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `query` | string | required | Your research question. Natural language, English or Chinese. |
-| `mode` | `"fast"` \| `"deep"` | `"fast"` | `fast` = 1 iteration, ~20–40s. `deep` = multi-iteration reflect-on-gaps loop, ~1–3 min and higher cost. |
-| `languages` | `"all"` \| `"en_only"` \| `"zh_only"` \| `"mixed"` | `"all"` | Constrain channel selection by language scope. |
-| `depth` | `"fast"` \| `"deep"` \| `"comprehensive"` | inherits `mode` | Finer-grained depth override; `comprehensive` extends `deep` with extra iteration budget. |
-| `output_format` | `"md"` \| `"html"` | `"md"` | Markdown is the canonical report format; HTML wraps the markdown for client rendering. |
-
-Output: a `ResearchResponse`-shaped result — most clients present it as a single text content block. On a successful research run the text is a Markdown report that typically ends with a `## References` section and `[N]`-style citations; on failure modes (rate limit, soft refusal, clarification needed) the content may instead be a short banner describing what happened. Don't assume `## References` always appears.
+| `channel_name` | string | required | One of the channels reported by `list_channels`. |
+| `query` | string | required | Search query. Natural language, English or Chinese. |
+| `k` | int | 10 | Max evidence items to return. |
+| `method_id` | string | (auto) | Pin a specific method when a channel offers more than one. |
 
 ## Verifying the integration
 
-Any MCP client supports a `tools/list` handshake before `tools/call`. If your client shows a GUI, the `research` tool appearing in the panel is proof enough. If you want a scripted check without a GUI client, run the following against any locally installed `autosearch-mcp`:
+Any MCP client supports a `tools/list` handshake before `tools/call`. If your client shows a GUI, seeing the v2 tool names (`list_skills`, `list_channels`, `run_channel`, …) in the panel is proof enough. For a scripted check without a GUI client, run this against any locally installed `autosearch-mcp`:
 
-Run this with the same Python interpreter that has AutoSearch installed (for a `pipx install autosearch` setup, that's `pipx run --spec autosearch python` or inside the pipx venv — the snippet imports `mcp` which lives alongside `autosearch-mcp`, not in your system Python).
+Run it with the same Python interpreter that has AutoSearch installed (for a `pipx install autosearch` setup, that's `pipx run --spec autosearch python` or inside the pipx venv — the snippet imports `mcp` which lives alongside `autosearch-mcp`, not in your system Python).
 
 ```python
 import asyncio, os
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-# Forward whichever provider key is set. The MCP server picks the first one it finds.
-PROVIDER_ENV = {
-    k: os.environ[k]
-    for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY")
-    if os.environ.get(k)
+REQUIRED_V2_TOOLS = {
+    "list_skills", "list_channels", "run_clarify", "select_channels_tool",
+    "run_channel", "citation_create", "citation_add", "citation_export",
+    "doctor", "health",
 }
-assert PROVIDER_ENV, "set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY"
 
 async def main():
     params = StdioServerParameters(
         command="autosearch-mcp",
-        env={**PROVIDER_ENV, "PATH": os.environ["PATH"]},
+        env={"PATH": os.environ["PATH"]},
     )
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             tools = await session.list_tools()
             tool_names = {t.name for t in tools.tools}
-            assert "research" in tool_names, f"research tool missing: {tool_names}"
-            result = await session.call_tool("research", {"query": "Explain BM25 ranking", "mode": "fast"})
-            report = "".join(c.text for c in result.content if hasattr(c, "text"))
-            assert report.strip(), "research returned empty content"
-            print("OK — autosearch-mcp responded with content length", len(report))
+            missing = REQUIRED_V2_TOOLS - tool_names
+            assert not missing, f"required v2 tools missing: {missing}"
+
+            # Smoke a free channel — no LLM key required.
+            result = await session.call_tool(
+                "run_channel",
+                {"channel_name": "arxiv", "query": "BM25 ranking", "k": 3},
+            )
+            payload = result.content[0].text if result.content else ""
+            print("OK — run_channel(arxiv) returned", len(payload), "chars")
 
 asyncio.run(main())
 ```
 
-This is exactly the smoke that lands under `tests/e2b/matrix.yaml::F004_S4_mcp_stdio` in CI, so if local Python says "OK" your client config is guaranteed to work at the protocol layer — the only variable left is the client's own config file path and schema (covered in the sections above).
+The same handshake lands under `tests/e2b/matrix.yaml::F004_S4_mcp_stdio` in CI, so if local Python says "OK" your client config is guaranteed to work at the protocol layer — the only variable left is the client's own config file path and schema (covered in the sections above).
 
 ## Troubleshooting
 
@@ -186,8 +203,9 @@ This is exactly the smoke that lands under `tests/e2b/matrix.yaml::F004_S4_mcp_s
 |---|---|---|
 | Client cannot find `autosearch-mcp` | Binary not on PATH for the client's shell | `pipx ensurepath && exec $SHELL`, or use an absolute path in `command` |
 | `tools/list` returns empty | Server started but crashed before registering tools | Check LLM provider env var is set in the `env` block, not just your outer shell |
-| `research` call returns empty Markdown | Provider rate-limited or invalid key | Verify the key independently: `anthropic` CLI / `openai api models list` / equivalent |
-| Report has no `## References` | LLM returned a soft refusal | Retry with a more specific query; confirm the provider chain has an active key |
+| `run_channel` returns `status="not_configured"` | The channel needs a key or login that isn't set yet | Follow the `fix_hint` in the response (e.g. `autosearch configure YOUTUBE_API_KEY <key>` or `autosearch login xhs`) |
+| `run_channel` returns `status="rate_limited"` | The declared per-minute / per-hour limit was exceeded for that channel + method | Wait `retry_after` seconds (in the response) or lower the agent's parallel-channel fan-out |
+| `run_channel` returns `status="channel_error"` with a redacted `reason` | Upstream channel hiccup; secret-shaped strings are scrubbed before reaching the response | Retry; if persistent, check `autosearch doctor --json` and the upstream provider's status page |
 
 ## Where to go next
 


### PR DESCRIPTION
## Summary

Per owner directive: **fix doc bugs, don't touch narrative.** This PR updates only the factual / contract claims that were wrong; tagline, "fixes this in one line", and other product-positioning copy are left alone.

### Bugs fixed

| File | Old | New | Why |
|---|---|---|---|
| `README.md` doctor block | `Always-on (21/21)` / `Env-gated (0/1)` / `Login (0/15)` | `Always-on (27/27)` / `API-key (0/11)` / `Login (0/2)` | Real channel tiers grew; the example was a lie |
| `README.zh.md` doctor block | same | same (Chinese tier names) | Same bug, Chinese version |
| `docs/install.md` channel count | `39 search channels` | `40 search channels` | discourse_forum was added |
| `docs/install.md` npx note | "npx and curl options run init automatically" | "curl runs init automatically; npx prompts before running install — `--yes` to skip" | PR #331 added the consent prompt; old description was now untrue |
| `docs/install.md` doctor sample | 21/21 / 0/1 / 0/15 — `Status: 21/37 channels ready` | 27/27 / 0/11 / 0/2 — `Status: 27/40 channels ready` | Same tier-count bug |
| `docs/mcp-clients.md` whole "research tool" section | "exposes two tools — `research` and `health`" + Input schema for `research` + verification script that calls `research` | v2 tool-supplier toolkit description (10 required tools listed + run_channel schema) + verification script that asserts the v2 tool set + smokes `run_channel` against the free `arxiv` channel | The deprecated `research` tool was the documented happy path; following the doc literally was the only way to *not* use AutoSearch v2 correctly |
| `docs/mcp-clients.md` Troubleshooting table | rows about `research` returning empty / "## References" missing | rows about `not_configured` / `rate_limited` / `channel_error` (real v2 statuses) | Old rows referenced a tool the doc no longer recommends |

### What I did NOT change (narrative held)

- README L6 tagline ("Open-source deep research alternative to OpenAI and Perplexity Deep Research")
- README L34 "AutoSearch fixes this in one line"
- README.zh equivalents
- `docs/install.md` "For Humans / For AI Agents" framing
- Any product-positioning copy

If the narrative refresh ever unblocks, those are the lines to revisit.

## Test plan

- [x] `grep -nE '21/21|21/15|21/37|0/15|39 channels|"research"|Use the research tool|main deep-research|## References'` over README/install/mcp-clients → 0 matches (was several)
- [x] `./scripts/release-gate.sh --quick` → 38 contract gates + lint + version + CLI all PASS
- [x] verification script in mcp-clients.md mentally walked: `REQUIRED_V2_TOOLS = {list_skills, list_channels, run_clarify, select_channels_tool, run_channel, citation_create, citation_add, citation_export, doctor, health}` matches the actual `mcp-check` output today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated channel availability examples and categorization in README files.
  * Clarified installation guide documenting curl and npx installation methods.
  * Updated MCP client integration documentation for version 2 changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->