### PR TITLE
chore: bump version to 2026.04.24.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.24.7"
+  "version": "2026.04.24.8"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.24.7",
+  "version": "2026.04.24.8",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2026.04.24.8 — 2026-04-24
+
+The "every channel stops lying about success" release — finishes the github
+pilot from `2026.04.24.7` across all 30+ channel adapters.
+
+- **Channels propagate typed failures.** Every channel (TikHub-shared and
+  direct-HTTP alike) now turns network errors / 401-403 / 429 / parse failures
+  into typed exceptions (`ChannelAuthError`, `RateLimited`, `TransientError`,
+  `PermanentError`) that the MCP boundary maps to distinct `run_channel`
+  statuses. A YouTube key gone bad surfaces as `auth_failed`; a TikHub
+  budget-exhausted surfaces as `rate_limited`; a network blip surfaces as
+  `channel_error`. Real empty results still come back as `no_results`.
+- **arxiv specifically:** an empty atom feed is now a quiet `[]` (legitimate
+  "no matches"). `ArxivRateLimitError` raises `RateLimited` and bozo / parse
+  errors raise `PermanentError`, so retry logic + circuit breaker can react
+  to the right thing.
+- **Two new helpers** in the public API: `autosearch.channels.base.raise_as_channel_error(exc)` for direct-HTTP channels, and `autosearch.lib.tikhub_client.to_channel_error(exc)` for TikHub-routed ones. New channel implementations only need to call the right helper from their broad except block.
+
 ## 2026.04.24.7 — 2026-04-24
 
 The "second-pass diagnostic" release — six follow-up bugs the v6 audit caught

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.24.7"
+version = "2026.04.24.8"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bumps to **2026.04.24.8** packaging #355 — every channel adapter now propagates typed errors (Bug 1 batch, finishing the github pilot from v7).

After merge, push tag `v2026.04.24.8` to trigger PyPI + npm + GitHub Release via release.yml.

## Test plan

- [x] `./scripts/release-gate.sh --quick` → all gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)