### PR TITLE
fix(channels/npm): swallowed-exception cleanup (v2ex/kr36 broad except, twitter/xhs tikhub schema drift, npm --version)

### DIFF
--- a/autosearch/skills/channels/kr36/methods/api_search.py
+++ b/autosearch/skills/channels/kr36/methods/api_search.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.html_scraper import HtmlFetchError, fetch_html, fetch_page
 
@@ -182,10 +183,10 @@ async def search(
         )
     except HtmlFetchError as exc:
         LOGGER.warning("kr36_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
     except Exception as exc:
         LOGGER.warning("kr36_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     return await asyncio.gather(
         *[_enrich_evidence(evidence, http_client=http_client) for evidence in evidences]

--- a/autosearch/skills/channels/twitter/methods/via_tikhub.py
+++ b/autosearch/skills/channels/twitter/methods/via_tikhub.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 
 import structlog
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
@@ -35,10 +36,10 @@ def _extract_tweets(payload: Mapping[str, object]) -> list[Mapping[str, object]]
     """Extract tweet objects — TikHub returns a flat list at data.timeline."""
     data = payload.get("data")
     if not isinstance(data, Mapping):
-        return []
+        raise PermanentError("twitter via_tikhub: unexpected payload shape (schema drift?)")
     timeline = data.get("timeline")
     if not isinstance(timeline, list):
-        return []
+        raise PermanentError("twitter via_tikhub: unexpected payload shape (schema drift?)")
     return [t for t in timeline if isinstance(t, Mapping)]
 
 

--- a/autosearch/skills/channels/v2ex/methods/api_search.py
+++ b/autosearch/skills/channels/v2ex/methods/api_search.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
+from autosearch.channels.base import raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="v2ex")
@@ -106,7 +107,7 @@ async def search(
             raise ValueError("invalid hits payload")
     except Exception as exc:
         LOGGER.warning("v2ex_search_failed", reason=str(exc))
-        return []
+        raise_as_channel_error(exc)
 
     fetched_at = datetime.now(UTC)
     evidences: list[Evidence] = []

--- a/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 
 import structlog
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
@@ -103,7 +104,7 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
 
     if not isinstance(items, list):
         LOGGER.warning("xiaohongshu_tikhub_search_failed", reason="invalid_payload_shape")
-        return []
+        raise PermanentError("xiaohongshu via_tikhub: invalid payload shape (schema drift?)")
 
     fetched_at = datetime.now(UTC)
     results: list[Evidence] = []

--- a/npm/bin/autosearch-ai.js
+++ b/npm/bin/autosearch-ai.js
@@ -195,6 +195,10 @@ async function main() {
     return;
   }
   if (popFlag("--version", "-V")) {
+    const installedVersion = getInstalledAutosearchVersion();
+    if (installedVersion !== null) {
+      checkVersionAlignment(installedVersion);
+    }
     printVersion();
     return;
   }

--- a/tests/channels/kr36/test_api_search.py
+++ b/tests/channels/kr36/test_api_search.py
@@ -254,6 +254,8 @@ async def test_search_falls_back_to_listing_snippet_on_fetch_page_error(
 async def test_search_returns_empty_on_http_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from autosearch.channels.base import TransientError
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -261,9 +263,9 @@ async def test_search_returns_empty_on_http_error(
         return httpx.Response(502, text="bad gateway", request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
+        with pytest.raises(TransientError):
+            await search(_query(), http_client=http_client)
 
-    assert results == []
     assert logger.events == [
         (
             "kr36_search_failed",

--- a/tests/channels/twitter/test_via_tikhub.py
+++ b/tests/channels/twitter/test_via_tikhub.py
@@ -173,11 +173,13 @@ async def test_search_returns_empty_on_tikhub_error(
 async def test_search_handles_unexpected_payload_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from autosearch.channels.base import PermanentError
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
     client = _FakeTikhubClient({"data": {"unexpected": "shape"}})
 
-    results = await search(_query(), client=cast(TikhubClient, client))
+    with pytest.raises(PermanentError):
+        await search(_query(), client=cast(TikhubClient, client))
 
-    assert results == []
     assert logger.events == []

--- a/tests/channels/v2ex/test_api_search.py
+++ b/tests/channels/v2ex/test_api_search.py
@@ -193,6 +193,8 @@ async def test_search_falls_back_to_content_excerpt_when_title_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from autosearch.channels.base import TransientError
+
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
 
@@ -200,9 +202,9 @@ async def test_search_returns_empty_on_http_error(monkeypatch: pytest.MonkeyPatc
         return httpx.Response(500, json={"error": "server error"}, request=request)
 
     async with _client(handler) as http_client:
-        results = await search(_query(), http_client=http_client)
+        with pytest.raises(TransientError):
+            await search(_query(), http_client=http_client)
 
-    assert results == []
     assert logger.events
     assert logger.events[0][0] == "v2ex_search_failed"
     assert "500" in str(logger.events[0][1]["reason"])

--- a/tests/channels/xiaohongshu/test_via_tikhub.py
+++ b/tests/channels/xiaohongshu/test_via_tikhub.py
@@ -183,6 +183,24 @@ async def test_search_returns_empty_on_tikhub_error(
 
 
 @pytest.mark.asyncio
+async def test_search_raises_on_invalid_payload_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autosearch.channels.base import PermanentError
+
+    logger = _Logger()
+    monkeypatch.setattr(MODULE, "LOGGER", logger)
+    client = _FakeTikhubClient({"data": {"data": {"items": {"unexpected": "shape"}}}})
+
+    with pytest.raises(PermanentError):
+        await search(_query(), client=cast(TikhubClient, client))
+
+    assert logger.events == [
+        ("xiaohongshu_tikhub_search_failed", {"reason": "invalid_payload_shape"})
+    ]
+
+
+@pytest.mark.asyncio
 async def test_search_truncates_desc_to_snippet_on_word_boundary() -> None:
     long_desc = ("word " * 59) + "splitpoint continues after the limit"
     client = _FakeTikhubClient(


### PR DESCRIPTION
## Summary

Four remaining channel paths still swallowed upstream failures as empty results, and the npm wrapper's `--version` flag skipped the version-skew warning. Paired with PR #359 these close the "silent no_results" gaps identified in the latest audit round.

- **twitter/via_tikhub**: `_extract_tweets()` returned `[]` on payload-shape drift. Now raises `PermanentError`.
- **xiaohongshu/via_tikhub**: `invalid_payload_shape` warning was followed by `return []`. Now raises `PermanentError` after the warning.
- **v2ex/api_search**: broad `except Exception: return []` ate networking, 5xx, and schema drift identically. Now calls `raise_as_channel_error(exc)` which classifies by exception type.
- **kr36/api_search**: same pattern in both `HtmlFetchError` and generic `Exception` branches — both call `raise_as_channel_error(exc)` now.
- **npm wrapper**: `--version` short-circuit ran `printVersion()` without `checkVersionAlignment()`, so skew went unreported to users who are about to file bugs. Now checks alignment first.

## Test plan

- [x] Updated 4 tests that locked in the old silent-empty behavior (kr36 HTTP 502, v2ex HTTP 500, twitter unexpected payload, xhs invalid payload shape) to assert the new typed-error behavior (`TransientError` / `PermanentError`). Legal-empty paths (empty timeline, items filtered on validation) still assert `[]`.
- [x] `bash scripts/release-gate.sh` → Release gate PASSED (879 default-marker tests green, including all updated assertions)
- [ ] CI green

## Related

- Depends on #359 being merged first (or not — this PR is orthogonal to the auth-fallback semantics in that one; the `raise_as_channel_error` helper it uses already exists on main from PR #357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)