### PR TITLE
chore: bump version to 2026.04.24.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.24.5"
+  "version": "2026.04.24.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.24.5",
+  "version": "2026.04.24.6",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026.04.24.6 — 2026-04-24
+
+The "six bugs caught by the product diagnostic" release. All 6 items in
+`docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md`
+are fixed; each landed as a separate minimal-change PR with regression tests.
+
+- **Long-running MCP processes pick up `autosearch configure NEW_KEY` without restart.** The shared `ChannelRuntime` now computes a cheap fingerprint (secrets-file mtime + presence of 20 channel-relevant env keys) on every `get_channel_runtime()` call. When the user adds a new key while Claude Code / Cursor is open, the runtime rebuilds and re-injects secrets into the env, so `run_channel("youtube")` no longer disagrees with `doctor` in the same process. (#348)
+- **`autosearch doctor` and `autosearch init --check-channels` agree on the count.** They used to report 37/40 vs 38/40 because they ran two independent availability pipelines; init now delegates to `doctor.scan_channels` as the single source of truth. (#346)
+- **`consolidate_research` no longer marks every item as `unknown source`.** `Evidence.to_context_dict()` writes the channel name under `source`; the compressor now reads either `source` or `source_channel`. Cross-channel grouping and citation tools work again. (#344)
+- **`recent_signal_fusion` actually ranks by date.** `Evidence` carries an optional `published_at` field; `to_context_dict()` emits it as ISO 8601; `arxiv` channel pilots the field by parsing the feed's `<published>` tag. Other channels can opt in incrementally. (#345)
+- **`citation_*` and `loop_*` MCP tools return structured errors on invalid IDs.** Previously a bad `index_id` / `state_id` raised a FastMCP `ToolError` and crashed the host agent's workflow. Now agents get `{"ok": false, "reason": "invalid_index_id" | "invalid_state_id"}` and can recover. (#347)
+- **Smoke test asserts the v2 default tool list, not the deprecated `research` tool.** v2026.04.24.5 hid `research` by default but the stdio smoke test still expected it; CI red on every push. Fixed. (#343)
+
 ## 2026.04.24.5 — 2026-04-24
 
 The "trim, gate, and stop tempting LLMs" release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.24.5"
+version = "2026.04.24.6"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bumps to **2026.04.24.6** packaging the six bug fixes from `docs/exec-plans/active/autosearch-0424-product-diagnostic-fix-plan.md`:

- #343 — smoke test asserts v2 default tool list (Bug 5)
- #344 — `consolidate_research` reads run_channel `source` key (Bug 3)
- #345 — `Evidence.published_at` flows into `recent_signal_fusion` (Bug 4)
- #346 — `init --check-channels` delegates to `doctor` (Bug 2)
- #347 — invalid id returns structured error, not ToolError (Bug 6)
- #348 — runtime refreshes on secrets/env change (Bug 1, the headline first-run fix)

After merge, push tag `v2026.04.24.6` to trigger PyPI + npm + GitHub Release via release.yml.

## Test plan

- [x] `./scripts/release-gate.sh --quick` → all gates PASS
- [x] CHANGELOG entry filled in (no empty version section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)