### PR TITLE
chore: bump version to 2026.04.24.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.24.3"
+  "version": "2026.04.24.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.24.3",
+  "version": "2026.04.24.4",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.04.24.4 — 2026-04-24
+
+The "smaller wheel, honest docs" release.
+
+- **Wheel surface shrinks ~600 lines.** The legacy v1 modules `autosearch/synthesis/` (citation + outline + report-rendering helpers) and the empty `autosearch/server/` shell are gone from the runtime package. Two new gates in `tests/unit/test_package_contents.py` (`test_legacy_v1_modules_not_in_source_tree`, `test_built_wheel_does_not_ship_legacy_v1_modules`) prevent them from sneaking back in. No production caller depended on them; v2 host agents synthesize their own answers.
+- **Docs no longer lie about the contract** while leaving the product narrative untouched per owner directive:
+  - `README.md` / `README.zh.md` doctor sample updated from the stale `Always-on (21/21) / Env-gated (0/1) / Login (0/15)` to the real tiers (`27/27 / API-key 0/11 / Login 0/2`).
+  - `docs/install.md` channel count `39 → 40`; the npx note now says it prompts before running install (matching the consent step added in `2026.04.24.3`).
+  - `docs/mcp-clients.md` rewritten around the v2 tool-supplier toolkit (10 required tools listed, `run_channel` schema documented, verification script switched from `call_tool("research", …)` to a `tools/list` check + free-channel smoke). The deprecated `research` tool is no longer the documented happy path.
+
 ## 2026.04.24.3 — 2026-04-24
 
 The "tighten the install path and the release gate" release. Closes the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.24.3"
+version = "2026.04.24.4"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bumps to **2026.04.24.4** packaging the two follow-up PRs since v3:

- #334 — drop legacy v1 modules (`autosearch/synthesis/` + `autosearch/server/`) from runtime + new wheel/source-tree guards in `test_package_contents.py`
- #335 — fix doc bugs without touching narrative (channel counts 39→40, doctor tier samples 21/21→27/27, `mcp-clients.md` rewritten around v2 tool-supplier toolkit)

After merge, push tag `v2026.04.24.4` to trigger PyPI + npm + GitHub Release via `release.yml`.

## Test plan

- [x] `./scripts/release-gate.sh --quick` → 38 contract gates + lint + version + CLI all PASS
- [x] CHANGELOG entry filled in (no empty version section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)