### PR TITLE
chore: bump version to 2026.04.25.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.25.1"
+  "version": "2026.04.25.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.25.1",
+  "version": "2026.04.25.2",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2026.04.25.2 — 2026-04-25
+
+The "sixth-pass channel-error" release — two more bugs from the
+post-`.25.1` audit round.
+
+- **TikHub hosted-proxy mode now actually works.** PR #364 taught
+  `TikhubClient` to run in proxy mode (`AUTOSEARCH_PROXY_URL` +
+  `AUTOSEARCH_PROXY_TOKEN` instead of `TIKHUB_API_KEY`), but every
+  TikHub channel's `SKILL.md` still hardcodes
+  `requires: [env:TIKHUB_API_KEY]`, so the MCP boundary's requires
+  check returned `unmet_requires=["env:TIKHUB_API_KEY"]` and every
+  TikHub channel surfaced `status=not_configured` for proxy users.
+  `ChannelRegistry._resolve_requires` now treats `env:TIKHUB_API_KEY`
+  as satisfied when both proxy vars are present. TikHub-specific shim,
+  documented inline; other `env:` tokens unaffected.
+- **Schema drift no longer hides at intermediate dict levels.** The
+  earlier audits closed the `invalid_payload_shape` hole at the final
+  `items` / `cards` level, but the navigation above it still used
+  `payload.get("data", {})` with dict defaults. When `data` was
+  missing or the wrong type, the default `{}` silently fell through,
+  the next `.get()` returned `[]`, and the final shape check saw a
+  valid (empty) list and skipped the raise — schema drift masqueraded
+  as a legitimate empty result. Four channels (`zhihu`, `xiaohongshu`,
+  `instagram`, `weibo`) now check `isinstance(d, Mapping)` at every
+  nesting level and raise `PermanentError` on mismatch.
+
 ## 2026.04.25.1 — 2026-04-25
 
 The "fifth-pass channel-error" release — three more audit rounds on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.1"
+version = "2026.04.25.2"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "autosearch"
-version = "2026.4.25.1"
+version = "2026.4.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Bumps version after #366 merged onto `2026.04.25.1`:

- #366 — fix(channels) TikHub proxy mode satisfies requires (P0 conditional) + 4 channels raise on nested schema drift (P1)

Changes:
- `pyproject.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `npm/package.json` → `2026.04.25.2` (npm: `2026.4.25`)
- `uv.lock` resolved to match
- `CHANGELOG.md` entry — "sixth-pass channel-error"

## Test plan

- [x] `bash scripts/release-gate.sh` → Release gate PASSED (908 tests)
- [ ] CI green → auto-merge → tag `v2026.04.25.2` triggers release.yml