### PR TITLE
fix(channels): typed errors map to distinct run_channel status (Bug 1 infra + github pilot)

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -40,6 +40,14 @@ class PermanentError(Exception):
     """Raised when a channel method fails in a non-retryable way."""
 
 
+class ChannelAuthError(PermanentError):
+    """Raised when an upstream rejects the request as unauthenticated /
+    unauthorized (HTTP 401 / 403, expired cookie, missing API key the
+    channel forgot to declare). Distinct from a quiet `[]` result so the
+    host agent can surface "your key looks invalid" instead of
+    "no matches" (Bug 1 / fix-plan)."""
+
+
 @dataclass(slots=True)
 class Environment:
     """Runtime probe result: what credentials/servers/binaries are available."""

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -45,14 +45,19 @@ class ResearchResponse(BaseModel):
 class RunChannelResponse(BaseModel):
     """Structured MCP tool response for the run_channel tool.
 
-    `status` discriminates the four meaningful outcomes a host agent must
-    distinguish:
+    `status` discriminates the meaningful outcomes a host agent must distinguish:
       - `ok`: results returned (may be empty list)
+      - `no_results`: channel ran successfully but found nothing for this query
       - `not_configured`: channel exists but its requirements (env keys,
         cookies, etc.) are not met. `unmet_requires` and `fix_hint` tell
         the agent exactly what to ask the user for.
       - `unknown_channel`: the requested name is not registered at all.
-      - `channel_error`: known and configured, but the call raised.
+      - `auth_failed`: upstream rejected the request (401/403, expired cookie,
+        invalid API key) — surface "your key looks invalid" to the user
+        instead of letting it look like "no matches" (Bug 1 / fix-plan).
+      - `rate_limited`: upstream returned 429 / explicit rate-limit signal —
+        agent should backoff and retry rather than treating as a hard error.
+      - `channel_error`: any other unexpected failure.
     """
 
     channel: str
@@ -691,13 +696,18 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             )
             if should_compact(channel_name):
                 compact(channel_name)
-            from autosearch.channels.base import RateLimited
+            from autosearch.channels.base import ChannelAuthError, RateLimited
             from autosearch.core.redact import redact
 
-            # Rate limit is a recoverable failure category — surface it as its
-            # own status so the host agent can backoff/retry instead of
-            # treating it like a hard channel error.
-            status = "rate_limited" if isinstance(exc, RateLimited) else "channel_error"
+            # Bug 1 (fix-plan): map known typed channel errors to distinct
+            # status values so an authentication failure / rate limit doesn't
+            # masquerade as "channel_error" or — worse — empty results.
+            if isinstance(exc, ChannelAuthError):
+                status = "auth_failed"
+            elif isinstance(exc, RateLimited):
+                status = "rate_limited"
+            else:
+                status = "channel_error"
             return RunChannelResponse(
                 channel=channel_name,
                 ok=False,

--- a/autosearch/skills/channels/github/methods/search_public_repos.py
+++ b/autosearch/skills/channels/github/methods/search_public_repos.py
@@ -5,6 +5,12 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import (
+    ChannelAuthError,
+    PermanentError,
+    RateLimited,
+    TransientError,
+)
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="github")
@@ -57,24 +63,42 @@ async def search(
         "order": "desc",
     }
 
+    # Bug 1 (fix-plan): distinguish "GitHub returned zero results" (legit empty)
+    # from network failures, auth rejection (401/403), rate limits (429), and
+    # malformed payloads. Each maps to a typed exception the MCP boundary
+    # translates into a distinct status — so a 401 on a misconfigured token
+    # no longer looks like "no matches found".
     try:
         if http_client is not None:
             response = await http_client.get(BASE_URL, params=params, headers=headers)
         else:
             async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
                 response = await client.get(BASE_URL, params=params, headers=headers)
+    except httpx.HTTPError as exc:
+        LOGGER.warning("github_search_public_repos_network_failed", reason=str(exc))
+        raise TransientError(f"github network error: {exc}") from exc
 
+    if response.status_code in (401, 403):
+        LOGGER.warning("github_search_public_repos_auth_failed", status=response.status_code)
+        raise ChannelAuthError(f"github rejected request (HTTP {response.status_code})")
+    if response.status_code == 429:
+        LOGGER.warning("github_search_public_repos_rate_limited")
+        raise RateLimited("github rate limit (HTTP 429)")
+    try:
         response.raise_for_status()
-        payload = response.json()
-        if not isinstance(payload, Mapping):
-            raise ValueError("invalid payload")
+    except httpx.HTTPStatusError as exc:
+        LOGGER.warning("github_search_public_repos_http_error", status=response.status_code)
+        raise TransientError(f"github HTTP {response.status_code}") from exc
 
-        items = payload.get("items")
-        if not isinstance(items, list):
-            raise ValueError("invalid items payload")
-    except Exception as exc:
-        LOGGER.warning("github_search_public_repos_failed", reason=str(exc))
-        return []
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise PermanentError(f"github returned non-JSON payload: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise PermanentError("github payload was not a JSON object")
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise PermanentError("github payload missing 'items' list (schema changed?)")
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/tests/channels/github/test_search_public_repos.py
+++ b/tests/channels/github/test_search_public_repos.py
@@ -143,28 +143,32 @@ async def test_search_sets_user_agent_and_accept_headers() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_returns_empty_on_http_error(
+async def test_search_raises_auth_error_on_403(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Bug 1 (fix-plan): a 401/403 must raise ChannelAuthError so the MCP
+    boundary returns status='auth_failed' instead of 'no_results'."""
+    from autosearch.channels.base import ChannelAuthError
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(403, json={"message": "rate limited"}, request=request)
+        return httpx.Response(403, json={"message": "Forbidden"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
-    assert logger.events
-    assert logger.events[0][0] == "github_search_public_repos_failed"
-    assert "403" in str(logger.events[0][1]["reason"])
+        with pytest.raises(ChannelAuthError):
+            await search(_query(), http_client=http_client)
 
 
 @pytest.mark.asyncio
-async def test_search_returns_empty_on_malformed_payload(
+async def test_search_raises_permanent_error_on_malformed_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Bug 1: a schema-shape change should raise PermanentError, not silently
+    return [] (which would look identical to a real empty result)."""
+    from autosearch.channels.base import PermanentError
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -172,12 +176,23 @@ async def test_search_returns_empty_on_malformed_payload(
         return httpx.Response(200, json={"total_count": 0}, request=request)
 
     async with _client(handler) as http_client:
+        with pytest.raises(PermanentError):
+            await search(_query(), http_client=http_client)
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_zero_real_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity: a real empty result (200 OK + items=[]) still returns [] —
+    the typed exceptions only fire on actual upstream failures."""
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"total_count": 0, "items": []}, request=request)
+
+    async with _client(handler) as http_client:
         results = await search(_query(), http_client=http_client)
 
     assert results == []
-    assert logger.events == [
-        (
-            "github_search_public_repos_failed",
-            {"reason": "invalid items payload"},
-        )
-    ]

--- a/tests/unit/test_run_channel_typed_status.py
+++ b/tests/unit/test_run_channel_typed_status.py
@@ -1,0 +1,97 @@
+"""Bug 1 (fix-plan): when a channel raises a typed error
+(`ChannelAuthError`, `RateLimited`, anything else), `run_channel` returns a
+distinct `status` so the host agent knows the difference between
+"actually no results" and "the channel is broken / rate-limited / 401".
+
+Pre-fix: every channel did `except Exception: return []`, so failures looked
+identical to legit empty results (`status="no_results"`)."""
+
+from __future__ import annotations
+
+import pytest
+
+import autosearch.mcp.server as mcp_server
+from autosearch.channels.base import ChannelAuthError, RateLimited
+from autosearch.core.channel_runtime import reset_channel_runtime
+
+
+class _RaisingChannel:
+    """Test channel that raises a configurable exception on every search()."""
+
+    languages = ["en"]
+
+    def __init__(self, name: str, exc: Exception) -> None:
+        self.name = name
+        self._exc = exc
+
+    async def search(self, _query):  # noqa: ANN001
+        raise self._exc
+
+
+class _EmptyChannel:
+    languages = ["en"]
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def search(self, _query):  # noqa: ANN001
+        return []
+
+
+@pytest.fixture
+def _stub_channel(monkeypatch, tmp_path):
+    """Replace _build_channels so run_channel sees only the stubbed channel."""
+    monkeypatch.setenv("AUTOSEARCH_LLM_MODE", "dummy")
+    monkeypatch.setenv("AUTOSEARCH_EXPERIENCE_DIR", str(tmp_path / "experience"))
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(tmp_path / "missing-secrets.env"))
+    reset_channel_runtime()
+
+    def _set(channel) -> None:
+        monkeypatch.setattr(mcp_server, "_build_channels", lambda: [channel])
+        reset_channel_runtime()
+
+    yield _set
+    reset_channel_runtime()
+
+
+async def _call_run_channel(channel_name: str):
+    server = mcp_server.create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    return await server._tool_manager.call_tool(
+        "run_channel", {"channel_name": channel_name, "query": "anything"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_returns_status_auth_failed(_stub_channel) -> None:
+    _stub_channel(_RaisingChannel("github", ChannelAuthError("HTTP 403")))
+    result = await _call_run_channel("github")
+    assert result.ok is False
+    assert result.status == "auth_failed", (
+        f"expected status='auth_failed', got '{result.status}' (Bug 1: a 401/403 "
+        "must NOT be reported as no_results / channel_error)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_returns_status_rate_limited(_stub_channel) -> None:
+    _stub_channel(_RaisingChannel("github", RateLimited("HTTP 429")))
+    result = await _call_run_channel("github")
+    assert result.ok is False
+    assert result.status == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_unknown_exception_returns_status_channel_error(_stub_channel) -> None:
+    _stub_channel(_RaisingChannel("github", RuntimeError("upstream went sideways")))
+    result = await _call_run_channel("github")
+    assert result.ok is False
+    assert result.status == "channel_error"
+
+
+@pytest.mark.asyncio
+async def test_real_empty_result_still_reports_no_results(_stub_channel) -> None:
+    """Sanity: a channel that legitimately returns [] is no_results, not an error."""
+    _stub_channel(_EmptyChannel("github"))
+    result = await _call_run_channel("github")
+    assert result.ok is True
+    assert result.status == "no_results"


### PR DESCRIPTION
## Summary

Bug 1 (fix-plan), the biggest one — channels swallowed real failures (`except Exception: return []`), the outer layer marked the call success, and `run_channel` reported `status="no_results"`. Authentication failures, 429s, schema changes, network blips all looked identical to an honest "found nothing".

This PR ships the **infra** + a **single-channel pilot** to prove the path works. Other channels migrate in follow-up PRs (can be batched to Codex).

### Infra (`autosearch/channels/base.py` + `autosearch/mcp/server.py`)
- New typed exception `ChannelAuthError(PermanentError)` for 401/403 / expired-cookie / invalid-key cases.
- `RateLimited` already existed; both now reach the MCP boundary as their own status.
- `run_channel` exception handler maps:
  - `ChannelAuthError` → `status="auth_failed"`
  - `RateLimited` → `status="rate_limited"`
  - anything else → `status="channel_error"` (unchanged catch-all)
- `RunChannelResponse` docstring updated to enumerate the full status vocabulary.

### Pilot: github channel (`autosearch/skills/channels/github/methods/search_public_repos.py`)
Replaced the broad `except Exception: return []` with explicit branches:
- `httpx.HTTPError` (network) → `TransientError`
- HTTP 401/403 → `ChannelAuthError`
- HTTP 429 → `RateLimited`
- other 4xx/5xx → `TransientError`
- non-JSON / missing `items` (schema change) → `PermanentError`
- legitimate 200 + empty `items` list → still returns `[]` (real "no matches")

### Other channels — follow-up

The remaining 30+ channel methods still do `except: return []`. They keep the old swallow behavior on this PR, then migrate one at a time (or in Codex-batched groups). Each migration is mechanical: identify the channel's HTTP/auth/parse boundaries, raise the matching typed error. `run_channel` already knows what to do with them.

## Test plan

- [x] new `tests/unit/test_run_channel_typed_status.py` (4 cases): auth_failed / rate_limited / channel_error / no_results-when-truly-empty
- [x] `tests/channels/github/test_search_public_repos.py` rewritten: 403 → ChannelAuthError, malformed payload → PermanentError, real empty → `[]`
- [x] `pytest tests/channels/github/ -v` → 6/6 PASS
- [x] `pytest tests/unit/test_run_channel_typed_status.py -v` → 4/4 PASS
- [x] `./scripts/release-gate.sh` (full) → all gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Error responses now clearly differentiate between authentication failures, rate limiting, network errors, and legitimate empty search results for better diagnostics and user feedback.

* **Tests**
  * Added comprehensive test coverage for improved error classification and empty result handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->