### PR TITLE
fix(mcp): research tool hidden by default; AUTOSEARCH_LEGACY_RESEARCH=1 to opt in (plan §P1-4)

### DIFF
--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -346,7 +346,18 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
         ),
     )
 
-    @server.tool()
+    # Plan §P1-4: the deprecated `research` tool is registered only when the
+    # user explicitly opts in via AUTOSEARCH_LEGACY_RESEARCH=1. By default the
+    # MCP tool list does NOT advertise it — so a host agent cannot mis-pick
+    # the v1 entry point over the v2 trio (list_skills + run_clarify + run_channel).
+    import os as _os_research_gate
+
+    _legacy_research_enabled = (
+        _os_research_gate.environ.get("AUTOSEARCH_LEGACY_RESEARCH", "").strip() == "1"
+    )
+    _maybe_register = server.tool() if _legacy_research_enabled else (lambda f: f)
+
+    @_maybe_register
     async def research(
         query: str,
         mode: Literal["fast", "deep"] = "fast",

--- a/tests/unit/test_list_skills.py
+++ b/tests/unit/test_list_skills.py
@@ -194,14 +194,31 @@ def test_scan_returns_empty_for_missing_root(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_skills_mcp_tool_is_registered() -> None:
-    """End-to-end: create MCP server, confirm list_skills tool is registered."""
+async def test_list_skills_mcp_tool_is_registered(monkeypatch) -> None:
+    """End-to-end: create MCP server, confirm list_skills + health are present
+    by default. The deprecated `research` tool is opt-in (plan §P1-4) — see
+    `test_legacy_research_tool_only_registered_when_opted_in` below."""
+    monkeypatch.delenv("AUTOSEARCH_LEGACY_RESEARCH", raising=False)
     server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
     tools = await server.list_tools()
     tool_names = {tool.name for tool in tools}
     assert "list_skills" in tool_names
-    assert "research" in tool_names
     assert "health" in tool_names
+    assert "research" not in tool_names, (
+        "deprecated `research` tool must NOT register by default (plan §P1-4); "
+        "set AUTOSEARCH_LEGACY_RESEARCH=1 to opt in"
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_research_tool_only_registered_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setenv("AUTOSEARCH_LEGACY_RESEARCH", "1")
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tools = await server.list_tools()
+    tool_names = {tool.name for tool in tools}
+    assert "research" in tool_names, (
+        "AUTOSEARCH_LEGACY_RESEARCH=1 must restore the legacy research tool"
+    )
 
 
 def test_skill_summary_pydantic_roundtrip() -> None:

--- a/tests/unit/test_research_deprecation.py
+++ b/tests/unit/test_research_deprecation.py
@@ -18,8 +18,10 @@ class _StubPipeline:
 
 
 @pytest.mark.asyncio
-async def test_research_emits_deprecation_warning() -> None:
-    """Calling the legacy research() MCP tool must emit a DeprecationWarning."""
+async def test_research_emits_deprecation_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When opted in via AUTOSEARCH_LEGACY_RESEARCH=1, calling research() must
+    still emit a DeprecationWarning so users know they're on a sunset path."""
+    monkeypatch.setenv("AUTOSEARCH_LEGACY_RESEARCH", "1")
     server = create_server(pipeline_factory=lambda: _StubPipeline())  # type: ignore[arg-type]
     tm = server._tool_manager  # noqa: SLF001
 
@@ -54,42 +56,23 @@ async def test_server_instructions_mention_tool_supplier_trio() -> None:
 
 
 @pytest.mark.asyncio
-async def test_research_default_returns_deprecation_without_pipeline(
+async def test_research_tool_not_registered_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """W3.3 PR A: default (no AUTOSEARCH_LEGACY_RESEARCH env) must NOT invoke the pipeline.
+    """Plan §P1-4: by default the deprecated research tool is not registered
+    at all — host agents only see it if AUTOSEARCH_LEGACY_RESEARCH=1 opts in.
 
-    The research() tool should return a ResearchResponse with:
-    - delivery_status == "deprecated"
-    - content mentions the trio
-    - routing_trace indicates deprecation
-
-    The Pipeline factory is set to a stub that would raise if called. If research()
-    is properly short-circuited, the test passes without triggering the stub.
+    Previous behavior was "registered but returns deprecation response"; that
+    still let LLMs choose the attractive `research` tool name and waste a turn.
     """
     monkeypatch.delenv("AUTOSEARCH_LEGACY_RESEARCH", raising=False)
 
-    from autosearch.mcp.server import ResearchResponse
-
     server = create_server(pipeline_factory=lambda: _StubPipeline())  # type: ignore[arg-type]
-    tm = server._tool_manager  # noqa: SLF001
-
-    import warnings as _warnings
-
-    with _warnings.catch_warnings():
-        _warnings.simplefilter("ignore", DeprecationWarning)
-        response = await tm.call_tool(
-            "research",
-            {"query": "anything", "mode": "fast"},
-        )
-
-    assert isinstance(response, ResearchResponse)
-    assert response.delivery_status == "deprecated"
-    assert "deprecated" in response.content.lower()
-    assert "list_skills" in response.content
-    assert "run_clarify" in response.content
-    assert "run_channel" in response.content
-    assert response.routing_trace.get("deprecated") is True
+    tools = await server.list_tools()
+    tool_names = {tool.name for tool in tools}
+    assert "research" not in tool_names, (
+        f"research must not register without opt-in (got: {sorted(tool_names)})"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The deprecated `research` MCP tool used to register on every server start and only return a deprecation response when called — but the attractive name still tempted host LLMs to pick it over the v2 trio. Now it's gated at registration time:

- **Default**: tool list does NOT include `research`. The MCP host literally cannot pick it; it will route through `list_skills` + `run_clarify` + `run_channel` instead.
- **Opt-in**: set `AUTOSEARCH_LEGACY_RESEARCH=1` and the tool reappears, behavior unchanged (deprecation warning + legacy pipeline path).

## Implementation

In `autosearch/mcp/server.py`, the `@server.tool()` decorator on `research()` is replaced with a conditional:

```python
_legacy_research_enabled = os.environ.get("AUTOSEARCH_LEGACY_RESEARCH", "").strip() == "1"
_maybe_register = server.tool() if _legacy_research_enabled else (lambda f: f)

@_maybe_register
async def research(...):
    ...
```

Identity decorator when not opted in — function still defined, just not registered with the tool manager. No body indentation, no need to refactor the 100-line function.

## Test contract changes

- `test_list_skills.py::test_list_skills_mcp_tool_is_registered` — now asserts `research not in tool_names` by default
- `test_list_skills.py::test_legacy_research_tool_only_registered_when_opted_in` — new, covers opt-in
- `test_research_deprecation.py::test_research_emits_deprecation_warning` — adds `monkeypatch.setenv("AUTOSEARCH_LEGACY_RESEARCH", "1")` so the tool exists when called
- `test_research_deprecation.py::test_research_tool_not_registered_by_default` — replaces the previous "default returns deprecation response" test (the response no longer fires because the tool isn't registered)
- `test_research_legacy_env_opt_in_restores_pipeline_path` — unchanged, already used the env var

Released as `2026.04.24.4` shipped 24 MCP tools today; with this PR default goes to 23. Required v2 tool count unchanged at 10.

## Test plan

- [x] `autosearch mcp-check` → 23 tools, research absent
- [x] `AUTOSEARCH_LEGACY_RESEARCH=1 autosearch mcp-check` → 24 tools, research present
- [x] `pytest tests/unit/test_list_skills.py tests/unit/test_research_deprecation.py -v` → 17/17 PASS
- [x] `./scripts/release-gate.sh` (full) → 38 contract gates + 832 default suite + CLI all PASS

## Follow-up

`docs/mcp-clients.md` already lists the v2 tools as the documented happy path (PR #335) and does not mention `research`, so no doc change required for default users. Anyone who needs the legacy tool should set `AUTOSEARCH_LEGACY_RESEARCH=1` — worth adding to a future migration guide section if asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)