### PR TITLE
fix(test): smoke asserts v2 default tools, not deprecated research (Bug 5)

### DIFF
--- a/tests/smoke/test_mcp_stdio_smoke.py
+++ b/tests/smoke/test_mcp_stdio_smoke.py
@@ -72,11 +72,17 @@ def test_mcp_stdio_smoke() -> None:
 
         assert tools_response["jsonrpc"] == "2.0"
         tool_names = {tool["name"] for tool in tools_response["result"]["tools"]}
-        assert {"research", "health"} <= tool_names
-        # Core v2 tools must be registered
+        # v2 contract: `research` is opt-in (set AUTOSEARCH_LEGACY_RESEARCH=1).
+        # Default surface must include health + the v2 required tools.
+        assert "health" in tool_names
         assert "list_skills" in tool_names
         assert "doctor" in tool_names
         assert "list_channels" in tool_names
+        assert "run_clarify" in tool_names
+        assert "run_channel" in tool_names
+        assert "research" not in tool_names, (
+            "deprecated `research` must not appear by default (plan §P1-4)"
+        )
 
         if process.stdin is not None:
             process.stdin.close()


### PR DESCRIPTION
## Summary

Bug 5 from `docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md`.

v2026.04.24.5 hid the deprecated `research` MCP tool by default (plan §P1-4). The stdio smoke test wasn't updated and still asserted `{"research", "health"} <= tool_names` — so smoke CI red on every push.

Now the default-mode smoke asserts:
- `health` + the 5 core v2 tools (`list_skills`, `doctor`, `list_channels`, `run_clarify`, `run_channel`)
- `research not in tool_names` — pins the v2 contract from regression

## Test plan

- [x] `pytest tests/smoke/test_mcp_stdio_smoke.py -v -m smoke` → 2/2 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MCP stdio tool validation to reflect v2 tool contract. Default tools now include `health`, `run_clarify`, and `run_channel`, with `research` no longer included by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->