### PR TITLE
fix(compress): consolidate_research reads run_channel 'source' key (Bug 3)

### DIFF
--- a/autosearch/core/context_compression.py
+++ b/autosearch/core/context_compression.py
@@ -30,7 +30,11 @@ def _evidence_from_dict(d: dict[str, Any]) -> Evidence | None:
             title=d.get("title", ""),
             snippet=d.get("snippet"),
             content=d.get("content"),
-            source_channel=d.get("source_channel", "unknown"),
+            # Bug 3 (fix-plan): run_channel emits Evidence.to_context_dict(),
+            # which writes the channel name under "source" (not "source_channel").
+            # Accept both so consolidate_research / compress_evidence don't see
+            # every item as "unknown" coming straight from run_channel output.
+            source_channel=d.get("source_channel") or d.get("source") or "unknown",
             score=float(d.get("score") or 0.0),
             fetched_at=datetime.now(UTC),
         )

--- a/tests/unit/test_consolidate_research_source_field.py
+++ b/tests/unit/test_consolidate_research_source_field.py
@@ -1,0 +1,58 @@
+"""Bug 3 (fix-plan): consolidate_research / compress_evidence used to read the
+channel name from `source_channel`, but `run_channel` writes it under `source`
+(via `Evidence.to_context_dict`). The mismatch made every consolidated item
+look like it came from an "unknown" source — defeating cross-channel grouping.
+
+This regression test pins both field names as accepted readers."""
+
+from __future__ import annotations
+
+from autosearch.core.context_compression import compress_evidence
+
+
+def _evidence_from_run_channel(
+    *, source_value: str, url: str = "https://arxiv.org/abs/2401.12345"
+) -> dict:
+    # Shape produced by run_channel → Evidence.to_context_dict():
+    return {
+        "url": url,
+        "title": "BM25 ranking explained",
+        "snippet": "BM25 weights ...",
+        "source": source_value,  # <-- the key in dispute
+        "score": 0.7,
+    }
+
+
+def test_compress_reads_source_key_from_run_channel_output() -> None:
+    """run_channel emits `source`; compressor must NOT treat it as `unknown`."""
+    items = [
+        _evidence_from_run_channel(source_value="arxiv"),
+        _evidence_from_run_channel(
+            source_value="arxiv",
+            url="https://arxiv.org/abs/2401.99999",
+        ),
+    ]
+    brief = compress_evidence(items, query="bm25")
+    coverage = brief["source_coverage"]
+    assert "arxiv" in coverage, (
+        f"compressor failed to recognize 'arxiv' from run_channel `source` key; coverage={coverage}"
+    )
+    assert "unknown" not in coverage, (
+        f"compressor treated run_channel output as unknown source: {coverage}"
+    )
+
+
+def test_compress_still_reads_explicit_source_channel_key() -> None:
+    """Backward-compat: callers that already write `source_channel` keep working."""
+    items = [
+        {
+            "url": "https://github.com/foo/bar",
+            "title": "x",
+            "snippet": "y",
+            "source_channel": "github",
+            "score": 0.5,
+        }
+    ]
+    brief = compress_evidence(items, query="x")
+    assert "github" in brief["source_coverage"]
+    assert "unknown" not in brief["source_coverage"]


### PR DESCRIPTION
## Summary

Bug 3 from `docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md`.

`Evidence.to_context_dict()` writes the channel name under `source` (line 97 of `autosearch/core/models.py`), but `_evidence_from_dict()` in `context_compression.py` only read `source_channel`. Result: every item flowing from `run_channel` → `consolidate_research` got tagged as `unknown`, so `source_coverage` was always `{"unknown": N}` and cross-channel grouping/citation was broken.

One-line fix: read either key.

```python
source_channel=d.get("source_channel") or d.get("source") or "unknown",
```

## Test plan

- [x] new `tests/unit/test_consolidate_research_source_field.py` (2 cases) — pins both reader paths
- [x] `pytest tests/unit/test_consolidate_research_source_field.py -v` → 2/2 PASS
- [x] `./scripts/release-gate.sh --quick` → all gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)