### PR TITLE
fix(runtime): refresh ChannelRuntime on secrets/env change (Bug 1)

### DIFF
--- a/autosearch/core/channel_runtime.py
+++ b/autosearch/core/channel_runtime.py
@@ -37,16 +37,84 @@ class ChannelRuntime:
 
 
 _runtime: ChannelRuntime | None = None
+_runtime_fingerprint: tuple | None = None
 _runtime_lock = threading.Lock()
+
+# Channel-relevant env keys whose presence/absence flips channel availability.
+# When any of these appears or disappears (or the secrets file mtime changes),
+# the runtime must rebuild so `doctor` and `run_channel` agree in the same MCP
+# process (Bug 1 / fix-plan).
+_CHANNEL_ENV_KEYS: tuple[str, ...] = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "CLAUDE_API_KEY",
+    "YOUTUBE_API_KEY",
+    "TIKHUB_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "OPENROUTER_API_KEY",
+    "SEARXNG_URL",
+    "AUTOSEARCH_SIGNSRV_URL",
+    "AUTOSEARCH_SERVICE_TOKEN",
+    "XHS_A1_COOKIE",
+    "XHS_COOKIES",
+    "XIAOHONGSHU_COOKIES",
+    "TWITTER_COOKIES",
+    "BILIBILI_COOKIES",
+    "WEIBO_COOKIES",
+    "DOUYIN_COOKIES",
+    "ZHIHU_COOKIES",
+    "XUEQIU_COOKIES",
+)
+
+
+def _current_fingerprint() -> tuple:
+    """Build a fingerprint that flips when secrets-file mtime or any
+    channel-relevant env-key presence changes.
+
+    Cheap to compute (one `stat` + a small set membership) so it can run on
+    every `get_channel_runtime()` call.
+    """
+    import os  # noqa: PLC0415
+
+    from autosearch.core.secrets_store import secrets_path  # noqa: PLC0415
+
+    try:
+        path = secrets_path()
+        mtime = path.stat().st_mtime if path.exists() else None
+    except OSError:
+        mtime = None
+    env_presence = tuple(sorted(k for k in _CHANNEL_ENV_KEYS if os.environ.get(k)))
+    return (mtime, env_presence)
 
 
 def get_channel_runtime() -> ChannelRuntime:
-    """Return the shared runtime, building it on first access. Thread-safe."""
-    global _runtime
-    if _runtime is None:
+    """Return the shared runtime, rebuilding when secrets/env fingerprint changes.
+
+    Thread-safe. Bug 1 (fix-plan): a long-running MCP process used to keep its
+    first-load runtime forever, so `autosearch configure NEW_KEY` written by
+    the user *while the MCP host was open* never reached `run_channel` — even
+    though `doctor` (which re-scans every call) saw it. Now both agree.
+    """
+    global _runtime, _runtime_fingerprint
+    fp = _current_fingerprint()
+    if _runtime is None or _runtime_fingerprint != fp:
         with _runtime_lock:
-            if _runtime is None:
+            fp = _current_fingerprint()
+            if _runtime is None or _runtime_fingerprint != fp:
+                # Re-inject secrets-file values into env BEFORE rebuilding the
+                # registry so newly added keys are visible to availability checks.
+                try:
+                    from autosearch.core.secrets_store import (  # noqa: PLC0415
+                        inject_into_env,
+                    )
+
+                    inject_into_env()
+                except Exception:  # noqa: BLE001
+                    pass
+                fp = _current_fingerprint()
                 _runtime = _build()
+                _runtime_fingerprint = fp
     return _runtime
 
 
@@ -54,18 +122,20 @@ def reset_channel_runtime() -> None:
     """Drop the cached runtime so the next `get_channel_runtime()` rebuilds.
 
     Tests use this between scenarios that monkeypatch channel sources or env
-    state. Production code never calls it.
+    state. Production code does not need to call it — the fingerprint check
+    above handles legitimate secrets-file changes.
     """
-    global _runtime
+    global _runtime, _runtime_fingerprint
     with _runtime_lock:
         _runtime = None
+        _runtime_fingerprint = None
 
 
 def install_test_runtime(channels: list[Channel], registry: ChannelRegistry | None = None) -> None:
     """Install a pre-built runtime for tests that need to inject specific
     channels (replacing the discovery-from-skills path). Pairs with
     `reset_channel_runtime()` in autouse fixtures."""
-    global _runtime
+    global _runtime, _runtime_fingerprint
     with _runtime_lock:
         _runtime = ChannelRuntime(
             registry=registry,
@@ -73,6 +143,9 @@ def install_test_runtime(channels: list[Channel], registry: ChannelRegistry | No
             limiter=RateLimiter(),
             channels=list(channels),
         )
+        # Pin the fingerprint so the next get_channel_runtime() doesn't
+        # rebuild over the test's injected channels.
+        _runtime_fingerprint = _current_fingerprint()
 
 
 def _build() -> ChannelRuntime:

--- a/tests/unit/test_runtime_refresh_on_secrets_change.py
+++ b/tests/unit/test_runtime_refresh_on_secrets_change.py
@@ -1,0 +1,75 @@
+"""Bug 1 (fix-plan): a long-running MCP process used to keep the first-load
+ChannelRuntime forever. After `autosearch configure NEW_KEY` wrote to the
+secrets file, `doctor` saw the new key (it re-scans every call) but
+`run_channel` did not (it ran against the cached runtime), so the same MCP
+process gave contradictory answers about channel availability.
+
+This pins the new fingerprint-based refresh: when the secrets-file mtime
+changes OR a channel-relevant env-key flips presence, `get_channel_runtime()`
+returns a fresh runtime."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from autosearch.core import channel_runtime as cr_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate_secrets(tmp_path, monkeypatch):
+    secrets_file = tmp_path / "ai-secrets.env"
+    secrets_file.write_text("# empty\n", encoding="utf-8")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(secrets_file))
+    # Drop any inherited keys so the fingerprint is deterministic.
+    for key in cr_mod._CHANNEL_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    cr_mod.reset_channel_runtime()
+    yield secrets_file
+    cr_mod.reset_channel_runtime()
+
+
+def test_runtime_rebuilds_when_env_key_appears(monkeypatch) -> None:
+    """A new env key appearing post-startup must invalidate the cached runtime."""
+    first = cr_mod.get_channel_runtime()
+    assert first is cr_mod.get_channel_runtime(), (
+        "stable: identical fingerprint → same runtime instance"
+    )
+
+    monkeypatch.setenv("YOUTUBE_API_KEY", "dummy-key")
+    second = cr_mod.get_channel_runtime()
+    assert second is not first, "fingerprint changed (new env key) but runtime was not rebuilt"
+
+
+def test_runtime_rebuilds_when_secrets_file_mtime_changes(_isolate_secrets) -> None:
+    secrets_file: Path = _isolate_secrets
+    first = cr_mod.get_channel_runtime()
+
+    # Bump mtime to a clearly later instant — file-system mtime resolution
+    # on some filesystems is 1s, so write a non-trivial gap.
+    later = time.time() + 5
+    os.utime(secrets_file, (later, later))
+
+    second = cr_mod.get_channel_runtime()
+    assert second is not first, "secrets-file mtime changed but runtime was not rebuilt"
+
+
+def test_stable_state_does_not_rebuild(_isolate_secrets) -> None:
+    first = cr_mod.get_channel_runtime()
+    second = cr_mod.get_channel_runtime()
+    third = cr_mod.get_channel_runtime()
+    assert first is second is third, (
+        "no fingerprint change → must reuse the cached runtime (cheap path)"
+    )
+
+
+def test_fingerprint_includes_secrets_mtime_and_env_presence() -> None:
+    fp = cr_mod._current_fingerprint()
+    assert isinstance(fp, tuple) and len(fp) == 2
+    mtime, env_presence = fp
+    assert isinstance(env_presence, tuple)
+    # mtime can be a float or None depending on whether the file exists
+    assert mtime is None or isinstance(mtime, float)


### PR DESCRIPTION
## Summary

Bug 1 from `docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md` — and the most user-visible "first-run" failure today.

A long-running MCP process built `ChannelRuntime` once on first access and held it forever. After the user ran `autosearch configure YOUTUBE_API_KEY xxx` *while Claude Code / Cursor was open*:
- `doctor` (re-scans on every call) saw youtube as available
- `run_channel("youtube")` (used the cached runtime) still returned `not_configured`

In one MCP process the agent got contradictory truth.

`get_channel_runtime()` now computes a cheap fingerprint on every call:
- secrets-file mtime (via `secrets_path()`)
- presence of channel-relevant env keys (the 20 keys that flip channel availability — provider keys, TIKHUB, YOUTUBE, login cookies, signing-worker URLs)

When the fingerprint changes the runtime rebuilds and re-injects the secrets file into the env first. When it doesn't change the cached runtime is reused (the cheap path that the existing P0-5 work depends on for cooldown/rate-limit accumulation — preserved).

## What I kept the same

- `reset_channel_runtime()` and `install_test_runtime()` still work; they pin the fingerprint so injected test channels aren't rebuilt over.
- The `_build()` path is unchanged.
- No tool surface change — agents continue calling `run_channel` exactly the same way.

## Test plan

- [x] new `tests/unit/test_runtime_refresh_on_secrets_change.py` — 4 cases:
  - new env key appearance triggers rebuild
  - secrets-file mtime change triggers rebuild
  - stable state reuses cached runtime (no rebuild loop)
  - fingerprint shape is stable
- [x] `pytest tests/unit/test_runtime_refresh_on_secrets_change.py -v` → 4/4 PASS
- [x] `./scripts/release-gate.sh` (full) → 38 contract gates + default suite + CLI all PASS
- [x] no change to existing health/cooldown/rate-limit accumulation tests (P0-5 work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)