### PR TITLE
fix(channels): TikHub proxy mode satisfies requires + 4 channels raise on nested schema drift

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from autosearch.observability.channel_health import ChannelHealth
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel_registry")
+_TIKHUB_API_KEY_TOKEN = "env:TIKHUB_API_KEY"
+_TIKHUB_PROXY_FALLBACK = {"AUTOSEARCH_PROXY_URL", "AUTOSEARCH_PROXY_TOKEN"}
 
 
 class ChannelRegistryError(ValueError):
@@ -417,6 +419,8 @@ class ChannelRegistry:
             elif kind == "mcp" and value not in env.mcp_servers:
                 unmet.append(token)
             elif kind == "env" and value not in env.env_keys:
+                if token == _TIKHUB_API_KEY_TOKEN and _TIKHUB_PROXY_FALLBACK.issubset(env.env_keys):
+                    continue
                 unmet.append(token)
             elif kind == "binary" and value not in env.binaries:
                 unmet.append(token)

--- a/autosearch/skills/channels/instagram/methods/via_tikhub.py
+++ b/autosearch/skills/channels/instagram/methods/via_tikhub.py
@@ -83,10 +83,15 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         return []
 
     # payload.data.data.items
-    outer = payload.get("data", {})
-    inner = outer.get("data", {}) if isinstance(outer, Mapping) else {}
-    items = inner.get("items", []) if isinstance(inner, Mapping) else []
-
+    outer = payload.get("data")
+    if not isinstance(outer, Mapping):
+        LOGGER.warning("instagram_tikhub_search_failed", reason="invalid_payload_shape")
+        raise PermanentError("instagram via_tikhub: invalid payload shape (schema drift?)")
+    inner = outer.get("data")
+    if not isinstance(inner, Mapping):
+        LOGGER.warning("instagram_tikhub_search_failed", reason="invalid_payload_shape")
+        raise PermanentError("instagram via_tikhub: invalid payload shape (schema drift?)")
+    items = inner.get("items")
     if not isinstance(items, list):
         LOGGER.warning("instagram_tikhub_search_failed", reason="invalid_payload_shape")
         raise PermanentError("instagram via_tikhub: invalid payload shape (schema drift?)")

--- a/autosearch/skills/channels/weibo/methods/via_tikhub.py
+++ b/autosearch/skills/channels/weibo/methods/via_tikhub.py
@@ -117,8 +117,14 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         return []
 
     data = payload.get("data")
-    nested_data = data.get("data") if isinstance(data, Mapping) else {}
-    cards = nested_data.get("cards") if isinstance(nested_data, Mapping) else []
+    if not isinstance(data, Mapping):
+        LOGGER.warning("weibo_tikhub_search_failed", reason="invalid_payload_shape")
+        raise PermanentError("weibo via_tikhub: invalid payload shape (schema drift?)")
+    nested_data = data.get("data")
+    if not isinstance(nested_data, Mapping):
+        LOGGER.warning("weibo_tikhub_search_failed", reason="invalid_payload_shape")
+        raise PermanentError("weibo via_tikhub: invalid payload shape (schema drift?)")
+    cards = nested_data.get("cards")
     if not isinstance(cards, list):
         LOGGER.warning("weibo_tikhub_search_failed", reason="invalid_payload_shape")
         raise PermanentError("weibo via_tikhub: invalid payload shape (schema drift?)")

--- a/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
@@ -98,10 +98,15 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         return []
 
     # Navigate: payload.data.data.items
-    outer = payload.get("data", {})
-    inner = outer.get("data", {}) if isinstance(outer, Mapping) else {}
-    items = inner.get("items", []) if isinstance(inner, Mapping) else []
-
+    outer = payload.get("data")
+    if not isinstance(outer, Mapping):
+        LOGGER.warning("xiaohongshu_tikhub_search_failed", reason="invalid_payload_shape")
+        raise PermanentError("xiaohongshu via_tikhub: invalid payload shape (schema drift?)")
+    inner = outer.get("data")
+    if not isinstance(inner, Mapping):
+        LOGGER.warning("xiaohongshu_tikhub_search_failed", reason="invalid_payload_shape")
+        raise PermanentError("xiaohongshu via_tikhub: invalid payload shape (schema drift?)")
+    items = inner.get("items")
     if not isinstance(items, list):
         LOGGER.warning("xiaohongshu_tikhub_search_failed", reason="invalid_payload_shape")
         raise PermanentError("xiaohongshu via_tikhub: invalid payload shape (schema drift?)")

--- a/autosearch/skills/channels/zhihu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/zhihu/methods/via_tikhub.py
@@ -89,8 +89,11 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         LOGGER.warning("zhihu_tikhub_search_failed", reason=str(exc))
         return []
 
-    data = payload.get("data", {})
-    items = data.get("data", []) if isinstance(data, Mapping) else []
+    data = payload.get("data")
+    if not isinstance(data, Mapping):
+        LOGGER.warning("zhihu_tikhub_search_failed", reason="invalid_payload_shape")
+        raise PermanentError("zhihu via_tikhub: invalid payload shape (schema drift?)")
+    items = data.get("data")
     if not isinstance(items, list):
         LOGGER.warning("zhihu_tikhub_search_failed", reason="invalid_payload_shape")
         raise PermanentError("zhihu via_tikhub: invalid payload shape (schema drift?)")

--- a/tests/channels/instagram/test_via_tikhub.py
+++ b/tests/channels/instagram/test_via_tikhub.py
@@ -51,3 +51,36 @@ async def test_search_raises_on_invalid_payload_shape() -> None:
             SubQuery(text="camera", rationale="Need Instagram post coverage"),
             client=cast(TikhubClient, client),
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload"),
+    [
+        {},
+        {"data": "wrong"},
+        {"data": {"data": []}},
+    ],
+)
+async def test_search_raises_when_nested_data_is_missing_or_wrong_type(
+    payload: dict[str, object],
+) -> None:
+    client = _FakeTikhubClient(payload)
+
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(
+            SubQuery(text="camera", rationale="Need Instagram post coverage"),
+            client=cast(TikhubClient, client),
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_allows_legitimate_empty_items_list() -> None:
+    client = _FakeTikhubClient({"data": {"data": {"items": []}}})
+
+    results = await search(
+        SubQuery(text="camera", rationale="Need Instagram post coverage"),
+        client=cast(TikhubClient, client),
+    )
+
+    assert results == []

--- a/tests/channels/weibo/test_via_tikhub.py
+++ b/tests/channels/weibo/test_via_tikhub.py
@@ -306,6 +306,33 @@ async def test_search_raises_on_invalid_payload_shape() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload"),
+    [
+        {},
+        {"data": []},
+        {"data": {"data": []}},
+    ],
+)
+async def test_search_raises_on_missing_or_invalid_nested_data_shape(
+    payload: dict[str, object],
+) -> None:
+    client = _FakeTikhubClient(payload)
+
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(_query(), client=cast(TikhubClient, client))
+
+
+@pytest.mark.asyncio
+async def test_search_allows_legitimate_empty_cards_list() -> None:
+    client = _FakeTikhubClient({"data": {"data": {"cards": []}}})
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert results == []
+
+
+@pytest.mark.asyncio
 async def test_search_returns_empty_on_tikhub_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/channels/xiaohongshu/test_via_tikhub.py
+++ b/tests/channels/xiaohongshu/test_via_tikhub.py
@@ -201,6 +201,35 @@ async def test_search_raises_on_invalid_payload_shape(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload"),
+    [
+        {},
+        {"data": []},
+        {"data": {"data": []}},
+    ],
+)
+async def test_search_raises_on_missing_or_invalid_nested_data_shape(
+    payload: dict[str, object],
+) -> None:
+    from autosearch.channels.base import PermanentError
+
+    client = _FakeTikhubClient(payload)
+
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(_query(), client=cast(TikhubClient, client))
+
+
+@pytest.mark.asyncio
+async def test_search_allows_legitimate_empty_items_list() -> None:
+    client = _FakeTikhubClient(_search_payload([]))
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert results == []
+
+
+@pytest.mark.asyncio
 async def test_search_truncates_desc_to_snippet_on_word_boundary() -> None:
     long_desc = ("word " * 59) + "splitpoint continues after the limit"
     client = _FakeTikhubClient(

--- a/tests/channels/zhihu/test_via_tikhub.py
+++ b/tests/channels/zhihu/test_via_tikhub.py
@@ -121,3 +121,35 @@ async def test_search_raises_permanent_error_on_malformed_payload() -> None:
             SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
             client=cast(TikhubClient, client),
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload"),
+    [
+        {},
+        {"data": []},
+    ],
+)
+async def test_search_raises_permanent_error_when_data_container_is_missing_or_invalid(
+    payload: dict[str, object],
+) -> None:
+    client = _FakeTikhubClient(payload)
+
+    with pytest.raises(PermanentError, match="invalid payload shape"):
+        await search(
+            SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
+            client=cast(TikhubClient, client),
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_allows_legitimate_empty_article_list() -> None:
+    client = _FakeTikhubClient({"data": {"data": []}})
+
+    results = await search(
+        SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
+        client=cast(TikhubClient, client),
+    )
+
+    assert results == []

--- a/tests/unit/test_channel_registry.py
+++ b/tests/unit/test_channel_registry.py
@@ -56,6 +56,28 @@ def test_compile_from_skills_method_unavailable_with_unmet_requires() -> None:
     assert "cookie:stub_cookie" in metadata.methods[0].unmet_requires
 
 
+def test_resolve_requires_accepts_tikhub_proxy_envs_as_api_key_fallback() -> None:
+    env = Environment(env_keys={"AUTOSEARCH_PROXY_URL", "AUTOSEARCH_PROXY_TOKEN"})
+
+    unmet = ChannelRegistry._resolve_requires(["env:TIKHUB_API_KEY"], env)
+
+    assert unmet == []
+
+
+def test_resolve_requires_keeps_tikhub_api_key_unmet_without_proxy_fallback() -> None:
+    unmet = ChannelRegistry._resolve_requires(["env:TIKHUB_API_KEY"], Environment())
+
+    assert unmet == ["env:TIKHUB_API_KEY"]
+
+
+def test_resolve_requires_does_not_apply_tikhub_proxy_shim_to_other_env_tokens() -> None:
+    env = Environment(env_keys={"AUTOSEARCH_PROXY_URL", "AUTOSEARCH_PROXY_TOKEN"})
+
+    unmet = ChannelRegistry._resolve_requires(["env:YOUTUBE_API_KEY"], env)
+
+    assert unmet == ["env:YOUTUBE_API_KEY"]
+
+
 def test_compile_from_skills_preserves_declared_metadata(tmp_path: Path) -> None:
     root = tmp_path / "channels"
     _write_channel_skill(


### PR DESCRIPTION
## Summary

Two more bugs from the post-merge audit round on `2026.04.25.1`.

### P0 (conditional) — TikHub hosted-proxy mode blocked by SKILL.md requires

PR #364 taught `TikhubClient` to run in hosted-proxy mode (use `AUTOSEARCH_PROXY_URL + AUTOSEARCH_PROXY_TOKEN` instead of `TIKHUB_API_KEY`). But every TikHub channel's SKILL.md still hardcodes `requires: [env:TIKHUB_API_KEY]`, so the MCP boundary's `_resolve_requires` check returned `unmet_requires=["env:TIKHUB_API_KEY"]` and `run_channel("zhihu")` (and every other TikHub channel) surfaced `status=not_configured` even when the proxy vars were properly set. Users on a hosted proxy had **zero** working TikHub channels.

**Verified**: with only `AUTOSEARCH_PROXY_URL + AUTOSEARCH_PROXY_TOKEN` set (no `TIKHUB_API_KEY`), `run_channel("zhihu")` returned `not_configured`.

Fix in `autosearch/channels/base.py:_resolve_requires`: when the token is `env:TIKHUB_API_KEY` and both proxy vars are in `env.env_keys`, treat `TIKHUB_API_KEY` as satisfied. TikHub-specific shim, documented inline. Other `env:` tokens unaffected.

### P1 — 4 channels still silently ate schema drift via `get("data", {})`

Earlier audit rounds closed the `invalid_payload_shape` hole at the final `items`/`cards` level, but the navigation above it used `payload.get("data", {})` with dict defaults. When `"data"` was missing or the wrong type, the default `{}` silently fell through, the next `.get()` returned `[]`, the final shape check saw a valid (empty) list and skipped the raise — schema drift masqueraded as legitimate empty results.

Four channels: `zhihu` (1 level), `xiaohongshu` / `instagram` / `weibo` (2 levels of dict nesting). Each navigation step now explicitly checks `isinstance(data, Mapping)` and raises `PermanentError` on mismatch.

Channels left alone (verified):
- `kuaishou` — already raises correctly via `get(..., ...) if isinstance(data, Mapping) else None` → `isinstance(None, list) == False` → existing `raise` triggers
- `wechat_channels` — recursive `docID` scan path is ambiguous (drift vs legit zero-results) and keeps its NOTE comment

## Test plan

- [x] `bash scripts/release-gate.sh` → Release gate PASSED (908 tests)
- [x] New test `tests/unit/test_channel_registry.py` covers proxy-fallback shim with positive, negative, and collateral-damage cases
- [x] Extended per-channel tests for zhihu/xhs/instagram/weibo covering missing data, non-Mapping data, non-Mapping intermediate dict, and legit empty items
- [ ] CI green

## After merge

Will bump to `2026.04.25.2` once this lands (merge batch of #366 only).