### PR TITLE
ci(cross-platform): Windows experience step uses v2 AUTOSEARCH_EXPERIENCE_DIR (plan §P1-10)

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -67,34 +67,37 @@ jobs:
         env:
           AUTOSEARCH_LLM_MODE: dummy
 
-      - name: Experience layer write/read
+      - name: Experience runtime layer (writes under AUTOSEARCH_EXPERIENCE_DIR, not package tree)
         run: |
           python -c "
-          import os, tempfile, json
+          import os, json, tempfile
           from pathlib import Path
           from datetime import datetime, UTC
 
+          # Set the runtime experience dir BEFORE importing the experience
+          # module so any module-level path resolution sees it (plan §P1-10).
+          # The previous version mutated _SKILLS_ROOT directly — that targeted
+          # the v1 bundled-seed path, not the v2 runtime path users actually
+          # write to.
+          tmp = tempfile.mkdtemp()
+          os.environ['AUTOSEARCH_EXPERIENCE_DIR'] = tmp
           os.environ['AUTOSEARCH_LLM_MODE'] = 'dummy'
-          import autosearch.skills.experience as exp_mod
+
           from autosearch.skills.experience import append_event
 
-          with tempfile.TemporaryDirectory() as tmp:
-              exp_mod._SKILLS_ROOT = Path(tmp)
-              (Path(tmp) / 'channels' / 'arxiv').mkdir(parents=True)
+          append_event('arxiv', {
+              'skill': 'arxiv',
+              'query': 'windows path test',
+              'outcome': 'success',
+              'count_returned': 5,
+              'ts': datetime.now(UTC).isoformat(),
+          })
 
-              append_event('arxiv', {
-                  'skill': 'arxiv',
-                  'query': 'windows path test',
-                  'outcome': 'success',
-                  'count_returned': 5,
-                  'ts': datetime.now(UTC).isoformat(),
-              })
-
-              pf = Path(tmp) / 'channels' / 'arxiv' / 'experience' / 'patterns.jsonl'
-              assert pf.exists(), 'patterns.jsonl not created'
-              line = json.loads(pf.read_text().strip())
-              assert line['query'] == 'windows path test'
-              print('Experience layer works on Windows:', pf)
+          runtime_path = Path(tmp) / 'channels' / 'arxiv' / 'experience' / 'patterns.jsonl'
+          assert runtime_path.exists(), f'patterns.jsonl missing at runtime path: {runtime_path}'
+          line = json.loads(runtime_path.read_text().strip())
+          assert line['query'] == 'windows path test'
+          print('Experience runtime layer works on Windows:', runtime_path)
           "
 
       - name: Windows path separator handling


### PR DESCRIPTION
## Summary

The Windows job's "Experience layer write/read" step was still pinned to the v1 contract: it mutated `exp_mod._SKILLS_ROOT = Path(tmp)` and asserted writes under that bundled-seed path. v2 runtime experience writes go to `AUTOSEARCH_EXPERIENCE_DIR` (or `~/.autosearch/experience` by default) — the package tree is read-only seeds. This PR rewrites the step to drive the v2 path.

What changed in `cross-platform.yml`:
- step renamed: "Experience layer write/read" → "Experience runtime layer (writes under AUTOSEARCH_EXPERIENCE_DIR, not package tree)"
- `tempfile.mkdtemp()` + `os.environ['AUTOSEARCH_EXPERIENCE_DIR'] = tmp` is set BEFORE the experience module is imported
- assertion now targets `<tmp>/channels/arxiv/experience/patterns.jsonl` (the real runtime path)
- removed the `_SKILLS_ROOT` private-attribute mutation and the manual `mkdir(channels/arxiv)` that v2 doesn't need

## Why now

Plan §P1-10. The old step would silently pass even if the v2 runtime path were broken — it was testing v1's bundled-seed write behavior, not what real users hit on Windows. After this fix the same step exercises the same code path that `tests/unit/test_experience_runtime_isolation.py` covers, but on a real Windows runner.

## Test plan

- [x] Local mac: ran the inline python verbatim against `.venv` → `patterns.jsonl` lands at the runtime path, content matches
- [x] `pytest tests/unit/test_experience_runtime_isolation.py` → still passes (this PR doesn't touch the unit test, but verifying nothing under it changed)
- [x] `./scripts/release-gate.sh --quick` → all gates PASS
- [ ] Windows runner: validated by next push to main triggering the workflow (or a manual `workflow_dispatch`); will check after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)