### PR TITLE
fix(models): Evidence.published_at flows into recent_signal_fusion (Bug 4)

### DIFF
--- a/autosearch/core/models.py
+++ b/autosearch/core/models.py
@@ -73,6 +73,11 @@ class Evidence(BaseModel):
     content: str | None = None
     source_channel: str
     fetched_at: datetime
+    # Bug 4 (fix-plan): when a channel knows the publish date (arxiv,
+    # github, twitter, papers, google_news, …), it must surface it so
+    # `recent_signal_fusion` and citation-quality tools can rank by recency.
+    # Optional — channels that don't know it leave it None.
+    published_at: datetime | None = None
     score: float | None = None
     source_page: FetchedPage | None = None
 
@@ -95,6 +100,9 @@ class Evidence(BaseModel):
             d["snippet"] = text[:max_content_chars]
         if self.source_channel:
             d["source"] = self.source_channel
+        if self.published_at is not None:
+            # ISO 8601 — recent_signal_fusion looks for the "published_at" key.
+            d["published_at"] = self.published_at.isoformat()
         if self.score and self.score > 0:
             d["score"] = round(self.score, 2)
         return d

--- a/autosearch/skills/channels/arxiv/methods/api_search.py
+++ b/autosearch/skills/channels/arxiv/methods/api_search.py
@@ -121,11 +121,23 @@ def _to_evidence(entry: object, *, fetched_at: datetime) -> Evidence:
     summary = _normalize_whitespace(str(getattr(entry, "summary", "") or ""))
     url = str(getattr(entry, "link", "") or getattr(entry, "id", "") or "").strip()
 
+    # Bug 4: feedparser exposes the arxiv <published> tag — surface it so
+    # recent_signal_fusion can rank papers by date.
+    published_at: datetime | None = None
+    published_raw = getattr(entry, "published", None)
+    if published_raw:
+        try:
+            parsed = datetime.fromisoformat(str(published_raw).replace("Z", "+00:00"))
+            published_at = parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+        except (TypeError, ValueError):
+            published_at = None
+
     return Evidence(
         url=url,
         title=title,
         snippet=summary[:500] or None,
         source_channel="arxiv",
         fetched_at=fetched_at,
+        published_at=published_at,
         score=0.0,
     )

--- a/tests/unit/test_evidence_published_at_flow.py
+++ b/tests/unit/test_evidence_published_at_flow.py
@@ -1,0 +1,66 @@
+"""Bug 4 (fix-plan): publish dates were dropped on the way to MCP context dicts,
+so `recent_signal_fusion` couldn't rank by recency. This pins the end-to-end
+flow: Evidence carries published_at → to_context_dict surfaces it under the
+key recent_signal_fusion already looks for → fusion produces a non-trivial
+recency ranking."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from autosearch.core.models import Evidence
+from autosearch.core.recent_signal_fusion import filter_recent
+
+
+def _ev(url: str, age_days: int) -> Evidence:
+    return Evidence(
+        url=url,
+        title=f"item from {age_days} days ago",
+        snippet="bm25 ranking",
+        source_channel="arxiv",
+        fetched_at=datetime.now(UTC),
+        published_at=datetime.now(UTC) - timedelta(days=age_days),
+    )
+
+
+def test_to_context_dict_emits_published_at_when_set() -> None:
+    ev = _ev("https://arxiv.org/abs/x", age_days=3)
+    ctx = ev.to_context_dict()
+    assert "published_at" in ctx, (
+        "Evidence with a known publish date must surface it in the slim "
+        "context dict for recent_signal_fusion to consume"
+    )
+
+
+def test_to_context_dict_omits_published_at_when_unknown() -> None:
+    ev = Evidence(
+        url="https://example.com",
+        title="t",
+        source_channel="generic",
+        fetched_at=datetime.now(UTC),
+    )
+    assert "published_at" not in ev.to_context_dict()
+
+
+def test_recent_signal_fusion_uses_published_at_from_run_channel_dicts() -> None:
+    """End-to-end: dicts shaped like run_channel output must rank by recency.
+
+    Before this fix: every item lacked a date key in the slim context dict, so
+    `filter_recent` excluded everything. After: the recent item survives the
+    90-day window and the older one is dropped.
+    """
+    items = [
+        _ev("https://arxiv.org/abs/old", age_days=400).to_context_dict(),
+        _ev("https://arxiv.org/abs/new", age_days=2).to_context_dict(),
+        _ev("https://arxiv.org/abs/mid", age_days=60).to_context_dict(),
+    ]
+    ranked = filter_recent(items, days=90)
+    urls = [item.get("url") for item in ranked]
+    assert "https://arxiv.org/abs/new" in urls, (
+        f"recent_signal_fusion dropped the recent item; got {urls}"
+    )
+    assert "https://arxiv.org/abs/old" not in urls, (
+        "filter_recent must exclude items older than the cutoff"
+    )
+    # Newest first ordering
+    assert urls[0] == "https://arxiv.org/abs/new", f"expected newest first; got {urls}"


### PR DESCRIPTION
## Summary

Bug 4 from `docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md`.

`recent_signal_fusion.filter_recent` looks for `published_at` (and other date keys) on each evidence dict, but `Evidence.to_context_dict()` didn't emit any date — so every item was excluded as "no parseable date" and recency ranking degraded to no-op when fed run_channel output.

Three minimal changes:
- `autosearch/core/models.py`: `Evidence.published_at: datetime | None = None` field; `to_context_dict()` emits it as ISO 8601 when set.
- `autosearch/skills/channels/arxiv/methods/api_search.py`: parse `entry.published` from the feedparser atom feed and fill `Evidence.published_at`. arxiv is the pilot; the field is opt-in for other channels (no schema break).
- `tests/unit/test_evidence_published_at_flow.py`: pins the end-to-end Evidence → to_context_dict → filter_recent flow + the None case (no date → no key).

## Why this scope

Plan F009 wants the same metadata across 6 channels. That's the bigger refactor. This PR is just the bug fix: the infrastructure (model field + serialization key + one channel actually filling it) is enough to make `recent_signal_fusion` produce a real ranking on arxiv results today. Other channel adapters can opt into the field as F009 lands.

## Test plan

- [x] `pytest tests/unit/test_evidence_published_at_flow.py -v` → 3/3 PASS
- [x] `./scripts/release-gate.sh --quick` → all gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)