### PR TITLE
fix(scripts): validate + perf scripts follow v6 research-opt-in contract (Bug 6)

### DIFF
--- a/scripts/validate/check_mcp_tools.py
+++ b/scripts/validate/check_mcp_tools.py
@@ -16,12 +16,14 @@ sys.path.insert(0, str(__import__("pathlib").Path(__file__).parents[2]))
 
 from autosearch.mcp.server import create_server  # noqa: E402
 
+# `research` is opt-in since 2026.04.24.5 (plan §P1-4); it must NOT be in the
+# default expected list and must reappear when AUTOSEARCH_LEGACY_RESEARCH=1.
 EXPECTED_TOOLS = [
-    "research",
     "health",
     "run_clarify",
     "run_channel",
     "list_skills",
+    "list_channels",
     "loop_init",
     "loop_update",
     "loop_get_gaps",
@@ -51,7 +53,7 @@ def main() -> int:
     total = len(EXPECTED_TOOLS)
     found = total - len(missing)
 
-    print(f"MCP tool check: {found}/{total} expected tools registered")
+    print(f"MCP tool check (default): {found}/{total} expected tools registered")
 
     if missing:
         print(f"  MISSING: {missing}")
@@ -60,6 +62,22 @@ def main() -> int:
 
     if missing:
         print("FAIL")
+        return 1
+
+    if "research" in registered:
+        print("FAIL: deprecated `research` tool registered by default (plan §P1-4)")
+        return 1
+
+    # Legacy opt-in check: with the env var set, research must come back.
+    os.environ["AUTOSEARCH_LEGACY_RESEARCH"] = "1"
+    try:
+        from autosearch.mcp.server import create_server as _create  # noqa: PLC0415
+
+        opt_in_tools = {t.name for t in _create()._tool_manager.list_tools()}
+    finally:
+        os.environ.pop("AUTOSEARCH_LEGACY_RESEARCH", None)
+    if "research" not in opt_in_tools:
+        print("FAIL: AUTOSEARCH_LEGACY_RESEARCH=1 did not restore `research`")
         return 1
 
     print("PASS")

--- a/tests/perf/test_mcp_rapid_calls.py
+++ b/tests/perf/test_mcp_rapid_calls.py
@@ -45,6 +45,10 @@ class _ImmediatePipeline:
 async def test_research_tool_handles_twenty_rapid_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Plan §P1-4 / Bug 6: research tool is opt-in since 2026.04.24.5.
+    # The perf test still measures rapid-call throughput against the legacy
+    # tool, so it must enable the opt-in flag before constructing the server.
+    monkeypatch.setenv("AUTOSEARCH_LEGACY_RESEARCH", "1")
     pipeline = _ImmediatePipeline(result=_ok_result())
     monkeypatch.setattr(mcp_server, "_default_pipeline_factory", lambda: pipeline)
     server = mcp_server.create_server()


### PR DESCRIPTION
## Summary

Bug 6 (the second one in the new fix-plan list — different from the smoke-test bug 6 we already shipped in v6).

`scripts/validate/check_mcp_tools.py` and `tests/perf/test_mcp_rapid_calls.py` were never updated when v2026.04.24.5 made `research` opt-in. They still expected `research` in the default tool list and failed manually.

- `check_mcp_tools.py`: drop `research` from `EXPECTED_TOOLS`; assert it is NOT registered by default; assert it reappears with `AUTOSEARCH_LEGACY_RESEARCH=1`. Now also requires `list_channels` (a real v2 required tool that was missing from the list).
- `tests/perf/test_mcp_rapid_calls.py`: `monkeypatch.setenv("AUTOSEARCH_LEGACY_RESEARCH", "1")` before `create_server()` so the perf-rate test can still measure throughput against the legacy tool.

## Test plan

- [x] `python scripts/validate/check_mcp_tools.py` → `21/21 expected tools registered + PASS`
- [x] `pytest tests/perf/test_mcp_rapid_calls.py -m perf` → 1 passed
- [x] `./scripts/release-gate.sh --quick` → all gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)