### PR TITLE
fix(init): --check-channels delegates to doctor (Bug 2)

### DIFF
--- a/autosearch/init/channel_status.py
+++ b/autosearch/init/channel_status.py
@@ -75,9 +75,50 @@ def summarize_registry(registry: ChannelRegistry) -> list[ChannelStatus]:
     return rows
 
 
-def compile_channel_statuses(channels_root: Path, env: Environment) -> list[ChannelStatus]:
-    registry = ChannelRegistry.compile_from_skills(channels_root, env, log_missing_impls=False)
-    return summarize_registry(registry)
+def compile_channel_statuses(
+    channels_root: Path, env: Environment | None = None
+) -> list[ChannelStatus]:
+    """Bug 2 (fix-plan): one source of truth for channel status.
+
+    Previously this scanned the registry independently from `doctor.scan_channels`,
+    which produced diverging counts (e.g. doctor 37/40 vs init 38/40). Now it
+    delegates to doctor and only translates the row shape into init's
+    presentation-layer enum (tier label, available/blocked/scaffold-only).
+
+    The `env` argument is kept for backward compatibility but no longer used —
+    doctor reads the live process environment itself.
+    """
+    # Lazy-import to avoid a top-level cycle and to keep doctor as the canonical
+    # availability owner.
+    from autosearch.core.doctor import scan_channels as _doctor_scan
+
+    return [_doctor_status_to_init_status(row) for row in _doctor_scan(channels_root)]
+
+
+_DOCTOR_TIER_TO_INIT_TIER: dict[int, Tier] = {0: "t0", 1: "t1", 2: "t2"}
+
+
+def _doctor_status_to_init_status(row: object) -> ChannelStatus:
+    """Translate a doctor row into the init-CLI ChannelStatus presentation."""
+    tier: Tier = _DOCTOR_TIER_TO_INIT_TIER.get(row.tier, "t0")
+    unmet = list(row.unmet_requires)
+    impl_missing = [u for u in unmet if u.startswith("impl_missing")]
+    real_unmet = [u for u in unmet if not u.startswith("impl_missing")]
+
+    if row.status == "ok":
+        status: Status = "available"
+        return ChannelStatus(channel=row.channel, tier=tier, status=status, unmet_requires=[])
+
+    # status in ("warn", "off"). `warn` means "some methods work, some don't" —
+    # match doctor's strict headline counting where only `ok` counts as
+    # "available". Surface real blockers in unmet_requires so the user can fix.
+    if impl_missing and not real_unmet:
+        return ChannelStatus(
+            channel=row.channel, tier="scaffold", status="scaffold-only", unmet_requires=[]
+        )
+    return ChannelStatus(
+        channel=row.channel, tier=tier, status="blocked", unmet_requires=real_unmet
+    )
 
 
 def blocked_requires(metadata: ChannelMetadata) -> list[str]:

--- a/tests/unit/test_init_channel_status_matches_doctor.py
+++ b/tests/unit/test_init_channel_status_matches_doctor.py
@@ -1,0 +1,45 @@
+"""Bug 2 (fix-plan): `autosearch doctor` and `autosearch init --check-channels`
+used to disagree on channel availability counts (e.g. 37/40 vs 38/40) because
+they ran two independent availability pipelines. This pins them to the same
+doctor source of truth so the divergence cannot return."""
+
+from __future__ import annotations
+
+from autosearch.core.doctor import scan_channels
+from autosearch.init.channel_status import (
+    compile_channel_statuses,
+    default_channels_root,
+)
+
+
+def test_init_check_channels_total_matches_doctor() -> None:
+    doctor_rows = scan_channels()
+    init_rows = compile_channel_statuses(default_channels_root())
+    assert len(init_rows) == len(doctor_rows), (
+        f"channel total diverged: doctor={len(doctor_rows)} init={len(init_rows)}"
+    )
+
+
+def test_init_check_channels_available_count_matches_doctor_ok_count() -> None:
+    doctor_rows = scan_channels()
+    init_rows = compile_channel_statuses(default_channels_root())
+    doctor_ok = sum(1 for r in doctor_rows if r.status == "ok")
+    init_avail = sum(1 for r in init_rows if r.status == "available")
+    assert init_avail == doctor_ok, (
+        f"available count diverged: doctor={doctor_ok} init={init_avail}; "
+        "init must use doctor as the single source of truth (plan §F003)"
+    )
+
+
+def test_init_per_channel_availability_matches_doctor() -> None:
+    doctor_rows = {r.channel: r for r in scan_channels()}
+    init_rows = compile_channel_statuses(default_channels_root())
+    mismatches: list[str] = []
+    for ir in init_rows:
+        dr = doctor_rows.get(ir.channel)
+        assert dr is not None, f"init row {ir.channel} has no doctor counterpart"
+        init_says_available = ir.status == "available"
+        doctor_says_ok = dr.status == "ok"
+        if init_says_available != doctor_says_ok:
+            mismatches.append(f"{ir.channel}: doctor={dr.status} init={ir.status}")
+    assert not mismatches, "per-channel availability disagreement:\n" + "\n".join(mismatches)


### PR DESCRIPTION
## Summary

Bug 2 from `docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md`.

`autosearch doctor` reported `37/40 channels ready`, `autosearch init --check-channels` reported `38/40`. Two independent pipelines (`compile_channel_statuses` + `summarize_registry` vs `scan_channels`) disagreed on the count a user sees during install.

`compile_channel_statuses()` now delegates to `doctor.scan_channels()` and only translates the row shape into init's presentation layer (tier label, `available` / `blocked` / `scaffold-only`). Only `status == "ok"` maps to `"available"` so the headline count matches doctor exactly.

The `env` argument is kept for backward compatibility but unused — doctor reads the process environment itself.

## What I kept

- `summarize_registry`, `infer_tier`, `shipped_methods`, `blocked_requires`, etc. remain for now — no external caller, but removing them is out of scope for a bug fix. Can be dead-code-swept in a separate PR.

## Test plan

- [x] `pytest tests/unit/test_init_channel_status_matches_doctor.py -v` → 3/3 PASS (total, available count, per-channel agreement)
- [x] `pytest tests/unit/ -m "not real_llm and not slow and not network" -q` → 530 PASS
- [x] `./scripts/release-gate.sh --quick` → all gates PASS
- [x] live: `autosearch doctor` and `autosearch init --check-channels` both report 37/40 available

🤖 Generated with [Claude Code](https://claude.com/claude-code)