### PR TITLE
fix(channels): typed errors propagate from all 30+ channel adapters (Bug 1 batch)

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -6,7 +6,7 @@ import inspect
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Awaitable, Callable, Protocol, Self
+from typing import TYPE_CHECKING, Awaitable, Callable, NoReturn, Protocol, Self
 
 import structlog
 
@@ -46,6 +46,42 @@ class ChannelAuthError(PermanentError):
     channel forgot to declare). Distinct from a quiet `[]` result so the
     host agent can surface "your key looks invalid" instead of
     "no matches" (Bug 1 / fix-plan)."""
+
+
+def raise_as_channel_error(exc: BaseException) -> NoReturn:
+    """Translate a generic transport/parsing exception into the typed
+    channels.base error the MCP boundary expects.
+
+    Bug 1 (fix-plan): channel methods used to swallow errors with
+    `except Exception: return []`. That conflates "search returned nothing"
+    with "401" / "429" / "schema changed" / "network died". This helper is
+    the standard adapter — call it from a channel's broad except block to
+    propagate the failure as a typed exception the MCP layer can route to
+    the right `run_channel` status (auth_failed / rate_limited / channel_error).
+    """
+    if isinstance(exc, (ChannelAuthError, RateLimited, TransientError, PermanentError)):
+        raise exc
+
+    try:
+        import httpx  # noqa: PLC0415
+
+        if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+            status = exc.response.status_code
+            if status in (401, 403):
+                raise ChannelAuthError(str(exc)) from exc
+            if status == 429:
+                raise RateLimited(str(exc)) from exc
+            if 500 <= status < 600:
+                raise TransientError(str(exc)) from exc
+            raise PermanentError(str(exc)) from exc
+        if isinstance(exc, httpx.HTTPError):  # network / timeout / connect
+            raise TransientError(str(exc)) from exc
+    except ImportError:  # pragma: no cover — httpx is a runtime dep
+        pass
+
+    if isinstance(exc, ValueError):
+        raise PermanentError(str(exc)) from exc
+    raise TransientError(str(exc)) from exc
 
 
 @dataclass(slots=True)

--- a/autosearch/lib/tikhub_client.py
+++ b/autosearch/lib/tikhub_client.py
@@ -295,3 +295,28 @@ class TikhubClient:
             return TikhubUpstreamError(message, status_code=status_code, detail=detail)
 
         return TikhubError(message, status_code=status_code, detail=detail)
+
+
+def to_channel_error(exc: TikhubError) -> Exception:
+    """Translate a TikHub-specific error into the channels/base typed error
+    the MCP boundary knows how to map to a `run_channel` status.
+
+    Bug 1 (fix-plan): without this adapter, channel methods using TikHub
+    catch (TikhubError, ValueError) and `return []`, so a 402 budget
+    exhausted, a 429 rate limit, or a 403 auth rejection all surface as
+    `status="no_results"` — indistinguishable from a real empty search.
+    """
+    from autosearch.channels.base import (  # noqa: PLC0415 — break import cycle
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
+    if isinstance(exc, (TikhubRateLimited, TikhubBudgetExhausted)):
+        return RateLimited(str(exc))
+    if isinstance(exc, TikhubUpstreamError) and exc.status_code in (401, 403):
+        return ChannelAuthError(str(exc))
+    if isinstance(exc, TikhubUpstreamError):
+        return PermanentError(str(exc))
+    return TransientError(str(exc))

--- a/autosearch/skills/channels/arxiv/methods/api_search.py
+++ b/autosearch/skills/channels/arxiv/methods/api_search.py
@@ -7,6 +7,7 @@ import feedparser
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="arxiv")
@@ -36,12 +37,17 @@ async def search(query: SubQuery) -> list[Evidence]:
 
     try:
         entries = await _search_entries_with_retry(query.text)
-    except ArxivRateLimitError:
+    except ArxivRateLimitError as exc:
+        # Bug 1 (fix-plan): rate limit is a recoverable failure category, not
+        # an empty result. Surface as RateLimited so the host agent can back
+        # off instead of treating it as "no matches".
+        from autosearch.channels.base import RateLimited
+
         LOGGER.warning("arxiv_search_failed", reason="rate_exceeded")
-        return []
+        raise RateLimited("arxiv rate limit (rate_exceeded)") from exc
     except Exception as exc:
         LOGGER.warning("arxiv_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     results = [_to_evidence(entry, fetched_at=fetched_at) for entry in entries]
@@ -84,10 +90,9 @@ async def _fetch_entries(query_text: str) -> list[object]:
         bozo_exception = getattr(feed, "bozo_exception", None)
         raise ValueError(str(bozo_exception or "failed to parse Atom feed"))
 
-    entries = list(getattr(feed, "entries", []))
-    if not entries:
-        raise ValueError("empty feed")
-    return entries
+    # An empty feed = arxiv legitimately found nothing. Return [] so the MCP
+    # boundary surfaces status="no_results" instead of channel_error.
+    return list(getattr(feed, "entries", []))
 
 
 def _is_rate_limited(response_text: str) -> bool:

--- a/autosearch/skills/channels/bilibili/methods/via_tikhub.py
+++ b/autosearch/skills/channels/bilibili/methods/via_tikhub.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="bilibili")
 SEARCH_PATH = "/api/v1/bilibili/web/fetch_general_search"
@@ -214,7 +214,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
                 "page_size": 10,
             },
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("bilibili_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("bilibili_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/crossref/methods/api_search.py
+++ b/autosearch/skills/channels/crossref/methods/api_search.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="crossref")
@@ -204,7 +205,7 @@ async def search(
             raise ValueError("invalid items payload")
     except Exception as exc:
         LOGGER.warning("crossref_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/dblp/methods/api_search.py
+++ b/autosearch/skills/channels/dblp/methods/api_search.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="dblp")
@@ -166,7 +167,7 @@ async def search(
             raise ValueError("invalid hit payload")
     except Exception as exc:
         LOGGER.warning("dblp_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/ddgs/methods/api.py
+++ b/autosearch/skills/channels/ddgs/methods/api.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 try:
@@ -33,7 +34,7 @@ async def search(query: SubQuery) -> list[Evidence]:
         )
     except Exception as exc:
         LOGGER.warning("ddgs_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     return [_to_evidence(result, fetched_at=fetched_at) for result in results]

--- a/autosearch/skills/channels/devto/methods/api_search.py
+++ b/autosearch/skills/channels/devto/methods/api_search.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="devto")
@@ -71,7 +72,7 @@ async def search(
             raise ValueError("invalid items payload")
     except Exception as exc:
         LOGGER.warning("devto_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/dockerhub/methods/api_search.py
+++ b/autosearch/skills/channels/dockerhub/methods/api_search.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="dockerhub")
@@ -21,7 +22,7 @@ async def search(query: SubQuery) -> list[Evidence]:
         return await _search_images(query.text)
     except Exception as exc:
         LOGGER.warning("dockerhub_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
 
 async def _search_images(query: str) -> list[Evidence]:

--- a/autosearch/skills/channels/douyin/methods/via_tikhub.py
+++ b/autosearch/skills/channels/douyin/methods/via_tikhub.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="douyin")
 SEARCH_PATH = "/api/v1/douyin/search/fetch_general_search_v1"
@@ -103,7 +103,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
             SEARCH_PATH,
             {"keyword": query.text, "cursor": 0, "sort_type": "0"},
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("douyin_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("douyin_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/google_news/methods/api_search.py
+++ b/autosearch/skills/channels/google_news/methods/api_search.py
@@ -11,6 +11,7 @@ import feedparser
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="google_news")
@@ -130,7 +131,7 @@ async def search(
         feed = await asyncio.to_thread(feedparser.parse, response.text)
     except Exception as exc:
         LOGGER.warning("google_news_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     if getattr(feed, "bozo", 0) == 1:
         reason = str(getattr(feed, "bozo_exception", None) or "failed to parse RSS feed")

--- a/autosearch/skills/channels/hackernews/methods/algolia.py
+++ b/autosearch/skills/channels/hackernews/methods/algolia.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="hackernews")
@@ -52,7 +53,7 @@ async def search(query: SubQuery) -> list[Evidence]:
             raise ValueError("invalid hits payload")
     except Exception as exc:
         LOGGER.warning("hackernews_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     return [_to_evidence(hit, fetched_at=fetched_at) for hit in hits if isinstance(hit, Mapping)]

--- a/autosearch/skills/channels/huggingface_hub/methods/api_search.py
+++ b/autosearch/skills/channels/huggingface_hub/methods/api_search.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(
@@ -107,7 +108,7 @@ async def search(
             raise ValueError("invalid items payload")
     except Exception as exc:
         LOGGER.warning("huggingface_hub_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/infoq_cn/methods/api_search.py
+++ b/autosearch/skills/channels/infoq_cn/methods/api_search.py
@@ -11,6 +11,7 @@ import feedparser
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="infoq_cn")
@@ -154,7 +155,7 @@ async def search(
         feed = await asyncio.to_thread(feedparser.parse, response.text)
     except Exception as exc:
         LOGGER.warning("infoq_cn_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     if getattr(feed, "bozo", 0) == 1:
         reason = str(getattr(feed, "bozo_exception", None) or "failed to parse RSS feed")

--- a/autosearch/skills/channels/instagram/methods/via_tikhub.py
+++ b/autosearch/skills/channels/instagram/methods/via_tikhub.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="instagram")
 SEARCH_PATH = "/api/v1/instagram/v2/general_search"
@@ -68,7 +68,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
     try:
         tikhub_client = client or TikhubClient()
         payload = await tikhub_client.get(SEARCH_PATH, {"keyword": query.text})
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("instagram_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("instagram_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/kuaishou/methods/via_tikhub.py
+++ b/autosearch/skills/channels/kuaishou/methods/via_tikhub.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="kuaishou")
 SEARCH_PATH = "/api/v1/kuaishou/app/search_comprehensive"
@@ -69,7 +69,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
                 "search_scope": "all",
             },
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("kuaishou_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("kuaishou_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/openalex/methods/api_search.py
+++ b/autosearch/skills/channels/openalex/methods/api_search.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="openalex")
@@ -175,7 +176,7 @@ async def search(
             raise ValueError("invalid results payload")
     except Exception as exc:
         LOGGER.warning("openalex_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/podcast_cn/methods/api_search.py
+++ b/autosearch/skills/channels/podcast_cn/methods/api_search.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="podcast_cn")
@@ -103,7 +104,7 @@ async def search(
             raise ValueError("invalid iTunes results payload")
     except Exception as exc:
         LOGGER.warning("podcast_cn_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/pubmed/methods/api_search.py
+++ b/autosearch/skills/channels/pubmed/methods/api_search.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="pubmed")
@@ -26,7 +27,7 @@ async def search(query: SubQuery) -> list[Evidence]:
         return [_to_evidence(s) for s in summaries if s]
     except Exception as exc:
         LOGGER.warning("pubmed_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
 
 async def _esearch(query: str) -> list[str]:

--- a/autosearch/skills/channels/reddit/methods/api_search.py
+++ b/autosearch/skills/channels/reddit/methods/api_search.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="reddit")
@@ -101,7 +102,7 @@ async def search(
             raise ValueError("invalid children payload")
     except Exception as exc:
         LOGGER.warning("reddit_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/searxng/methods/api_search.py
+++ b/autosearch/skills/channels/searxng/methods/api_search.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
-from autosearch.channels.base import MethodUnavailable
+from autosearch.channels.base import MethodUnavailable, raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="searxng")
@@ -28,7 +28,7 @@ async def search(query: SubQuery) -> list[Evidence]:
         raise
     except Exception as exc:
         LOGGER.warning("searxng_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
 
 async def _do_search(base_url: str, query: str) -> list[Evidence]:

--- a/autosearch/skills/channels/sec_edgar/methods/api_search.py
+++ b/autosearch/skills/channels/sec_edgar/methods/api_search.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="sec_edgar")
@@ -122,7 +123,7 @@ async def search(
             raise ValueError("invalid items payload")
     except Exception as exc:
         LOGGER.warning("sec_edgar_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/sogou_weixin/methods/api_search.py
+++ b/autosearch/skills/channels/sogou_weixin/methods/api_search.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.html_scraper import HtmlFetchError, fetch_html, fetch_page
 
@@ -183,10 +184,10 @@ async def search(
         )
     except HtmlFetchError as exc:
         LOGGER.warning("sogou_weixin_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
     except Exception as exc:
         LOGGER.warning("sogou_weixin_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     return await asyncio.gather(
         *[_enrich_evidence(evidence, http_client=http_client) for evidence in evidences]

--- a/autosearch/skills/channels/stackoverflow/methods/api_search.py
+++ b/autosearch/skills/channels/stackoverflow/methods/api_search.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="stackoverflow")
@@ -99,7 +100,7 @@ async def search(
             raise ValueError("invalid items payload")
     except Exception as exc:
         LOGGER.warning("stackoverflow_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/tieba/methods/api_search.py
+++ b/autosearch/skills/channels/tieba/methods/api_search.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="tieba")
@@ -28,7 +29,7 @@ async def search(query: SubQuery) -> list[Evidence]:
         return await _search_tieba(query.text)
     except Exception as exc:
         LOGGER.warning("tieba_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
 
 async def _search_tieba(query: str) -> list[Evidence]:

--- a/autosearch/skills/channels/tiktok/methods/via_tikhub.py
+++ b/autosearch/skills/channels/tiktok/methods/via_tikhub.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="tiktok")
 SEARCH_PATH = "/api/v1/tiktok/app/v3/fetch_general_search_result"
@@ -87,7 +87,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
                 "publish_time": 0,
             },
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("tiktok_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("tiktok_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/twitter/methods/via_tikhub.py
+++ b/autosearch/skills/channels/twitter/methods/via_tikhub.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="twitter")
 SEARCH_PATH = "/api/v1/twitter/web/fetch_search_timeline"
@@ -87,7 +87,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
             SEARCH_PATH,
             {"keyword": query.text, "search_type": "Latest"},
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("twitter_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("twitter_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/wechat_channels/methods/via_tikhub.py
+++ b/autosearch/skills/channels/wechat_channels/methods/via_tikhub.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="wechat_channels")
 SEARCH_PATH = "/api/v1/wechat_channels/fetch_search_latest"
@@ -80,7 +80,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
             SEARCH_PATH,
             {"keywords": query.text, "count": 12},
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("wechat_channels_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("wechat_channels_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/weibo/methods/via_tikhub.py
+++ b/autosearch/skills/channels/weibo/methods/via_tikhub.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="weibo")
 SEARCH_PATH = "/api/v1/weibo/web/fetch_search"
@@ -102,7 +102,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
             SEARCH_PATH,
             {"keyword": query.text, "page": 1, "search_type": "1"},
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("weibo_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("weibo_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/wikidata/methods/api_search.py
+++ b/autosearch/skills/channels/wikidata/methods/api_search.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="wikidata")
@@ -69,7 +70,7 @@ async def search(
             raise ValueError("invalid search payload")
     except Exception as exc:
         LOGGER.warning("wikidata_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/wikipedia/methods/api_search.py
+++ b/autosearch/skills/channels/wikipedia/methods/api_search.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="wikipedia")
@@ -94,7 +95,7 @@ async def search(
             raise ValueError("invalid search payload")
     except Exception as exc:
         LOGGER.warning("wikipedia_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="xiaohongshu")
 
@@ -83,7 +83,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
             SEARCH_PATH,
             {"keyword": query.text, "page": 1, "page_size": 20, "sort": "general", "note_type": 0},
         )
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("xiaohongshu_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("xiaohongshu_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/autosearch/skills/channels/youtube/methods/data_api_v3.py
+++ b/autosearch/skills/channels/youtube/methods/data_api_v3.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="youtube")
@@ -63,7 +64,7 @@ async def search(query: SubQuery) -> list[Evidence]:
         return []
     except Exception as exc:
         LOGGER.warning("youtube_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
 
 def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidence:

--- a/autosearch/skills/channels/zhihu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/zhihu/methods/via_tikhub.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 import structlog
 
 from autosearch.core.models import Evidence, SubQuery
-from autosearch.lib.tikhub_client import TikhubClient, TikhubError
+from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="zhihu")
 SEARCH_PATH = "/api/v1/zhihu/web/fetch_article_search_v3"
@@ -75,7 +75,16 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
     try:
         tikhub_client = client or TikhubClient()
         payload = await tikhub_client.get(SEARCH_PATH, {"keyword": query.text})
-    except (TikhubError, ValueError) as exc:
+    except TikhubError as exc:
+        # Bug 1 (fix-plan): translate TikHub error → channels.base typed
+        # error so a 401/403/429/402 surfaces as auth_failed/rate_limited
+        # at the MCP boundary instead of looking like an empty result.
+        LOGGER.warning("zhihu_tikhub_search_failed", reason=str(exc))
+        raise to_channel_error(exc) from exc
+    except ValueError as exc:
+        # TikhubClient() raises ValueError on missing TIKHUB_API_KEY; the
+        # MCP boundary already returns not_configured for that case via
+        # SKILL.md requires, so this is a redundant safety net.
         LOGGER.warning("zhihu_tikhub_search_failed", reason=str(exc))
         return []
 

--- a/docs/million-user-product-readiness-plan.md
+++ b/docs/million-user-product-readiness-plan.md
@@ -1,0 +1,1073 @@
+# AutoSearch Million-User Product Readiness Repair Plan
+
+Date: 2026-04-24
+
+Scope: current checkout after the latest v2 repair round. This document focuses
+on bugs and product gaps that still block AutoSearch from being safe, reliable,
+and understandable for a large public user base.
+
+The plan intentionally focuses on fresh installs and current users of the v2
+tool-supplier architecture. Existing-user migration is out of scope unless it
+directly affects fresh-install correctness.
+
+## Executive Verdict
+
+AutoSearch is much healthier than it was before the latest repairs, but it is
+not ready for million-user distribution yet.
+
+The current release gate passes:
+
+```bash
+scripts/release-gate.sh --quick
+uv run pytest -q -m "not real_llm and not perf and not slow and not network" -x
+uv build --wheel
+```
+
+Observed result:
+
+- quick release gate passed;
+- default non-live test suite passed: 818 passed, 21 deselected;
+- wheel build succeeded;
+- `autosearch doctor --json` returns a valid channel list;
+- `autosearch mcp-check` reports the 10 required v2 tools.
+
+However, the current gates do not catch several production blockers:
+
+- configured secrets can be visible to `doctor` but invisible to the actual
+  channel method;
+- channels with missing implementation files can be reported as available;
+- `run_channel` still reports some configured-off channels as `unknown_channel`;
+- channel errors can leak secret-looking strings into MCP tool responses;
+- runtime health/circuit breaker state is recreated per call;
+- `rate_limit` metadata is declared but not enforced;
+- public docs and some E2B matrices still describe the old v1 research/report
+  contract;
+- npm/install paths still execute remote mutable scripts by default.
+
+The next repair round should not add channels. It should make the existing v2
+contract true end to end.
+
+## Current Product Contract
+
+The product should be described and tested as:
+
+1. User installs AutoSearch.
+2. User runs `autosearch doctor`.
+3. User runs `autosearch mcp-check`.
+4. User connects AutoSearch as an MCP server.
+5. The host agent calls:
+   - `list_channels`
+   - `list_skills`
+   - `run_clarify`
+   - `select_channels_tool`
+   - `run_channel`
+   - `citation_create`
+   - `citation_add`
+   - `citation_export`
+   - optional workflow helpers such as `consolidate_research`
+6. The host agent synthesizes the final answer.
+
+AutoSearch should not be marketed as a standalone one-command report generator.
+The deprecated `query` CLI and deprecated MCP `research` tool must stay out of
+the default happy path.
+
+## Evidence Collected
+
+The audit verified these commands locally:
+
+```bash
+scripts/release-gate.sh --quick
+uv run pytest -q -m "not real_llm and not perf and not slow and not network" -x
+uv run autosearch --version
+uv run autosearch doctor --json
+uv run autosearch mcp-check
+uv build --wheel
+```
+
+Focused probes also checked:
+
+- secrets-file-only YouTube configuration;
+- missing channel implementations;
+- `run_channel` behavior for unconfigured known channels;
+- secret leakage through exception messages;
+- wheel content;
+- stale documentation and E2B contract text.
+
+## Critical Findings
+
+### P0-1. Secrets File Visibility Is Split Between Doctor And Runtime
+
+`autosearch configure` and `autosearch login` write to a secrets file. The new
+`autosearch.core.secrets_store` module lets `doctor` and environment probing see
+keys from that file.
+
+But many actual runtime methods still read only process environment variables:
+
+- `autosearch/skills/channels/youtube/methods/data_api_v3.py`
+- `autosearch/lib/tikhub_client.py`
+- `autosearch/llm/providers/openai.py`
+- `autosearch/llm/providers/anthropic.py`
+- `autosearch/llm/providers/gemini.py`
+- `autosearch/skills/tools/fetch-firecrawl/methods/scrape.py`
+- video transcription tools
+
+Reproduction:
+
+```bash
+tmpd="$(mktemp -d)"
+printf 'YOUTUBE_API_KEY=dummy-key\n' > "$tmpd/secrets.env"
+
+env -u YOUTUBE_API_KEY \
+  AUTOSEARCH_SECRETS_FILE="$tmpd/secrets.env" \
+  AUTOSEARCH_EXPERIENCE_DIR="$tmpd/experience" \
+  uv run python - <<'PY'
+import asyncio, os
+from autosearch.core.doctor import scan_channels
+from autosearch.mcp.server import create_server
+
+print("env_youtube=", bool(os.environ.get("YOUTUBE_API_KEY")))
+print("doctor_youtube=", [
+    (r.status, r.message) for r in scan_channels() if r.channel == "youtube"
+])
+
+async def main():
+    tm = create_server()._tool_manager
+    res = await tm.call_tool(
+        "run_channel",
+        {"channel_name": "youtube", "query": "test", "k": 1},
+    )
+    print(res.model_dump())
+
+asyncio.run(main())
+PY
+```
+
+Observed behavior:
+
+- process env does not contain `YOUTUBE_API_KEY`;
+- `doctor` reports YouTube as `ok`;
+- `run_channel` returns `ok=True`;
+- evidence is empty;
+- `reason=None`;
+- logs show the method skipped because there was no API key.
+
+Impact:
+
+- user believes configuration succeeded;
+- agent believes channel succeeded;
+- no useful evidence is returned;
+- release gate does not catch this.
+
+Required fix:
+
+- Introduce a single runtime configuration API for secret values.
+- Either inject secrets-file values into process env at CLI/MCP startup, or
+  replace direct `os.getenv()` calls with `resolve_env_value()`.
+- Ensure environment variables still override file values.
+- Add tests where the secret exists only in `AUTOSEARCH_SECRETS_FILE`.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_secrets_store.py
+uv run pytest tests/unit/test_runtime_secrets_contract.py
+```
+
+The required contract:
+
+- if `doctor` says a method is configured because of a secrets-file key, the
+  actual method must see the same key;
+- if the actual method cannot see the key, `doctor` must not report that method
+  as available.
+
+### P0-2. Doctor Can Report Missing Implementations As Available
+
+Several channel methods are declared in `SKILL.md` but their implementation
+files do not exist in the current runtime package.
+
+Observed missing declarations:
+
+```text
+bilibili      api_video_detail       methods/api_video_detail.py
+douyin        via_douyin_mcp         methods/via_douyin_mcp.py
+github        search_repositories    methods/search_repos.py
+github        search_issues          methods/search_issues.py
+github        search_code            methods/search_code.py
+twitter       api_search             methods/api_search.py
+xiaohongshu   via_mcporter           methods/via_mcporter.py
+xiaohongshu   via_xhs_cli            methods/via_xhs_cli.py
+zhihu         api_search             methods/api_search.py
+zhihu         api_answer_detail      methods/api_answer.py
+```
+
+Reproduction:
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+from autosearch.skills.loader import load_all
+
+root = Path("autosearch/skills/channels")
+missing = []
+for spec in load_all(root):
+    for method in spec.methods:
+        if not (spec.skill_dir / method.impl).is_file():
+            missing.append((spec.name, method.id, method.impl))
+
+print("missing_count", len(missing))
+for row in missing:
+    print(row)
+PY
+```
+
+Doctor currently computes availability from declared requirements, not from
+compiled method availability. That means a method with a satisfied key but
+missing implementation can be counted as available.
+
+Impact:
+
+- status output overstates real channel coverage;
+- users configure keys and still hit fallback paths;
+- support diagnostics will mislead maintainers;
+- channel governance numbers are not trustworthy.
+
+Required fix:
+
+- Make `doctor.scan_channels()` use the same compiled method model as
+  `ChannelRegistry`.
+- Count `impl_missing` as unavailable.
+- Include missing implementations in JSON output.
+- Add a static test that all declared method impl files exist unless explicitly
+  marked as planned/disabled.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_channel_skill_scaffolds.py
+uv run pytest tests/unit/test_doctor_impl_availability.py
+```
+
+Expected behavior:
+
+- missing impls never count as available;
+- `doctor --json` exposes `impl_missing`;
+- release gate fails if new missing impl declarations are introduced.
+
+### P0-3. run_channel Confuses Known But Unconfigured Channels With Unknown Channels
+
+When a channel is known but not configured, `run_channel` should return a
+recoverable `not_configured` response with fix hints.
+
+Current behavior:
+
+```bash
+tmpd="$(mktemp -d)"
+
+env -u YOUTUBE_API_KEY \
+  AUTOSEARCH_SECRETS_FILE="$tmpd/missing.env" \
+  AUTOSEARCH_EXPERIENCE_DIR="$tmpd/experience" \
+  uv run python - <<'PY'
+import asyncio
+from autosearch.core.doctor import scan_channels
+from autosearch.mcp.server import create_server
+
+print([
+    {"channel": r.channel, "status": r.status, "fix_hint": r.fix_hint}
+    for r in scan_channels() if r.channel == "youtube"
+])
+
+async def main():
+    res = await create_server()._tool_manager.call_tool(
+        "run_channel",
+        {"channel_name": "youtube", "query": "test"},
+    )
+    print(res.model_dump())
+
+asyncio.run(main())
+PY
+```
+
+Observed:
+
+- `doctor` knows YouTube is `off` and gives a fix hint;
+- `run_channel("youtube")` returns `unknown_channel`;
+- the user does not get the YouTube-specific fix hint.
+
+Impact:
+
+- agents cannot self-repair setup;
+- users see contradictory diagnostics;
+- configured-off channels look like typos.
+
+Required fix:
+
+- Return all known channel metadata from the runtime registry.
+- Keep separate sets for:
+  - known channel;
+  - available channel;
+  - configured-off channel;
+  - unknown channel.
+- Change `RunChannelResponse` to include:
+  - `status`: `ok | no_results | not_configured | unknown_channel | channel_error`
+  - `unmet_requires`
+  - `fix_hint`
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_mcp_run_channel.py
+```
+
+Expected behavior:
+
+- `run_channel("youtube")` without key returns `not_configured`;
+- response includes `env:YOUTUBE_API_KEY`;
+- response includes `autosearch configure YOUTUBE_API_KEY <your-key>`.
+
+### P0-4. MCP Tool Responses Can Leak Secret-Looking Error Messages
+
+`run_channel` catches all exceptions and includes `str(exc)` in the MCP response.
+
+Reproduction:
+
+```bash
+AUTOSEARCH_EXPERIENCE_DIR="$(mktemp -d)" uv run python - <<'PY'
+import asyncio
+from autosearch.mcp.server import create_server
+
+class BadChannel:
+    name = "arxiv"
+    languages = ["en"]
+
+    async def search(self, query):
+        raise RuntimeError(
+            "upstream rejected Authorization: Bearer sk-ant-SECRETSECRETSECRETSECRET"
+        )
+
+async def main():
+    import autosearch.mcp.server as server_mod
+    server_mod._build_channels = lambda: [BadChannel()]
+    res = await create_server()._tool_manager.call_tool(
+        "run_channel",
+        {"channel_name": "arxiv", "query": "x"},
+    )
+    print(res.model_dump())
+
+asyncio.run(main())
+PY
+```
+
+Observed:
+
+- the secret-looking Bearer token appears in `reason`.
+
+Impact:
+
+- a channel library, upstream response, or accidental exception can expose
+  credentials to an MCP client transcript;
+- users may paste leaked credentials into issues or logs;
+- diagnostics redaction does not protect live tool responses.
+
+Required fix:
+
+- Move redaction to a shared runtime utility.
+- Apply redaction at every CLI/MCP boundary:
+  - `run_channel`
+  - `run_clarify`
+  - `research`
+  - `delegate_subtask`
+  - `citation_*`
+  - `doctor`
+- Return stable error categories instead of raw exception text where possible.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_secret_redaction.py
+uv run pytest tests/unit/test_mcp_error_redaction.py
+```
+
+Expected behavior:
+
+- no `sk-`, `sk-ant-`, `Bearer`, `Cookie:`, or token-shaped value appears in
+  MCP response text;
+- the user still sees a useful error category and next action.
+
+### P0-5. ChannelHealth Is Recreated Per Call
+
+The runtime now attaches `ChannelHealth`, but `_build_channels()` creates a new
+registry and a new `ChannelHealth()` each time.
+
+Impact:
+
+- failure state does not persist across MCP tool calls;
+- circuit breaker is mostly local to one short-lived registry;
+- cooldown behavior is not useful under real user traffic.
+
+Required fix:
+
+- Create a server-lifecycle `ChannelRuntime` object.
+- Store:
+  - compiled registry;
+  - shared `ChannelHealth`;
+  - limiter state;
+  - last error summaries;
+  - optional reload timestamp.
+- Inject this runtime into MCP tools.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_channel_bootstrap_health.py
+uv run pytest tests/unit/test_mcp_runtime_health_persistence.py
+```
+
+Expected behavior:
+
+- repeated failures across separate `run_channel` tool calls enter cooldown;
+- `health()` and `doctor()` can report cooldown state.
+
+### P0-6. Declared Method rate_limit Is Not Enforced
+
+Channel `SKILL.md` files declare `rate_limit`, but runtime does not enforce it.
+
+Impact:
+
+- free upstreams can be hammered;
+- paid providers such as TikHub can burn budget unexpectedly;
+- rate-limit metadata gives a false sense of safety.
+
+Required fix:
+
+- Add per-method limiter keyed by `(channel, method)`.
+- Start with in-process limits:
+  - `per_min`
+  - `per_hour`
+  - optional concurrency cap
+- Return structured `rate_limited` status when exceeded.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_channel_rate_limit.py
+```
+
+Expected behavior:
+
+- parallel calls obey the declared method limit;
+- exceeded limit does not call upstream;
+- response includes reset or retry-after guidance where available.
+
+## High Priority Product Gaps
+
+### P1-1. Public Docs Still Describe The Old Product
+
+Stale examples remain in:
+
+- `README.md`
+- `README.zh.md`
+- `docs/install.md`
+- `docs/mcp-clients.md`
+- plugin metadata
+
+Examples:
+
+- README still says AutoSearch is an open-source deep research replacement.
+- README still says AutoSearch fixes the problem in one line.
+- README still shows `Always-on (21/21)`.
+- install docs still show old MCP config shape.
+- MCP docs still say the server exposes two tools and that `research` is the
+  main entry point.
+
+Required fix:
+
+- Rewrite public docs around the v2 MCP tool-supplier contract.
+- Make `doctor + mcp-check + run_channel` the happy path.
+- Move `query` and `research` to legacy migration docs only.
+- Update examples to match current channel counts and current config writers.
+
+Acceptance:
+
+```bash
+rg -n "Always-on \\(21/21\\)|21/37|Use the research tool|main deep-research entry point|autosearch query" README.md README.zh.md docs
+```
+
+Expected behavior:
+
+- no match in primary docs;
+- legacy docs may mention old paths only when clearly labeled deprecated.
+
+### P1-2. E2B Contract Tests Still Miss Some Old v1 Expectations
+
+`tests/unit/test_e2b_matrix_contract.py` only checks selected matrix files.
+
+Stale v1 expectations still exist in:
+
+- `tests/e2b/matrix-extensions.yaml`
+- `tests/e2b/matrix-w1w4-bench.yaml`
+
+Required fix:
+
+- Expand the matrix contract test to scan all `tests/e2b/*.yaml`.
+- Allow old `query` checks only when they explicitly assert deprecation.
+- Disallow `stdout_contains: "References"` in release or extension gates.
+- Disallow prompts telling agents to use the deprecated `research` tool.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_e2b_matrix_contract.py
+rg -n "stdout_contains: \"References\"|Use the research tool|call_tool\\(\"research\"" tests/e2b
+```
+
+### P1-3. configure/login Still Put Secrets On Command Lines
+
+Current `configure` takes the secret value as a required argument.
+
+Risks:
+
+- shell history leak;
+- process-list leak;
+- no non-interactive `--stdin`;
+- no explicit permission hardening;
+- existing keys require manual edits.
+
+Required fix:
+
+- Change `autosearch configure KEY` to prompt with hidden input by default.
+- Add `--stdin` for automation.
+- Add `--yes` or equivalent for tests.
+- Add `--replace` for existing keys.
+- Set secrets file mode to `0600`.
+- For `login --from-string`, prefer stdin or hidden prompt.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_cli_configure.py
+uv run pytest tests/unit/test_cli_login.py
+```
+
+Expected behavior:
+
+- no secret argument is required on the CLI;
+- file permissions are `0600`;
+- replacing a key is explicit and tested.
+
+### P1-4. Deprecated research Tool Is Still Listed By Default
+
+The MCP `research` tool is registered and visible in tool lists even though it
+returns a deprecation response by default.
+
+Impact:
+
+- LLMs are likely to choose the attractive high-level tool name;
+- users see a tool that product docs should no longer promote;
+- compatibility surface remains larger than needed.
+
+Required fix:
+
+- Default: do not register `research`.
+- Compatibility mode: register `legacy_research` only when
+  `AUTOSEARCH_LEGACY_RESEARCH=1`.
+- If removing registration is too risky, rename to `legacy_research` and mark
+  it deprecated in the description.
+
+Acceptance:
+
+```bash
+uv run autosearch mcp-check
+```
+
+Expected behavior:
+
+- required v2 tools are present;
+- default tool list does not include `research`;
+- legacy opt-in has its own explicit test.
+
+### P1-5. MCP health() Is Not A Real Health Report
+
+Current `health()` returns only `ok`.
+
+Required fix:
+
+Return structured data:
+
+- AutoSearch version;
+- tool count;
+- required tool status;
+- channel counts by status and tier;
+- secrets file exists / key count, without values;
+- MCP client config status if available;
+- runtime health cooldown snapshot;
+- last error summary, redacted.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_mcp_health.py
+```
+
+### P1-6. delegate_subtask Bypasses run_channel Semantics
+
+`delegate_subtask` directly calls channels and returns slim dicts. It bypasses:
+
+- not-configured semantics;
+- redaction;
+- BM25/rerank pipeline;
+- future rate limiter;
+- future shared health;
+- citation-ready output.
+
+Required fix:
+
+- Extract a shared internal `run_channel_core()` function.
+- Make both `run_channel` and `delegate_subtask` use it.
+- Preserve parallelism with a configurable concurrency cap.
+
+Acceptance:
+
+```bash
+uv run pytest tests/test_delegate.py
+uv run pytest tests/unit/test_mcp_run_channel.py
+```
+
+## Install And Release Trust
+
+### P1-7. install.sh Uses Mutable main And Runs init Automatically
+
+Current installer uses:
+
+```bash
+https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh
+```
+
+and runs:
+
+```bash
+autosearch init
+```
+
+Required fix:
+
+- support `--version`;
+- support `--dry-run`;
+- support `--no-init`;
+- prefer pinned release URL in docs;
+- show source URL before execution;
+- avoid modifying shell profiles unless user accepts.
+
+Acceptance:
+
+```bash
+bash scripts/install.sh --dry-run
+bash scripts/install.sh --dry-run --no-init
+bash scripts/install.sh --dry-run --version 2026.04.24.1
+```
+
+### P1-8. npm postinstall Executes Remote Installer
+
+`npm/package.json` still has:
+
+```json
+"postinstall": "node bin/autosearch-ai.js"
+```
+
+The wrapper runs:
+
+```bash
+curl -fsSL .../main/scripts/install.sh | bash
+```
+
+Required fix:
+
+- remove `postinstall`;
+- make `npx autosearch-ai` an explicit launcher only;
+- do not execute remote scripts during npm install;
+- add a confirmation step unless `--yes` is passed;
+- provide a no-network diagnostic path.
+
+Acceptance:
+
+```bash
+cd npm
+npm pack
+npm install --ignore-scripts ./autosearch-ai-*.tgz
+```
+
+Expected behavior:
+
+- install does not run remote scripts;
+- explicit `npx autosearch-ai` is the only execution path.
+
+### P1-9. Release Workflow npm Summary Computes The Wrong Version Link
+
+The release workflow publishes npm with `derive_npm_version()`, but the summary
+computes a different version string using `YEAR.MMDD.SEQ`.
+
+Required fix:
+
+- use the same Python helper for the summary.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_release_gate_script.py
+```
+
+Add a test that asserts `release.yml` does not manually compute npm version
+with a separate formula.
+
+## Cross-Platform And Packaging
+
+### P1-10. Cross-Platform Experience Test Uses The Old Path Contract
+
+The Windows workflow mutates `_SKILLS_ROOT` and expects experience writes under
+that directory. The current runtime experience path uses
+`AUTOSEARCH_EXPERIENCE_DIR` or `~/.autosearch/experience`.
+
+Required fix:
+
+- Set `AUTOSEARCH_EXPERIENCE_DIR` in the workflow test.
+- Assert the new runtime path, not the bundled skill root.
+
+Acceptance:
+
+```bash
+pytest tests/unit/test_experience_runtime_isolation.py
+```
+
+and the GitHub `cross-platform.yml` workflow should pass on Windows and macOS.
+
+### P2-1. Wheel Still Ships Legacy Pipeline And Server Modules
+
+The wheel still contains:
+
+- `autosearch/core/pipeline.py`
+- `autosearch/server/main.py`
+- `autosearch/server/openai_compat.py`
+- `autosearch/synthesis/report.py`
+- `autosearch/synthesis/section.py`
+
+This is not immediately fatal, but it increases the accidental public surface.
+
+Required fix:
+
+- decide whether these are supported legacy modules;
+- if not supported, move behind a legacy extra or remove from runtime package;
+- if supported, document and test them explicitly.
+
+Acceptance:
+
+```bash
+uv build --wheel
+python -m zipfile -l dist/autosearch-*.whl | rg "autosearch/core/pipeline|autosearch/server|autosearch/synthesis/report"
+```
+
+The expected output must match the product decision.
+
+### P2-2. Bundled Experience Seeds Need A Clear Policy
+
+Runtime experience writes are now moved out of the package tree, which is good.
+The wheel still includes seed experience files such as:
+
+- `autosearch/skills/channels/bilibili/experience.md`
+- `autosearch/skills/channels/github/experience.md`
+- `autosearch/skills/channels/linkedin/experience/experience.md`
+- `autosearch/skills/channels/xueqiu/experience/experience.md`
+
+Required fix:
+
+- decide whether seed digests are allowed package data;
+- remove any raw `patterns.jsonl` from package data;
+- standardize seed digest path as either `<skill>/experience.md` or
+  `<skill>/experience/experience.md`, not both.
+
+Acceptance:
+
+```bash
+uv build --wheel
+wheel="$(ls -1t dist/*.whl | head -1)"
+python -m zipfile -l "$wheel" | rg "experience/(patterns\\.jsonl|experience\\.md)|/experience\\.md"
+```
+
+No raw `patterns.jsonl` should ship.
+
+### P2-3. Experience Stores Raw Query Text
+
+Runtime location is safer now, but `append_event()` still stores raw `query`.
+
+Required fix:
+
+- redact obvious secrets and PII before writing;
+- consider hashing query text by default;
+- make raw-query capture opt-in.
+
+Acceptance:
+
+```bash
+uv run pytest tests/unit/test_experience_redaction.py
+```
+
+Expected behavior:
+
+- API keys, cookies, Bearer tokens, email addresses, and phone-like strings do
+  not appear in runtime experience files.
+
+## Release Gate Upgrades
+
+The release gate should fail on real product-contract breakage, not only on
+lint and basic CLI surface.
+
+Add these gates:
+
+### Gate A. Secrets Runtime Contract
+
+```bash
+uv run pytest tests/unit/test_runtime_secrets_contract.py
+```
+
+Must prove:
+
+- secrets-file-only key is visible to the method that uses it;
+- `doctor` and `run_channel` agree.
+
+### Gate B. Channel Implementation Integrity
+
+```bash
+uv run pytest tests/unit/test_channel_impl_integrity.py
+```
+
+Must prove:
+
+- every non-planned method has a real impl file;
+- missing impls cannot count as available.
+
+### Gate C. MCP Error Redaction
+
+```bash
+uv run pytest tests/unit/test_mcp_error_redaction.py
+```
+
+Must prove:
+
+- secret-looking strings never appear in MCP tool responses.
+
+### Gate D. Known-Off Channel Semantics
+
+```bash
+uv run pytest tests/unit/test_mcp_run_channel_not_configured.py
+```
+
+Must prove:
+
+- known but unconfigured channels return `not_configured`, not `unknown_channel`.
+
+### Gate E. Docs Contract
+
+```bash
+uv run pytest tests/unit/test_docs_contract.py
+```
+
+Must scan:
+
+- `README.md`
+- `README.zh.md`
+- `docs/install.md`
+- `docs/mcp-clients.md`
+- `npm/package.json`
+- `.claude-plugin/*.json`
+
+Must reject default-path claims such as:
+
+- `Always-on (21/21)`
+- `21/37`
+- `Use the research tool`
+- `main deep-research entry point`
+- `OpenAI and Perplexity Deep Research alternative`
+
+Legacy docs can mention old paths only with clear deprecation language.
+
+### Gate F. E2B Matrix Contract
+
+```bash
+uv run pytest tests/unit/test_e2b_matrix_contract.py
+```
+
+Must scan every `tests/e2b/*.yaml`, not just the main matrix.
+
+Must reject:
+
+- `stdout_contains: "References"` in default v2 gates;
+- prompts that tell the agent to use deprecated `research`;
+- `autosearch query` unless the task explicitly asserts deprecation.
+
+### Gate G. Package Content
+
+```bash
+uv build --wheel
+uv run pytest tests/unit/test_package_contents.py
+```
+
+Must prove:
+
+- no raw runtime `patterns.jsonl` in wheel;
+- runtime deps do not include `pytest` or `ruff`;
+- version files are consistent;
+- published package contents match intentional policy.
+
+## Repair Roadmap
+
+### Batch 1: Runtime Truth
+
+Goal: make status, config, and runtime behavior agree.
+
+Tasks:
+
+1. Add runtime secrets contract tests.
+2. Replace or wrap direct `os.getenv()` uses in channels/providers.
+3. Make doctor use compiled method availability.
+4. Add missing-impl integrity test.
+5. Change `run_channel` to return `not_configured` for known-off channels.
+6. Add structured status to `RunChannelResponse`.
+
+Verification:
+
+```bash
+uv run pytest tests/unit/test_secrets_store.py
+uv run pytest tests/unit/test_runtime_secrets_contract.py
+uv run pytest tests/unit/test_channel_impl_integrity.py
+uv run pytest tests/unit/test_mcp_run_channel.py
+```
+
+### Batch 2: Safety Boundaries
+
+Goal: no secrets leak through normal support or MCP paths.
+
+Tasks:
+
+1. Move redaction to a shared utility.
+2. Redact all CLI/MCP boundary error strings.
+3. Add experience redaction.
+4. Harden `configure` and `login` input paths.
+
+Verification:
+
+```bash
+uv run pytest tests/unit/test_secret_redaction.py
+uv run pytest tests/unit/test_mcp_error_redaction.py
+uv run pytest tests/unit/test_experience_redaction.py
+uv run pytest tests/unit/test_cli_configure.py
+```
+
+### Batch 3: Runtime Reliability
+
+Goal: make health, cooldown, and rate limits real.
+
+Tasks:
+
+1. Add `ChannelRuntime`.
+2. Persist `ChannelHealth` across MCP tool calls.
+3. Add rate limiter.
+4. Make `delegate_subtask` use shared channel core.
+5. Upgrade `health()` to structured report.
+
+Verification:
+
+```bash
+uv run pytest tests/unit/test_mcp_runtime_health_persistence.py
+uv run pytest tests/unit/test_channel_rate_limit.py
+uv run pytest tests/test_delegate.py
+uv run pytest tests/unit/test_mcp_health.py
+```
+
+### Batch 4: Product Contract Cleanup
+
+Goal: docs, examples, matrices, and plugin metadata tell the same story.
+
+Tasks:
+
+1. Rewrite README and README.zh.
+2. Rewrite install docs.
+3. Rewrite MCP client docs.
+4. Update plugin metadata.
+5. Update E2B extension and bench matrices.
+6. Expand docs and matrix contract tests.
+
+Verification:
+
+```bash
+uv run pytest tests/unit/test_docs_contract.py
+uv run pytest tests/unit/test_e2b_matrix_contract.py
+rg -n "Always-on \\(21/21\\)|21/37|Use the research tool|main deep-research entry point" README.md README.zh.md docs tests/e2b
+```
+
+### Batch 5: Install Trust
+
+Goal: reduce surprise execution and improve enterprise acceptability.
+
+Tasks:
+
+1. Add install script flags: `--dry-run`, `--no-init`, `--version`.
+2. Update docs to prefer pinned release installs.
+3. Remove npm `postinstall`.
+4. Require explicit execution for remote install.
+5. Fix release npm summary version calculation.
+
+Verification:
+
+```bash
+bash scripts/install.sh --dry-run
+bash scripts/install.sh --dry-run --no-init
+cd npm && npm pack
+uv run pytest tests/unit/test_release_gate_script.py
+```
+
+### Batch 6: Release Gate Integration
+
+Goal: prevent the same regressions from returning.
+
+Tasks:
+
+1. Add new gate tests from this document.
+2. Wire them into `scripts/release-gate.sh`.
+3. Run the full gate in release workflow, not only `--quick`, or make `--quick`
+   include all contract tests.
+
+Verification:
+
+```bash
+scripts/release-gate.sh
+```
+
+## Final Acceptance Bar
+
+AutoSearch can be considered public-release ready when all of these are true:
+
+- A fresh user can install, run `doctor`, run `mcp-check`, and use at least one
+  free channel through MCP without reading source code.
+- If a channel is unconfigured, `run_channel` returns a precise fix hint.
+- If `doctor` reports a method available, the actual method can use the same
+  configuration source.
+- Missing implementation files cannot count as available.
+- MCP responses and diagnostics do not leak secret-looking strings.
+- Runtime health and rate-limit state persist across tool calls.
+- Docs no longer direct users to deprecated `query` or `research` as the happy path.
+- npm install does not silently execute remote scripts.
+- Release gate catches stale docs, stale E2B expectations, secret leaks, and
+  channel availability false positives.
+
+## Do Not Prioritize Yet
+
+Do not prioritize these before the P0/P1 items above:
+
+- adding more channels;
+- improving report prose;
+- large benchmark expansions;
+- new synthesis pipelines;
+- legacy `query` resurrection;
+- UI or dashboard work.
+
+The current bottleneck is not channel count. The bottleneck is trust: status must
+be truthful, configuration must really work, failures must be safe, and the docs
+must describe the product that actually ships.

--- a/tests/channels/arxiv/test_api_search.py
+++ b/tests/channels/arxiv/test_api_search.py
@@ -73,23 +73,37 @@ async def test_search_returns_evidence(search, subquery):
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_http_error(search, subquery):
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     with patch(
         "httpx.AsyncClient.get",
         new_callable=AsyncMock,
         side_effect=httpx.HTTPStatusError("500", request=None, response=None),
     ):
-        results = await search(subquery)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(subquery)
 
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_rate_limit(search, subquery):
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     mock_resp = MagicMock(spec=httpx.Response)
     mock_resp.text = "Rate exceeded."
     mock_resp.raise_for_status = MagicMock()
 
     with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_resp):
-        results = await search(subquery)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(subquery)

--- a/tests/channels/bilibili/test_via_tikhub.py
+++ b/tests/channels/bilibili/test_via_tikhub.py
@@ -253,9 +253,14 @@ async def test_search_returns_empty_on_tikhub_error(
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
-    results = await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+    # Bug 1 (fix-plan): TikhubError now propagates as a typed channel
+    # error so the MCP boundary can surface auth_failed / rate_limited /
+    # channel_error instead of an indistinguishable empty result.
+    from autosearch.channels.base import TransientError
 
-    assert results == []
+    with pytest.raises(TransientError):
+        await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+
     assert logger.events
     assert logger.events[0][0] == "bilibili_tikhub_search_failed"
     assert SEARCH_PATH in str(logger.events[0][1]["reason"])

--- a/tests/channels/crossref/test_api_search.py
+++ b/tests/channels/crossref/test_api_search.py
@@ -212,6 +212,14 @@ async def test_search_handles_empty_items() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -219,9 +227,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(502, json={"error": "bad gateway"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "crossref_search_failed"
     assert "502" in str(logger.events[0][1]["reason"])

--- a/tests/channels/dblp/test_api_search.py
+++ b/tests/channels/dblp/test_api_search.py
@@ -231,6 +231,14 @@ async def test_search_handles_empty_hits() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -238,9 +246,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(503, json={"error": "unavailable"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "dblp_search_failed"
     assert "503" in str(logger.events[0][1]["reason"])

--- a/tests/channels/ddgs/test_api.py
+++ b/tests/channels/ddgs/test_api.py
@@ -51,7 +51,9 @@ async def test_search_returns_evidence(search, subquery):
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_exception(search, subquery):
-    with patch.object(ddgs_mod, "DDGS", side_effect=Exception("network error")):
-        results = await search(subquery)
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import TransientError
 
-    assert results == []
+    with patch.object(ddgs_mod, "DDGS", side_effect=Exception("network error")):
+        with pytest.raises(TransientError):
+            await search(subquery)

--- a/tests/channels/devto/test_api_search.py
+++ b/tests/channels/devto/test_api_search.py
@@ -143,6 +143,14 @@ async def test_search_decodes_html_entities_in_title() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -150,9 +158,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(500, json={"error": "server error"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "devto_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])
@@ -162,6 +169,14 @@ async def test_search_returns_empty_on_http_error(
 async def test_search_returns_empty_on_malformed_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -169,9 +184,8 @@ async def test_search_returns_empty_on_malformed_payload(
         return httpx.Response(200, json={}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events == [
         (
             "devto_search_failed",

--- a/tests/channels/dockerhub/test_api_search.py
+++ b/tests/channels/dockerhub/test_api_search.py
@@ -69,14 +69,16 @@ async def test_search_returns_evidence(search, subquery):
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_error(search, subquery):
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import TransientError
+
     with patch(
         "httpx.AsyncClient.get",
         new_callable=AsyncMock,
         side_effect=httpx.ConnectError("connection refused"),
     ):
-        results = await search(subquery)
-
-    assert results == []
+        with pytest.raises(TransientError):
+            await search(subquery)
 
 
 @pytest.mark.asyncio()

--- a/tests/channels/douyin/test_via_tikhub.py
+++ b/tests/channels/douyin/test_via_tikhub.py
@@ -171,9 +171,14 @@ async def test_search_returns_empty_on_tikhub_error(
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
-    results = await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+    # Bug 1 (fix-plan): TikhubError now propagates as a typed channel
+    # error so the MCP boundary can surface auth_failed / rate_limited /
+    # channel_error instead of an indistinguishable empty result.
+    from autosearch.channels.base import TransientError
 
-    assert results == []
+    with pytest.raises(TransientError):
+        await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+
     assert logger.events
     assert logger.events[0][0] == "douyin_tikhub_search_failed"
     assert SEARCH_PATH in str(logger.events[0][1]["reason"])

--- a/tests/channels/google_news/test_api_search.py
+++ b/tests/channels/google_news/test_api_search.py
@@ -225,6 +225,14 @@ async def test_search_returns_empty_on_bozo_parse(
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -232,9 +240,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(502, text="bad gateway", request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "google_news_search_failed"
     assert "502" in str(logger.events[0][1]["reason"])

--- a/tests/channels/hackernews/test_algolia.py
+++ b/tests/channels/hackernews/test_algolia.py
@@ -71,11 +71,18 @@ async def test_search_returns_evidence(search, subquery):
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_network_error(search, subquery):
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     with patch(
         "httpx.AsyncClient.get",
         new_callable=AsyncMock,
         side_effect=httpx.ConnectError("refused"),
     ):
-        results = await search(subquery)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(subquery)

--- a/tests/channels/huggingface_hub/test_api_search.py
+++ b/tests/channels/huggingface_hub/test_api_search.py
@@ -165,6 +165,14 @@ async def test_search_handles_empty_response() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -172,9 +180,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(500, json={"error": "boom"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "huggingface_hub_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])

--- a/tests/channels/infoq_cn/test_api_search.py
+++ b/tests/channels/infoq_cn/test_api_search.py
@@ -204,6 +204,14 @@ async def test_search_source_channel_uses_first_category() -> None:
 
 @pytest.mark.asyncio
 async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -211,9 +219,8 @@ async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatc
         return httpx.Response(500, text="server error", request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query("LLM"), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query("LLM"), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "infoq_cn_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])

--- a/tests/channels/kuaishou/test_via_tikhub.py
+++ b/tests/channels/kuaishou/test_via_tikhub.py
@@ -200,9 +200,17 @@ async def test_search_returns_empty_on_tikhub_error(
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
-    results = await search(_query(), client=_FailingTikhubClient(TOKEN_LITERAL))
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
 
-    assert results == []
+    with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+        await search(_query(), client=_FailingTikhubClient(TOKEN_LITERAL))
+
     assert logger.events
     assert logger.events[0][0] == "kuaishou_tikhub_search_failed"
     reason = str(logger.events[0][1]["reason"])

--- a/tests/channels/openalex/test_api_search.py
+++ b/tests/channels/openalex/test_api_search.py
@@ -182,6 +182,14 @@ async def test_search_handles_empty_response() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -189,9 +197,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(500, json={"error": "boom"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "openalex_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])

--- a/tests/channels/podcast_cn/test_api_search.py
+++ b/tests/channels/podcast_cn/test_api_search.py
@@ -178,6 +178,14 @@ async def test_search_sets_country_cn_param() -> None:
 
 @pytest.mark.asyncio
 async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -185,9 +193,8 @@ async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatc
         return httpx.Response(503, json={"error": "unavailable"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "podcast_cn_search_failed"
     assert "503" in str(logger.events[0][1]["reason"])

--- a/tests/channels/pubmed/test_api_search.py
+++ b/tests/channels/pubmed/test_api_search.py
@@ -81,6 +81,14 @@ async def test_search_returns_empty_on_no_ids(search, subquery):
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_http_error(search, subquery):
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     import httpx
 
     with patch(
@@ -88,9 +96,8 @@ async def test_search_returns_empty_on_http_error(search, subquery):
         new_callable=AsyncMock,
         side_effect=httpx.HTTPStatusError("error", request=None, response=None),
     ):
-        results = await search(subquery)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(subquery)
 
 
 def _mock_response(data: dict):

--- a/tests/channels/reddit/test_api_search.py
+++ b/tests/channels/reddit/test_api_search.py
@@ -158,6 +158,14 @@ async def test_search_sets_user_agent_header() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -165,9 +173,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(429, json={"message": "slow down"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "reddit_search_failed"
     assert "429" in str(logger.events[0][1]["reason"])
@@ -177,6 +184,14 @@ async def test_search_returns_empty_on_http_error(
 async def test_search_returns_empty_on_malformed_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -184,9 +199,8 @@ async def test_search_returns_empty_on_malformed_payload(
         return httpx.Response(200, json={"data": {}}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events == [
         (
             "reddit_search_failed",

--- a/tests/channels/searxng/test_api_search.py
+++ b/tests/channels/searxng/test_api_search.py
@@ -79,6 +79,14 @@ async def test_search_raises_unavailable_when_no_url(search, subquery):
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_http_error(search, subquery):
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     with (
         patch.dict("os.environ", {"SEARXNG_URL": "http://localhost:8080"}),
         patch(
@@ -87,6 +95,5 @@ async def test_search_returns_empty_on_http_error(search, subquery):
             side_effect=httpx.ConnectError("refused"),
         ),
     ):
-        results = await search(subquery)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(subquery)

--- a/tests/channels/sec_edgar/test_api_search.py
+++ b/tests/channels/sec_edgar/test_api_search.py
@@ -239,6 +239,14 @@ async def test_search_sends_required_user_agent_header() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -246,9 +254,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(500, json={"message": "boom"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "sec_edgar_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])

--- a/tests/channels/sogou_weixin/test_api_search.py
+++ b/tests/channels/sogou_weixin/test_api_search.py
@@ -297,6 +297,14 @@ async def test_search_falls_back_to_listing_snippet_on_fetch_page_error(
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -304,9 +312,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(403, text="forbidden", request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events == [
         (
             "sogou_weixin_search_failed",
@@ -322,6 +329,7 @@ async def test_search_returns_empty_on_http_error(
 
 @pytest.mark.asyncio
 async def test_search_returns_empty_on_empty_html() -> None:
+    # Empty HTML is a legit "no matches" — channel returns [] without raising.
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, text="<html><body>no results</body></html>", request=request)
 

--- a/tests/channels/stackoverflow/test_api_search.py
+++ b/tests/channels/stackoverflow/test_api_search.py
@@ -163,6 +163,14 @@ async def test_search_decodes_html_entities_in_title() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -170,9 +178,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(502, json={"error": "bad gateway"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "stackoverflow_search_failed"
     assert "502" in str(logger.events[0][1]["reason"])
@@ -182,6 +189,14 @@ async def test_search_returns_empty_on_http_error(
 async def test_search_returns_empty_on_malformed_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -189,9 +204,8 @@ async def test_search_returns_empty_on_malformed_payload(
         return httpx.Response(200, json={}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events == [
         (
             "stackoverflow_search_failed",

--- a/tests/channels/tieba/test_api_search.py
+++ b/tests/channels/tieba/test_api_search.py
@@ -58,14 +58,21 @@ async def test_search_returns_evidence(search, subquery):
 
 @pytest.mark.asyncio()
 async def test_search_returns_empty_on_http_error(search, subquery):
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     with patch(
         "httpx.AsyncClient.get",
         new_callable=AsyncMock,
         side_effect=httpx.ConnectError("refused"),
     ):
-        results = await search(subquery)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(subquery)
 
 
 @pytest.mark.asyncio()

--- a/tests/channels/tiktok/test_via_tikhub.py
+++ b/tests/channels/tiktok/test_via_tikhub.py
@@ -229,9 +229,17 @@ async def test_search_returns_empty_on_tikhub_error(
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
-    results = await search(_query(), client=_FailingTikhubClient(TOKEN_LITERAL))
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
 
-    assert results == []
+    with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+        await search(_query(), client=_FailingTikhubClient(TOKEN_LITERAL))
+
     assert logger.events
     assert logger.events[0][0] == "tiktok_tikhub_search_failed"
     reason = str(logger.events[0][1]["reason"])

--- a/tests/channels/twitter/test_via_tikhub.py
+++ b/tests/channels/twitter/test_via_tikhub.py
@@ -156,9 +156,14 @@ async def test_search_returns_empty_on_tikhub_error(
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
-    results = await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+    # Bug 1 (fix-plan): TikhubError now propagates as a typed channel
+    # error so the MCP boundary can surface auth_failed / rate_limited /
+    # channel_error instead of an indistinguishable empty result.
+    from autosearch.channels.base import TransientError
 
-    assert results == []
+    with pytest.raises(TransientError):
+        await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+
     assert logger.events
     assert logger.events[0][0] == "twitter_tikhub_search_failed"
     assert SEARCH_PATH in str(logger.events[0][1]["reason"])

--- a/tests/channels/weibo/test_via_tikhub.py
+++ b/tests/channels/weibo/test_via_tikhub.py
@@ -303,12 +303,20 @@ async def test_search_returns_empty_on_tikhub_error(
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
-    results = await search(
-        _query(),
-        client=cast(TikhubClient, _FailingTikhubClient("secret-token-xyz")),
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
     )
 
-    assert results == []
+    with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+        await search(
+            _query(),
+            client=cast(TikhubClient, _FailingTikhubClient("secret-token-xyz")),
+        )
+
     assert logger.events
     assert logger.events[0][0] == "weibo_tikhub_search_failed"
     reason = str(logger.events[0][1]["reason"])

--- a/tests/channels/wikidata/test_api_search.py
+++ b/tests/channels/wikidata/test_api_search.py
@@ -191,6 +191,14 @@ async def test_search_sends_user_agent_with_contact_info() -> None:
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -198,9 +206,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(500, json={"error": "boom"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "wikidata_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])
@@ -210,6 +217,14 @@ async def test_search_returns_empty_on_http_error(
 async def test_search_returns_empty_on_malformed_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -217,7 +232,6 @@ async def test_search_returns_empty_on_malformed_payload(
         return httpx.Response(200, json={"success": 1}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events == [("wikidata_search_failed", {"reason": "invalid search payload"})]

--- a/tests/channels/wikipedia/test_api_search.py
+++ b/tests/channels/wikipedia/test_api_search.py
@@ -198,6 +198,14 @@ async def test_search_sends_user_agent_with_contact_info() -> None:
 async def test_search_returns_empty_on_malformed_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -205,9 +213,8 @@ async def test_search_returns_empty_on_malformed_payload(
         return httpx.Response(200, json={"query": {}}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events == [("wikipedia_search_failed", {"reason": "invalid search payload"})]
 
 
@@ -215,6 +222,14 @@ async def test_search_returns_empty_on_malformed_payload(
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import (
+        ChannelAuthError,
+        PermanentError,
+        RateLimited,
+        TransientError,
+    )
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -222,9 +237,8 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(500, json={"error": "boom"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
-
-    assert results == []
+        with pytest.raises((TransientError, PermanentError, RateLimited, ChannelAuthError)):
+            await search(_query(), http_client=http_client)
     assert logger.events
     assert logger.events[0][0] == "wikipedia_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])

--- a/tests/channels/xiaohongshu/test_via_tikhub.py
+++ b/tests/channels/xiaohongshu/test_via_tikhub.py
@@ -172,9 +172,12 @@ async def test_search_returns_empty_on_tikhub_error(
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
-    results = await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import TransientError
 
-    assert results == []
+    with pytest.raises(TransientError):
+        await search(_query(), client=cast(TikhubClient, _FailingTikhubClient()))
+
     assert logger.events
     assert logger.events[0][0] == "xiaohongshu_tikhub_search_failed"
 

--- a/tests/channels/zhihu/test_via_tikhub.py
+++ b/tests/channels/zhihu/test_via_tikhub.py
@@ -100,10 +100,12 @@ async def test_search_maps_tikhub_articles_to_evidence() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_returns_empty_list_on_tikhub_error() -> None:
-    results = await search(
-        SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
-        client=cast(TikhubClient, _FailingTikhubClient()),
-    )
+async def test_search_raises_typed_error_on_tikhub_error() -> None:
+    # Bug 1 (fix-plan): typed exception now propagates instead of [].
+    from autosearch.channels.base import TransientError
 
-    assert results == []
+    with pytest.raises(TransientError):
+        await search(
+            SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
+            client=cast(TikhubClient, _FailingTikhubClient()),
+        )

--- a/tests/unit/test_arxiv_channel.py
+++ b/tests/unit/test_arxiv_channel.py
@@ -106,13 +106,10 @@ async def test_search_empty_feed_returns_empty_list(monkeypatch: pytest.MonkeyPa
 
     results = await registry.get("arxiv").search(_subquery("retrieval augmented generation"))
 
+    # Bug 1 (fix-plan): an empty feed is a legitimate "no results" — channel
+    # returns [] without raising, MCP boundary surfaces status="no_results".
     assert results == []
-    assert logger.events == [
-        (
-            "arxiv_search_failed",
-            {"reason": "empty feed"},
-        )
-    ]
+    assert logger.events == []
 
 
 @pytest.mark.asyncio
@@ -130,15 +127,14 @@ async def test_search_handles_network_error_gracefully(
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    results = await registry.get("arxiv").search(_subquery("rag"))
+    # Bug 1 (fix-plan): network failure now raises TransientError so the host
+    # agent can distinguish a transient blip from "actually no results".
+    from autosearch.channels.base import TransientError
 
-    assert results == []
-    assert logger.events == [
-        (
-            "arxiv_search_failed",
-            {"reason": "boom"},
-        )
-    ]
+    with pytest.raises(TransientError):
+        await registry.get("arxiv").search(_subquery("rag"))
+    assert logger.events
+    assert logger.events[0][0] == "arxiv_search_failed"
 
 
 @pytest.mark.asyncio
@@ -155,9 +151,11 @@ async def test_search_handles_parse_error_gracefully(
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    results = await registry.get("arxiv").search(_subquery("rag"))
+    # Bug 1 (fix-plan): malformed feed → typed PermanentError, not silent [].
+    from autosearch.channels.base import PermanentError
 
-    assert results == []
+    with pytest.raises(PermanentError):
+        await registry.get("arxiv").search(_subquery("rag"))
     assert logger.events
     assert logger.events[0][0] == "arxiv_search_failed"
     assert "reason" in logger.events[0][1]
@@ -250,9 +248,12 @@ async def test_arxiv_rate_exceeded_exhausts_retries_returns_empty(
     monkeypatch.setattr(search_callable.__globals__["asyncio"], "sleep", fake_sleep)
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    results = await registry.get("arxiv").search(_subquery("retry query"))
+    # Bug 1 (fix-plan): rate limit exhaustion now raises RateLimited so the
+    # host agent can backoff intentionally rather than treating it as empty.
+    from autosearch.channels.base import RateLimited
 
-    assert results == []
+    with pytest.raises(RateLimited):
+        await registry.get("arxiv").search(_subquery("retry query"))
     assert call_count == 4
     assert logger.events == [
         (
@@ -279,9 +280,11 @@ async def test_arxiv_rate_exceeded_backoff_doubles(
     monkeypatch.setattr(search_callable.__globals__["httpx"].AsyncClient, "get", fake_get)
     monkeypatch.setattr(search_callable.__globals__["asyncio"], "sleep", fake_sleep)
 
-    results = await registry.get("arxiv").search(_subquery("retry query"))
+    # Bug 1 (fix-plan): rate-limit exhaustion raises RateLimited.
+    from autosearch.channels.base import RateLimited
 
-    assert results == []
+    with pytest.raises(RateLimited):
+        await registry.get("arxiv").search(_subquery("retry query"))
     assert sleep_calls == [1, 2, 4]
 
 
@@ -381,9 +384,12 @@ async def test_arxiv_cache_does_not_store_rate_limit_failures(
     monkeypatch.setattr(search_callable.__globals__["asyncio"], "sleep", fake_sleep)
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    first_results = await registry.get("arxiv").search(_subquery("retry query"))
+    # Bug 1 (fix-plan): rate-limit failures raise RateLimited; verify they
+    # ALSO don't poison the cache so a follow-up succeeds.
+    from autosearch.channels.base import RateLimited
 
-    assert first_results == []
+    with pytest.raises(RateLimited):
+        await registry.get("arxiv").search(_subquery("retry query"))
     assert search_callable.__globals__["_QUERY_CACHE"] == {}
 
     second_results = await registry.get("arxiv").search(_subquery("retry query"))

--- a/tests/unit/test_ddgs_channel.py
+++ b/tests/unit/test_ddgs_channel.py
@@ -92,9 +92,11 @@ async def test_search_handles_exception_gracefully(monkeypatch: pytest.MonkeyPat
     )
     monkeypatch.setitem(search_callable.__globals__, "LOGGER", logger)
 
-    results = await registry.get("ddgs").search(SubQuery(text="bm25", rationale="Need web results"))
+    # Bug 1 (fix-plan): channel raises typed error instead of [].
+    from autosearch.channels.base import TransientError
 
-    assert results == []
+    with pytest.raises(TransientError):
+        await registry.get("ddgs").search(SubQuery(text="bm25", rationale="Need web results"))
     assert logger.events == [
         (
             "ddgs_search_failed",


### PR DESCRIPTION
## Summary

Closes the github-only pilot from #353 — every other channel adapter now
propagates typed errors instead of swallowing failures into `[]`.

### Infra

- `autosearch/channels/base.py`: `raise_as_channel_error(exc)` helper that
  classifies a generic `httpx.HTTPError` / `ValueError` / `Exception` and
  raises the matching typed exception (ChannelAuthError / RateLimited /
  TransientError / PermanentError).
- `autosearch/lib/tikhub_client.py`: `to_channel_error(exc)` adapter that
  translates the existing TikHub-specific errors (TikhubBudgetExhausted,
  TikhubRateLimited, TikhubUpstreamError, TikhubError) into the
  channels.base typed errors.

### TikHub-shared (10 channels)
`bilibili / douyin / instagram / kuaishou / tiktok / twitter / weibo /
wechat_channels / xiaohongshu / zhihu` (the `via_tikhub.py` files) — the
shared except block now calls `raise to_channel_error(exc) from exc`. The
`except ValueError` on missing `TIKHUB_API_KEY` is kept as a
not_configured safety net (the MCP boundary already returns
not_configured first via SKILL.md requires).

### Direct-HTTP (22 channels)
`arxiv / crossref / dblp / ddgs / devto / dockerhub / google_news /
hackernews / huggingface_hub / infoq_cn / linkedin / openalex /
podcast_cn / pubmed / reddit / searxng / sec_edgar / sogou_weixin /
stackoverflow / tieba / wikidata / wikipedia / xueqiu / youtube`: broad
`except Exception: return []` replaced with `raise_as_channel_error(exc)`.

### arxiv special-case fixes
- empty atom feed now returns `[]` silently (legitimate "no results")
  instead of raising
- `ArxivRateLimitError` raises `RateLimited` (was `return []`)
- bozo / parse errors raise `PermanentError`

### Tests
- 26 `returns_empty_on_error` channel tests rewritten to expect typed
  exceptions
- 5 unit tests in `test_arxiv_channel` + `test_ddgs_channel` updated for
  the same reason
- Happy-path tests untouched — real empty results still return `[]`
  without raising

## Now run_channel returns 4 distinct statuses

Before this PR: every failure looked like `status="no_results"`.
After: agents can distinguish

| status | trigger |
|---|---|
| `auth_failed` | 401 / 403 / TikHub auth reject |
| `rate_limited` | 429 / TikHub 402 / arxiv "Rate exceeded" |
| `channel_error` | network / timeout / unknown |
| `no_results` | upstream returned empty list legitimately |

## Test plan

- [x] `pytest tests/channels/ -q` → 197 PASS
- [x] `./scripts/release-gate.sh` (full) → 38 contract gates + 838 default suite + CLI all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)