### PR TITLE
fix(channels): TikHub channels raise on item-level schema drift

### DIFF
--- a/autosearch/skills/channels/instagram/methods/via_tikhub.py
+++ b/autosearch/skills/channels/instagram/methods/via_tikhub.py
@@ -105,4 +105,10 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         if ev is not None:
             results.append(ev)
 
+    if items and not results:
+        LOGGER.warning("instagram_tikhub_search_failed", reason="item_schema_drift")
+        raise PermanentError(
+            "instagram via_tikhub: items present but none parsed (item schema drift?)"
+        )
+
     return results

--- a/autosearch/skills/channels/wechat_channels/methods/via_tikhub.py
+++ b/autosearch/skills/channels/wechat_channels/methods/via_tikhub.py
@@ -131,4 +131,10 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         if ev is not None:
             results.append(ev)
 
+    if items and not results:
+        LOGGER.warning("wechat_channels_tikhub_search_failed", reason="item_schema_drift")
+        raise PermanentError(
+            "wechat_channels via_tikhub: items present but none parsed (item schema drift?)"
+        )
+
     return results

--- a/autosearch/skills/channels/weibo/methods/via_tikhub.py
+++ b/autosearch/skills/channels/weibo/methods/via_tikhub.py
@@ -131,9 +131,18 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
 
     fetched_at = datetime.now(UTC)
     results: list[Evidence] = []
-    for mblog in _extract_mblogs(cards):
+    mblogs = _extract_mblogs(cards)
+    if cards and not mblogs:
+        LOGGER.warning("weibo_tikhub_search_failed", reason="item_schema_drift")
+        raise PermanentError("weibo via_tikhub: items present but none parsed (item schema drift?)")
+
+    for mblog in mblogs:
         evidence = _to_evidence(mblog, fetched_at=fetched_at)
         if evidence is not None:
             results.append(evidence)
+
+    if mblogs and not results:
+        LOGGER.warning("weibo_tikhub_search_failed", reason="item_schema_drift")
+        raise PermanentError("weibo via_tikhub: items present but none parsed (item schema drift?)")
 
     return results

--- a/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_tikhub.py
@@ -120,4 +120,10 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         if evidence is not None:
             results.append(evidence)
 
+    if items and not results:
+        LOGGER.warning("xiaohongshu_tikhub_search_failed", reason="item_schema_drift")
+        raise PermanentError(
+            "xiaohongshu via_tikhub: items present but none parsed (item schema drift?)"
+        )
+
     return results

--- a/autosearch/skills/channels/zhihu/methods/via_tikhub.py
+++ b/autosearch/skills/channels/zhihu/methods/via_tikhub.py
@@ -107,4 +107,8 @@ async def search(query: SubQuery, client: TikhubClient | None = None) -> list[Ev
         if evidence is not None:
             results.append(evidence)
 
+    if items and not results:
+        LOGGER.warning("zhihu_tikhub_search_failed", reason="item_schema_drift")
+        raise PermanentError("zhihu via_tikhub: items present but none parsed (item schema drift?)")
+
     return results

--- a/tests/channels/instagram/test_via_tikhub.py
+++ b/tests/channels/instagram/test_via_tikhub.py
@@ -43,6 +43,30 @@ class _FakeTikhubClient:
 
 
 @pytest.mark.asyncio
+async def test_search_raises_permanent_error_when_items_present_but_none_parse() -> None:
+    client = _FakeTikhubClient(
+        {
+            "data": {
+                "data": {
+                    "items": [
+                        {
+                            "shortcode": "ABC123",
+                            "caption": {"text": "Looks valid except code was renamed."},
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    with pytest.raises(PermanentError, match="items present but none parsed"):
+        await search(
+            SubQuery(text="camera", rationale="Need Instagram post coverage"),
+            client=cast(TikhubClient, client),
+        )
+
+
+@pytest.mark.asyncio
 async def test_search_raises_on_invalid_payload_shape() -> None:
     client = _FakeTikhubClient({"data": {"data": {"items": {"unexpected": []}}}})
 

--- a/tests/channels/wechat_channels/test_via_tikhub.py
+++ b/tests/channels/wechat_channels/test_via_tikhub.py
@@ -54,3 +54,37 @@ async def test_search_raises_on_invalid_payload_shape() -> None:
             SubQuery(text="新能源", rationale="Need WeChat Channels coverage"),
             client=cast(TikhubClient, client),
         )
+
+
+@pytest.mark.asyncio
+async def test_search_raises_permanent_error_when_items_present_but_none_parse() -> None:
+    client = _FakeTikhubClient(
+        {
+            "data": {
+                "feeds": [
+                    {
+                        "docID": "",
+                        "title": "Looks like a result but lacks a usable video identifier.",
+                    }
+                ]
+            }
+        }
+    )
+
+    with pytest.raises(PermanentError, match="items present but none parsed"):
+        await search(
+            SubQuery(text="新能源", rationale="Need WeChat Channels coverage"),
+            client=cast(TikhubClient, client),
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_allows_legitimate_empty_items_list() -> None:
+    client = _FakeTikhubClient({"data": {"feeds": []}})
+
+    results = await search(
+        SubQuery(text="新能源", rationale="Need WeChat Channels coverage"),
+        client=cast(TikhubClient, client),
+    )
+
+    assert results == []

--- a/tests/channels/weibo/test_via_tikhub.py
+++ b/tests/channels/weibo/test_via_tikhub.py
@@ -272,7 +272,7 @@ async def test_search_falls_back_to_mid_url_when_bid_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_skips_item_with_no_usable_id() -> None:
+async def test_search_raises_permanent_error_when_mblogs_present_but_none_parse() -> None:
     client = _FakeTikhubClient(
         {
             "data": {
@@ -292,9 +292,35 @@ async def test_search_skips_item_with_no_usable_id() -> None:
         }
     )
 
-    results = await search(_query(), client=cast(TikhubClient, client))
+    with pytest.raises(PermanentError, match="items present but none parsed"):
+        await search(_query(), client=cast(TikhubClient, client))
 
-    assert results == []
+
+@pytest.mark.asyncio
+async def test_search_raises_permanent_error_when_cards_present_but_no_mblogs_parse() -> None:
+    client = _FakeTikhubClient(
+        {
+            "data": {
+                "data": {
+                    "cards": [
+                        {
+                            "card_type": 9,
+                            "blog": {
+                                "id": 909,
+                                "mid": 909,
+                                "bid": "QBpHNjc3x",
+                                "text": "mblog field was renamed.",
+                                "user": {"id": 112244, "screen_name": "SchemaDrift"},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    with pytest.raises(PermanentError, match="items present but none parsed"):
+        await search(_query(), client=cast(TikhubClient, client))
 
 
 @pytest.mark.asyncio

--- a/tests/channels/xiaohongshu/test_via_tikhub.py
+++ b/tests/channels/xiaohongshu/test_via_tikhub.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import pytest
 
+from autosearch.channels.base import PermanentError
 from autosearch.core.models import SubQuery
 from autosearch.lib.tikhub_client import TikhubClient, TikhubError
 
@@ -149,20 +150,20 @@ async def test_search_uses_id_without_xsec_when_token_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_skips_item_without_id() -> None:
+async def test_search_raises_permanent_error_when_items_present_but_none_parse() -> None:
     client = _FakeTikhubClient(
         _search_payload(
             [
                 {
+                    "note_id": "note-renamed",
                     "noteCard": {"displayTitle": "No ID note", "desc": "Should be skipped."},
                 }
             ]
         )
     )
 
-    results = await search(_query(), client=cast(TikhubClient, client))
-
-    assert results == []
+    with pytest.raises(PermanentError, match="items present but none parsed"):
+        await search(_query(), client=cast(TikhubClient, client))
 
 
 @pytest.mark.asyncio
@@ -186,8 +187,6 @@ async def test_search_returns_empty_on_tikhub_error(
 async def test_search_raises_on_invalid_payload_shape(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from autosearch.channels.base import PermanentError
-
     logger = _Logger()
     monkeypatch.setattr(MODULE, "LOGGER", logger)
     client = _FakeTikhubClient({"data": {"data": {"items": {"unexpected": "shape"}}}})
@@ -212,8 +211,6 @@ async def test_search_raises_on_invalid_payload_shape(
 async def test_search_raises_on_missing_or_invalid_nested_data_shape(
     payload: dict[str, object],
 ) -> None:
-    from autosearch.channels.base import PermanentError
-
     client = _FakeTikhubClient(payload)
 
     with pytest.raises(PermanentError, match="invalid payload shape"):

--- a/tests/channels/zhihu/test_via_tikhub.py
+++ b/tests/channels/zhihu/test_via_tikhub.py
@@ -124,6 +124,31 @@ async def test_search_raises_permanent_error_on_malformed_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_search_raises_permanent_error_when_items_present_but_none_parse() -> None:
+    client = _FakeTikhubClient(
+        {
+            "data": {
+                "data": [
+                    {
+                        "article": {
+                            "id": "123456",
+                            "title": "Renamed object field",
+                            "excerpt": "Looks valid except the item field drifted.",
+                        }
+                    }
+                ]
+            }
+        }
+    )
+
+    with pytest.raises(PermanentError, match="items present but none parsed"):
+        await search(
+            SubQuery(text="LLM agent", rationale="Need Zhihu article coverage"),
+            client=cast(TikhubClient, client),
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("payload"),
     [


### PR DESCRIPTION
## Summary

Earlier audits closed top-level and intermediate schema drift, but item-level field renames still slipped through: if TikHub renamed e.g. zhihu's `object` to `article`, every item failed `_to_evidence()`, the function returned `[]`, and MCP saw `no_results` instead of `channel_error`.

Five channels (`zhihu`, `xiaohongshu`, `instagram`, `weibo`, `wechat_channels`) now check at the end of the parse loop: if `items` is non-empty but `results` (the parsed evidence) is empty, raise `PermanentError("...item_schema_drift")`.

Empty input items still returns `[]` (legitimate empty search) — only items-but-zero-output triggers the raise.

## Test plan

- [x] New tests per channel covering item-level drift (zhihu `object`→`article`, xhs `id`→`note_id`, weibo mblog rename, instagram, wechat `docID` present + required field missing)
- [x] Existing legitimate-empty regressions still pass
- [x] Full pytest 915 passed
- [x] Release gate PASSED
- [ ] CI green