### PR TITLE
fix(channels): ChannelAuthError falls through + XHS 300011 raises typed error + test_experience_e2e uses bundled channel

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -204,6 +204,15 @@ class _CompiledChannel:
                 )
                 last_retryable = exc
                 continue
+            except ChannelAuthError as exc:
+                self._record_health(
+                    method=method.id,
+                    success=False,
+                    started_at=started_at,
+                    error=type(exc).__name__,
+                )
+                last_retryable = exc
+                continue
             except PermanentError as exc:
                 # Must come before the bare-Exception clause below; previously this
                 # handler was unreachable because Exception caught it first.

--- a/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
@@ -205,21 +205,28 @@ async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> li
 
         # Empty results on a seemingly successful response → check if account is restricted
         if not items and xhs_code == 0:
+            me_payload: Mapping[str, object] | None = None
             try:
                 me_resp = await _client.get(
                     "https://edith.xiaohongshu.com/api/sns/web/v2/user/me",
                     headers={k: v for k, v in xhs_headers.items() if k not in ("Content-Type",)},
                     timeout=8,
                 )
-                me = me_resp.json()
-                if me.get("code") == 300011:
-                    LOGGER.warning(
-                        "xhs_account_restricted",
-                        reason="XHS account flagged — search silently returns empty. Run 'autosearch login xhs' with a normal account.",
-                    )
-                    return []
+                me_payload = me_resp.json()
             except Exception:
-                pass  # health check failure is non-fatal; return empty results
+                pass  # health check failure is non-fatal; fall through to empty list
+
+            if isinstance(me_payload, Mapping) and me_payload.get("code") == 300011:
+                from autosearch.channels.base import ChannelAuthError
+
+                LOGGER.warning(
+                    "xhs_account_restricted",
+                    reason="XHS account flagged — search silently returns empty. Run 'autosearch login xhs' with a different account.",
+                )
+                raise ChannelAuthError(
+                    "XHS account flagged (code=300011). "
+                    "Run 'autosearch login xhs' with a different account."
+                )
 
         fetched_at = datetime.now(UTC)
         results: list[Evidence] = []

--- a/scripts/validate/test_experience_e2e.py
+++ b/scripts/validate/test_experience_e2e.py
@@ -21,7 +21,7 @@ sys.path.insert(0, str(Path(__file__).parents[2]))
 from autosearch.core.experience_compact import compact
 from autosearch.skills.experience import append_event, should_compact
 
-CHANNEL = "test-experience-channel"
+CHANNEL = "github"
 N_EVENTS = 10
 
 

--- a/tests/unit/test_xhs_signsrv_account_restriction.py
+++ b/tests/unit/test_xhs_signsrv_account_restriction.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from autosearch.channels.base import ChannelAuthError
+from autosearch.core.models import SubQuery
+from autosearch.skills.channels.xiaohongshu.methods import via_signsrv
+
+
+class _Response:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> object:
+        return self._payload
+
+
+class _Client:
+    async def post(self, url: str, **kwargs: object) -> _Response:
+        _ = kwargs
+        if url.endswith("/sign/xhs"):
+            return _Response(
+                {
+                    "ok": True,
+                    "X-s": "sig",
+                    "X-t": "123",
+                    "X-s-common": "common",
+                    "X-b3-traceid": "trace",
+                }
+            )
+        return _Response({"code": 0, "data": {"data": {"items": []}}})
+
+    async def get(self, url: str, **kwargs: object) -> _Response:
+        _ = url
+        _ = kwargs
+        return _Response({"code": 300011})
+
+
+@pytest.mark.asyncio
+async def test_xhs_signsrv_empty_search_with_me_300011_raises_channel_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(via_signsrv.__dict__, "_SIGNSRV_URL", "https://signsrv.example")
+    monkeypatch.setitem(via_signsrv.__dict__, "_SERVICE_TOKEN", "as_test")
+    monkeypatch.setitem(via_signsrv.__dict__, "_XHS_COOKIES", "a1=test-cookie")
+
+    with pytest.raises(ChannelAuthError, match="300011"):
+        await via_signsrv.search(
+            SubQuery(text="防晒", rationale="Need XHS coverage"),
+            client=_Client(),
+        )


### PR DESCRIPTION
## Summary

Three P1 fixes surfaced by an audit of fallback/auth-error semantics:

- **base.py**: `ChannelAuthError` was swallowed by `except PermanentError: raise` in the fallback loop (it inherits PermanentError), so a bad cookie on method A kneecapped method B with independent auth. Added a dedicated `except ChannelAuthError` before PermanentError that records health-failure, stashes the error in `last_retryable`, and continues to the next method. If every method exhausts, `last_retryable` is still raised so MCP surfaces `auth_failed`.
- **xhs via_signsrv**: account-restriction detection (`code=300011`) previously `return []`, giving users a fake empty search. A first naive fix raised `ChannelAuthError` inside a `try/except Exception: pass` block, so the typed error was silently eaten — the fix was a no-op. Restructured so the `try` only wraps the health-check HTTP + JSON parse, and the `raise` lives outside it.
- **scripts/validate/test_experience_e2e.py**: used fake `CHANNEL = "test-experience-channel"`, which is not a bundled skill — `_runtime_skill_dir` returned None, `append_event` early-returned, and patterns.jsonl was never written. The script always red with `FileNotFoundError`. Switched to bundled `github` (temp `AUTOSEARCH_EXPERIENCE_DIR` keeps the real runtime dir clean).

## Test plan

- [x] `.venv/bin/python scripts/validate/test_experience_e2e.py` → PASS
- [x] `.venv/bin/python -m pytest tests/unit/ -x -q -m "not real_llm and not slow and not network"` → 565 passed (includes new `test_xhs_signsrv_account_restriction.py`)
- [x] `bash scripts/release-gate.sh` → Release gate PASSED (879 default-marker tests)
- [ ] CI green

## Follow-up (separate PR, not in this one)

- twitter/xhs `via_tikhub` invalid_payload returns `[]` (schema-change hiding)
- v2ex / kr36 broad `except Exception: return []`
- npm wrapper `--version` branch skips `checkVersionAlignment`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted XHS accounts now raise a clear authentication error instead of silently returning empty results.
  * Improved authentication error handling during channel searches to enable proper fallback retry logic.

* **Tests**
  * Added test coverage for XHS account restriction detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->