### PR TITLE
test(package): pin experience-seed path consistency (plan §P2-2)

### DIFF
--- a/tests/unit/test_package_contents.py
+++ b/tests/unit/test_package_contents.py
@@ -135,3 +135,39 @@ def test_built_wheel_does_not_ship_legacy_v1_modules() -> None:
     assert not leaked, f"{latest.name} still ships legacy v1 modules (plan §P2-1):\n" + "\n".join(
         f"  {n}" for n in leaked
     )
+
+
+def test_no_channel_uses_legacy_experience_subdir_seed_path() -> None:
+    """Plan §P2-2: bundled experience seed digests must live at
+    `<skill>/experience.md`, NOT `<skill>/experience/experience.md`. The runtime
+    loader (`autosearch.skills.experience.load_experience_digest`) only checks
+    the top-level path, so seeds parked in the subdir variant were silently
+    dead. Standardize on top-level."""
+    channels_root = ROOT / "autosearch" / "skills" / "channels"
+    offenders = sorted(
+        channels_root.glob("*/experience/experience.md"),
+    )
+    assert not offenders, (
+        "channel(s) still ship the legacy experience-subdir seed path; the "
+        "loader will not see them. Move each to <skill>/experience.md "
+        "(top-level):\n" + "\n".join(f"  {p.relative_to(ROOT)}" for p in offenders)
+    )
+
+
+def test_built_wheel_uses_only_top_level_experience_seed_path() -> None:
+    """Companion: even if a future PR re-creates a `<skill>/experience/` dir
+    locally, this guard catches it at the wheel layer (where setuptools'
+    `**/*.md` glob would otherwise quietly include it)."""
+    dist = ROOT / "dist"
+    wheels = sorted(dist.glob("autosearch-*.whl"))
+    if not wheels:
+        pytest.skip("no built wheel in dist/ — run `uv build --wheel` first")
+    latest = wheels[-1]
+    with zipfile.ZipFile(latest) as zf:
+        names = zf.namelist()
+    pattern = re.compile(r"^autosearch/skills/channels/[^/]+/experience/experience\.md$")
+    leaked = [n for n in names if pattern.match(n)]
+    assert not leaked, (
+        f"{latest.name} ships seed digest(s) at the legacy subdir path "
+        "(plan §P2-2):\n" + "\n".join(f"  {n}" for n in leaked)
+    )


### PR DESCRIPTION
## Summary

Adds two new guards to \`tests/unit/test_package_contents.py\` that pin plan §P2-2:

- \`test_no_channel_uses_legacy_experience_subdir_seed_path\` — source tree must not contain any \`autosearch/skills/channels/*/experience/experience.md\`
- \`test_built_wheel_uses_only_top_level_experience_seed_path\` — built wheel must not ship that subdir variant either

## Why

Plan §P2-2: bundled seed digests were split across two paths. \`autosearch.skills.experience.load_experience_digest\` only checks \`<skill>/experience.md\` (top-level). Two channels — **linkedin** and **xueqiu** — were shipping their seed at \`<skill>/experience/experience.md\` instead, so the loader has been silently ignoring both seeds since the v2 runtime path landed.

Today's \`uv build --wheel\` ships:
\`\`\`
bilibili/experience.md         (221 bytes)  ← loader sees ✓
github/experience.md           (219 bytes)  ← loader sees ✓
stackoverflow/experience.md    (226 bytes)  ← loader sees ✓
xiaohongshu/experience.md      (224 bytes)  ← loader sees ✓
linkedin/experience/experience.md  (1 byte) ← loader BLIND
xueqiu/experience/experience.md    (1 byte) ← loader BLIND
\`\`\`

After local cleanup + rebuild:
\`\`\`
bilibili/experience.md         ✓
github/experience.md           ✓
stackoverflow/experience.md    ✓
xiaohongshu/experience.md      ✓
\`\`\`

linkedin & xueqiu had 1-byte placeholder files that the loader never read; removing them changes nothing user-visible (\`load_experience_digest\` already returns \`None\` for missing seeds), but unifies the contract so the next person who adds a seed for those channels does it at the right path.

## Note on git diff

The two \`<skill>/experience/\` directories were already \`.gitignore\`-excluded (only \`xiaohongshu/experience/\` and \`meta/channel-selection/experience/\` are explicit exceptions), so the cleanup is invisible in \`git diff\`. The new tests are the durable artifact: they fail loudly if anyone re-creates that subdir locally OR if a future PR adds a new exception that lets the variant slip into the wheel.

A reviewer or future contributor doing a fresh \`git clone\` will see neither directory and the tests will pass immediately. Local state with stale files needs:
\`\`\`bash
rm -rf autosearch/skills/channels/linkedin/experience
rm -rf autosearch/skills/channels/xueqiu/experience
\`\`\`

## Test plan

- [x] \`uv build --wheel\` after cleanup → wheel only contains the 4 standard top-level seeds
- [x] \`pytest tests/unit/test_package_contents.py -v\` → 8/8 PASS (was 6, now 6 + 2 new P2-2 guards)
- [x] \`./scripts/release-gate.sh --quick\` → all gates PASS
- [x] CI on this PR will run from a fresh checkout — verifies the "fresh clone is clean" assertion above

🤖 Generated with [Claude Code](https://claude.com/claude-code)