### PR TITLE
fix(mcp/channels): structlog→stderr for stdio + 4 TikHub schema-drift paths raise

### DIFF
--- a/autosearch/mcp/cli.py
+++ b/autosearch/mcp/cli.py
@@ -1,8 +1,15 @@
 # Self-written, plan v2.3 § 13.5
-from autosearch.mcp.server import create_server
+import sys
+
+import structlog
 
 
 def main() -> None:
+    structlog.configure(
+        logger_factory=structlog.WriteLoggerFactory(file=sys.stderr),
+    )
+    from autosearch.mcp.server import create_server
+
     create_server().run(transport="stdio")
 
 

--- a/autosearch/skills/channels/bilibili/methods/via_tikhub.py
+++ b/autosearch/skills/channels/bilibili/methods/via_tikhub.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 import structlog
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
@@ -230,7 +231,7 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
     result_groups = _extract_result_groups(payload)
     if result_groups is None:
         LOGGER.warning("bilibili_tikhub_search_failed", reason="invalid_payload_shape")
-        return []
+        raise PermanentError("bilibili via_tikhub: invalid payload shape (schema drift?)")
 
     fetched_at = datetime.now(UTC)
     results: list[Evidence] = []

--- a/autosearch/skills/channels/douyin/methods/via_tikhub.py
+++ b/autosearch/skills/channels/douyin/methods/via_tikhub.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 import structlog
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
@@ -120,7 +121,7 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
     items = data.get("data") if isinstance(data, Mapping) else None
     if not isinstance(items, list):
         LOGGER.warning("douyin_tikhub_search_failed", reason="invalid_payload_shape")
-        return []
+        raise PermanentError("douyin via_tikhub: invalid payload shape (schema drift?)")
 
     fetched_at = datetime.now(UTC)
     results: list[Evidence] = []

--- a/autosearch/skills/channels/tiktok/methods/via_tikhub.py
+++ b/autosearch/skills/channels/tiktok/methods/via_tikhub.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 
 import structlog
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
@@ -104,7 +105,7 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
     items = data.get("data") if isinstance(data, Mapping) else None
     if not isinstance(items, list):
         LOGGER.warning("tiktok_tikhub_search_failed", reason="invalid_payload_shape")
-        return []
+        raise PermanentError("tiktok via_tikhub: invalid payload shape (schema drift?)")
 
     fetched_at = datetime.now(UTC)
     results: list[Evidence] = []

--- a/autosearch/skills/channels/wechat_channels/methods/via_tikhub.py
+++ b/autosearch/skills/channels/wechat_channels/methods/via_tikhub.py
@@ -116,6 +116,10 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
 
     if not items:
         LOGGER.warning("wechat_channels_tikhub_search_failed", reason="no_items_in_response")
+        # NOTE: ambiguous path — if TikHub renamed the docID key this would
+        # be schema drift (should raise PermanentError), but it's also the
+        # legit "search found zero results" result. Leaving as [] until we
+        # see concrete drift reports.
         return []
 
     fetched_at = datetime.now(UTC)

--- a/autosearch/skills/channels/zhihu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/zhihu/methods/via_tikhub.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 
 import structlog
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError, to_channel_error
 
@@ -92,7 +93,7 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
     items = data.get("data", []) if isinstance(data, Mapping) else []
     if not isinstance(items, list):
         LOGGER.warning("zhihu_tikhub_search_failed", reason="invalid_payload_shape")
-        return []
+        raise PermanentError("zhihu via_tikhub: invalid payload shape (schema drift?)")
 
     fetched_at = datetime.now(UTC)
     results: list[Evidence] = []

--- a/tests/channels/bilibili/test_via_tikhub.py
+++ b/tests/channels/bilibili/test_via_tikhub.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pytest
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError
 
@@ -267,9 +268,8 @@ async def test_search_returns_empty_on_tikhub_error(
 
 
 @pytest.mark.asyncio
-async def test_search_returns_empty_on_malformed_payload() -> None:
+async def test_search_raises_permanent_error_on_malformed_payload() -> None:
     client = _FakeTikhubClient({"data": {"data": {"unexpected": []}}})
 
-    results = await search(_query(), client=cast(TikhubClient, client))
-
-    assert results == []
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(_query(), client=cast(TikhubClient, client))

--- a/tests/channels/douyin/test_via_tikhub.py
+++ b/tests/channels/douyin/test_via_tikhub.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pytest
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError
 
@@ -162,6 +163,14 @@ async def test_search_skips_entry_without_aweme_info() -> None:
     results = await search(_query(), client=cast(TikhubClient, client))
 
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_raises_permanent_error_on_malformed_payload() -> None:
+    client = _FakeTikhubClient({"data": {"data": {"unexpected": []}}})
+
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(_query(), client=cast(TikhubClient, client))
 
 
 @pytest.mark.asyncio

--- a/tests/channels/tiktok/test_via_tikhub.py
+++ b/tests/channels/tiktok/test_via_tikhub.py
@@ -7,6 +7,7 @@ from typing import cast
 import httpx
 import pytest
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import SubQuery
 from autosearch.lib.tikhub_client import TikhubClient
 
@@ -175,6 +176,14 @@ async def test_search_skips_items_without_required_fields() -> None:
     results = await search(_query(), client=cast(TikhubClient, client))
 
     assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_raises_permanent_error_on_malformed_payload() -> None:
+    client = _FakeTikhubClient({"data": {"data": {"unexpected": []}}})
+
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(_query(), client=cast(TikhubClient, client))
 
 
 @pytest.mark.asyncio

--- a/tests/channels/zhihu/test_via_tikhub.py
+++ b/tests/channels/zhihu/test_via_tikhub.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pytest
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError
 
@@ -108,4 +109,15 @@ async def test_search_raises_typed_error_on_tikhub_error() -> None:
         await search(
             SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
             client=cast(TikhubClient, _FailingTikhubClient()),
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_raises_permanent_error_on_malformed_payload() -> None:
+    client = _FakeTikhubClient({"data": {"data": {"unexpected": []}}})
+
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(
+            SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
+            client=cast(TikhubClient, client),
         )

--- a/tests/smoke/test_mcp_stdio_no_stdout_pollution.py
+++ b/tests/smoke/test_mcp_stdio_no_stdout_pollution.py
@@ -1,0 +1,121 @@
+# Self-written, plan v2.3 § W2 smoke MCP stdio stdout purity
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.smoke.conftest import console_script_command, smoke_env
+
+
+def _send_jsonrpc(process: subprocess.Popen[str], payload: dict[str, object]) -> None:
+    if process.stdin is None:
+        raise AssertionError("Process stdin is not available.")
+    process.stdin.write(json.dumps(payload) + "\n")
+    process.stdin.flush()
+
+
+@pytest.mark.smoke
+def test_mcp_stdio_logs_go_to_stderr_not_stdout(tmp_path: Path) -> None:
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    (shim_dir / "sitecustomize.py").write_text(
+        "\n".join(
+            [
+                "import structlog",
+                "from autosearch.mcp import server as mcp_server",
+                "",
+                "_original = mcp_server._search_single_channel",
+                "",
+                "async def _wrapped(channel, query, rationale):",
+                "    structlog.get_logger('tests.smoke').warning(",
+                "        'forced_stdio_warning',",
+                "        channel=getattr(channel, 'name', 'unknown'),",
+                "    )",
+                "    return await _original(channel, query, rationale)",
+                "",
+                "mcp_server._search_single_channel = _wrapped",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    env = smoke_env(AUTOSEARCH_LLM_MODE="dummy")
+    pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{shim_dir}{os.pathsep}{pythonpath}" if pythonpath else str(shim_dir)
+
+    process = subprocess.Popen(
+        [*console_script_command("autosearch-mcp", "autosearch.mcp.cli")],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+
+    try:
+        _send_jsonrpc(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "0.0.0"},
+                },
+            },
+        )
+        _send_jsonrpc(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            },
+        )
+        _send_jsonrpc(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "run_channel",
+                    "arguments": {
+                        "channel_name": "demo",
+                        "query": "stdout pollution regression",
+                    },
+                },
+            },
+        )
+        if process.stdin is not None:
+            process.stdin.close()
+            process.stdin = None
+
+        stdout, stderr = process.communicate(timeout=20)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.communicate()
+
+    assert process.returncode == 0, stderr
+    stdout_lines = [line for line in stdout.splitlines() if line.strip()]
+    assert stdout_lines, "Expected JSON-RPC output on stdout."
+
+    response_ids: set[int] = set()
+    for line in stdout_lines:
+        payload = json.loads(line)
+        assert isinstance(payload, dict)
+        assert payload.get("jsonrpc") == "2.0"
+        if isinstance(payload.get("id"), int):
+            response_ids.add(payload["id"])
+
+    assert response_ids == {1, 2}
+    assert stderr.strip(), "Expected log or diagnostic output on stderr."

--- a/tests/unit/test_e2b_orchestrator_imports.py
+++ b/tests/unit/test_e2b_orchestrator_imports.py
@@ -17,9 +17,10 @@ LIB_DIR = REPO_ROOT / "scripts" / "e2b" / "lib"
 
 def _load(name: str):
     path = LIB_DIR / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name, path)
+    module_name = f"test_e2b_lib_{name}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 


### PR DESCRIPTION
## Summary

Two fixes surfaced by the latest audit round:

### P0 — MCP stdio JSON-RPC polluted by structlog

`autosearch-mcp` runs `transport="stdio"`, so stdout **is** the JSON-RPC channel. But structlog's default `PrintLoggerFactory` writes to stdout — any `LOGGER.warning(...)` inside a channel during a `run_channel` call corrupts the stream. Clients silently fail or drop messages.

Verified locally: `python -c "import structlog; structlog.get_logger('x').warning('e')"` prints to stdout, not stderr. `tests/smoke/test_mcp_stdio_smoke.py` already acknowledges this by skipping real stdio ("avoid structlog stdout contamination").

Fix: `autosearch/mcp/cli.py` calls `structlog.configure(logger_factory=WriteLoggerFactory(file=sys.stderr))` at the start of `main()`. Done inside `main()` (not at module import) so the regular CLI (`autosearch/cli/main.py`) is not affected — CLI users still see logs on stdout.

Added `tests/smoke/test_mcp_stdio_no_stdout_pollution.py` — spawns a real `autosearch-mcp` subprocess, triggers a log-producing code path, and asserts every non-empty stdout line parses as valid JSON-RPC.

### P1 — 4 more TikHub channels returned [] on schema drift

PR #360 fixed `twitter/via_tikhub` and `xhs/via_tikhub` to raise `PermanentError` on `invalid_payload_shape`. Four more channels had the identical pattern and were missed:

- `bilibili/methods/via_tikhub.py:232`
- `zhihu/methods/via_tikhub.py:95`
- `douyin/methods/via_tikhub.py:123`
- `tiktok/methods/via_tikhub.py:107`

Each now raises instead of returning `[]`, matching the pattern already established for twitter/xhs. Tests that locked in the old silent-empty behavior updated to assert `pytest.raises(PermanentError)`.

### wechat_channels — annotated, behavior unchanged

`wechat_channels/via_tikhub` has a `no_items_in_response → return []` path that is genuinely ambiguous (schema drift vs. legit zero results). Added a `NOTE` comment flagging this for future investigation; behavior unchanged.

### Out-of-scope test infra fix

`tests/unit/test_e2b_orchestrator_imports.py` registered loaded modules under bare stdlib names (e.g. `sys.modules["secrets"]`), hijacking stdlib for every test that ran after it. This broke `tests/channels/ddgs/test_api.py` when the full suite ran (the ddgs path transitively imports `secrets` via urllib3). Prefixed registration name to `test_e2b_lib_<name>`. Committed separately and explicitly labeled; pulled in so the full release-gate pytest run goes green end-to-end.

## Test plan

- [x] `bash scripts/release-gate.sh` → Release gate PASSED (879+ tests, now includes new MCP stdio smoke test and 4 updated channel tests)
- [x] New smoke test confirms real `autosearch-mcp` stdout is pure JSON-RPC even when a channel logs a warning
- [ ] CI green