### PR TITLE
chore: bump version to 2026.04.24.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.24.4"
+  "version": "2026.04.24.5"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.24.4",
+  "version": "2026.04.24.5",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.04.24.5 — 2026-04-24
+
+The "trim, gate, and stop tempting LLMs" release.
+
+- **The deprecated `research` MCP tool no longer registers by default.** Previously it shipped on every server start and only returned a deprecation response when called — but the attractive name still tempted host LLMs to pick it over the v2 trio. Default tool count drops from 24 → 23. Set `AUTOSEARCH_LEGACY_RESEARCH=1` to opt in if you really need it; the behavior in opt-in mode is unchanged.
+- **`scripts/install.sh` now supports `--dry-run`, `--no-init`, and `--version`.** Enterprise users can preview every command before piping the script into bash, CI can run unattended without the interactive `autosearch init`, and you can pin a specific release (`--version 2026.04.24.5`) instead of always taking latest. Default behavior is byte-identical when no flags are passed.
+- **Windows CI now exercises the v2 runtime experience path.** The `cross-platform.yml` workflow's experience-layer step was still mutating `_SKILLS_ROOT` (v1 contract); it now sets `AUTOSEARCH_EXPERIENCE_DIR` and asserts writes against the real runtime path so a Windows-specific path-handling regression actually trips a check.
+- **E2B test matrices stop importing modules that were removed in 2026.04.24.4.** `matrix.yaml` shipped-imports list dropped 5 deleted module names; `matrix-extensions.yaml`'s F112 channel-failure-isolation phase removed (covered by unit tests against `ChannelRuntime`); `roadmap_r1_r5_commits_exist` task removed; `tests/e2b/bench/single_channel_bench.py` deleted (132-line v1 bench whose import target no longer exists). Net **-269 / +3 lines**.
+- **Two new package-content guards**: `tests/unit/test_package_contents.py` now also fails the release if any channel ships a seed digest at the legacy `<skill>/experience/experience.md` path (the runtime loader only checks the top-level `<skill>/experience.md`, so subdir variants were silently dead). Caught and removed `linkedin/experience/experience.md` + `xueqiu/experience/experience.md` 1-byte placeholders that had been quietly riding in the wheel.
+
 ## 2026.04.24.4 — 2026-04-24
 
 The "smaller wheel, honest docs" release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.24.4"
+version = "2026.04.24.5"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bumps to **2026.04.24.5** packaging the five follow-up PRs since v4:

- #337 — clean dead legacy import refs in E2B matrices/bench (PR #334 follow-up)
- #338 — `install.sh` gains `--dry-run` / `--no-init` / `--version` flags (plan §P1-7)
- #339 — Windows CI workflow uses v2 `AUTOSEARCH_EXPERIENCE_DIR` contract (plan §P1-10)
- #340 — `research` MCP tool default-hidden; `AUTOSEARCH_LEGACY_RESEARCH=1` to opt in (plan §P1-4)
- #341 — pin experience-seed path consistency: top-level only, never `<skill>/experience/experience.md` (plan §P2-2)

After merge, push tag \`v2026.04.24.5\` to trigger PyPI + npm + GitHub Release via \`release.yml\`.

## Test plan

- [x] \`./scripts/release-gate.sh --quick\` → 38 contract gates + lint + version + CLI all PASS
- [x] CHANGELOG entry filled in (no empty version section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)