### PR TITLE
fix(mcp): invalid id returns structured error, not ToolError (Bug 6)

### DIFF
--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -785,18 +785,27 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
     @server.tool()
     def loop_update(state_id: str, evidence: list[dict], query: str) -> dict:
         """Update loop state with evidence from run_channel. Returns state summary."""
-        return _ls_update(state_id, evidence, query)
+        try:
+            return _ls_update(state_id, evidence, query)
+        except KeyError:
+            return {"ok": False, "reason": "invalid_state_id", "state_id": state_id}
 
     @server.tool()
     def loop_get_gaps(state_id: str) -> dict:
         """Get coverage gaps for this loop. Returns {state_id, gaps}."""
-        return {"state_id": state_id, "gaps": _ls_get_gaps(state_id)}
+        try:
+            return {"state_id": state_id, "gaps": _ls_get_gaps(state_id)}
+        except KeyError:
+            return {"ok": False, "reason": "invalid_state_id", "state_id": state_id}
 
     @server.tool()
     def loop_add_gap(state_id: str, gap: str) -> dict:
         """Mark a topic as a coverage gap. Returns {state_id, gaps}."""
-        _ls_add_gap(state_id, gap)
-        return {"state_id": state_id, "gaps": _ls_get_gaps(state_id)}
+        try:
+            _ls_add_gap(state_id, gap)
+            return {"state_id": state_id, "gaps": _ls_get_gaps(state_id)}
+        except KeyError:
+            return {"ok": False, "reason": "invalid_state_id", "state_id": state_id}
 
     # F007: citation index
     @server.tool()
@@ -807,20 +816,36 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
     @server.tool()
     def citation_add(index_id: str, url: str, title: str = "", source: str = "") -> dict:
         """Add URL to citation index (idempotent). Returns {index_id, citation_number, url}."""
-        num = _ci_add(index_id, url, title=title, source=source)
+        try:
+            num = _ci_add(index_id, url, title=title, source=source)
+        except KeyError:
+            return {"ok": False, "reason": "invalid_index_id", "index_id": index_id}
         return {"index_id": index_id, "citation_number": num, "url": url}
 
     @server.tool()
     def citation_export(index_id: str) -> dict:
         """Export citations as Markdown. Returns {index_id, markdown, count}."""
-        markdown = _ci_export(index_id)
-        count = len(_CI_STORE[index_id]._entries)
+        try:
+            markdown = _ci_export(index_id)
+            count = len(_CI_STORE[index_id]._entries)
+        except KeyError:
+            return {"ok": False, "reason": "invalid_index_id", "index_id": index_id}
         return {"index_id": index_id, "markdown": markdown, "count": count}
 
     @server.tool()
     def citation_merge(target_id: str, source_id: str) -> dict:
         """Merge source citation index into target. Returns {merged_count, skipped_duplicates}."""
-        return _ci_merge(target_id, source_id)
+        try:
+            return _ci_merge(target_id, source_id)
+        except KeyError as exc:
+            missing = str(exc).strip("'\"")
+            which = "target_id" if missing == target_id else "source_id"
+            return {
+                "ok": False,
+                "reason": f"invalid_{which}",
+                "target_id": target_id,
+                "source_id": source_id,
+            }
 
     # F004: group-first channel selection
     @server.tool()

--- a/tests/unit/test_mcp_invalid_id_structured_error.py
+++ b/tests/unit/test_mcp_invalid_id_structured_error.py
@@ -1,0 +1,94 @@
+"""Bug 6 (fix-plan): citation_* and loop_* MCP tools used to raise FastMCP
+ToolError on an invalid index_id / state_id, breaking the host agent's
+workflow. They must instead return a structured response the agent can
+recognize and recover from."""
+
+from __future__ import annotations
+
+import pytest
+
+from autosearch.mcp.server import create_server
+
+
+@pytest.mark.asyncio
+async def test_citation_add_invalid_index_returns_structured_error() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    result = await tm.call_tool(
+        "citation_add",
+        {"index_id": "does-not-exist", "url": "https://example.com"},
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "invalid_index_id"
+    assert result["index_id"] == "does-not-exist"
+
+
+@pytest.mark.asyncio
+async def test_citation_export_invalid_index_returns_structured_error() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    result = await tm.call_tool("citation_export", {"index_id": "ghost"})
+    assert result["ok"] is False
+    assert result["reason"] == "invalid_index_id"
+
+
+@pytest.mark.asyncio
+async def test_citation_merge_invalid_target_returns_structured_error() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    create = await tm.call_tool("citation_create", {})
+    real_id = create["index_id"]
+    result = await tm.call_tool(
+        "citation_merge",
+        {"target_id": "ghost-target", "source_id": real_id},
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "invalid_target_id"
+
+
+@pytest.mark.asyncio
+async def test_loop_update_invalid_state_returns_structured_error() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    result = await tm.call_tool(
+        "loop_update",
+        {"state_id": "no-such-loop", "evidence": [], "query": "x"},
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "invalid_state_id"
+
+
+@pytest.mark.asyncio
+async def test_loop_get_gaps_invalid_state_returns_structured_error() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    result = await tm.call_tool("loop_get_gaps", {"state_id": "no-such-loop"})
+    assert result["ok"] is False
+    assert result["reason"] == "invalid_state_id"
+
+
+@pytest.mark.asyncio
+async def test_loop_add_gap_invalid_state_returns_structured_error() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    result = await tm.call_tool("loop_add_gap", {"state_id": "no-such-loop", "gap": "topic"})
+    assert result["ok"] is False
+    assert result["reason"] == "invalid_state_id"
+
+
+@pytest.mark.asyncio
+async def test_valid_citation_workflow_still_works() -> None:
+    """Sanity: error-handling wrapper must not break the happy path."""
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    create = await tm.call_tool("citation_create", {})
+    idx = create["index_id"]
+    add = await tm.call_tool(
+        "citation_add",
+        {"index_id": idx, "url": "https://arxiv.org/abs/x"},
+    )
+    assert add.get("ok") is not False
+    assert add["citation_number"] == 1
+    export = await tm.call_tool("citation_export", {"index_id": idx})
+    assert export.get("ok") is not False
+    assert export["count"] == 1


### PR DESCRIPTION
## Summary

Bug 6 from `docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md`.

`citation_add` / `citation_export` / `citation_merge` / `loop_update` / `loop_get_gaps` / `loop_add_gap` looked up the id in an in-memory dict (`_CITATION_INDEXES[index_id]` / `_LOOP_STATES[state_id]`) and let the `KeyError` bubble up as a FastMCP `ToolError`, which crashes the host agent's workflow. Agents had no recoverable signal — just an exception.

Each tool now wraps the underlying call: on `KeyError` it returns a structured `{ok: false, reason: "invalid_index_id" | "invalid_state_id", ...}`. `citation_merge` figures out which of the two ids was missing.

## Why wrappers, not core changes

Plan §F010 suggested adding "safe lookup helpers" in `citation_index.py` / `loop_state.py`. I kept the change to the MCP boundary (one file: `autosearch/mcp/server.py`) so we don't change `add_citation()` / `_LOOP_STATES[id]` semantics for any other internal caller. Same effect from the agent's perspective, smaller blast radius.

## Test plan

- [x] new `tests/unit/test_mcp_invalid_id_structured_error.py` (7 cases) — all 6 tools + a happy-path sanity check
- [x] `pytest tests/unit/test_mcp_invalid_id_structured_error.py -v` → 7/7 PASS
- [x] `./scripts/release-gate.sh --quick` → all gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)