### PR TITLE
fix(report): preserve published_at + canonicalize citation URLs

### DIFF
--- a/autosearch/core/citation_index.py
+++ b/autosearch/core/citation_index.py
@@ -5,7 +5,57 @@ In-memory, per server process (lost on restart — intentional).
 
 from __future__ import annotations
 
+import re
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import uuid
+
+
+_TRACKING_QUERY_PARAMS = {
+    "fbclid",
+    "gclid",
+    "ref",
+    "source",
+    "mc_cid",
+    "mc_eid",
+    "_ga",
+    "_gl",
+}
+_ARXIV_ABS_VERSION_RE = re.compile(r"^(/abs/.+?)v\d+$")
+
+
+def _canonicalize_url(url: str) -> str:
+    """Return a dedupe-only canonical URL while preserving display URLs elsewhere."""
+    parsed = urlsplit(url)
+
+    netloc = parsed.netloc
+    if parsed.hostname:
+        host_start = netloc.lower().rfind(parsed.hostname.lower())
+        if host_start >= 0:
+            netloc = (
+                netloc[:host_start]
+                + netloc[host_start : host_start + len(parsed.hostname)].lower()
+                + netloc[host_start + len(parsed.hostname) :]
+            )
+
+    path = re.sub(r"/{2,}", "/", parsed.path)
+    if path != "/":
+        path = path.rstrip("/")
+    if parsed.hostname and parsed.hostname.lower() == "arxiv.org":
+        path = _ARXIV_ABS_VERSION_RE.sub(r"\1", path)
+
+    query_items = [
+        (name, value)
+        for name, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not _is_tracking_query_param(name)
+    ]
+    query = urlencode(query_items, doseq=True)
+
+    return urlunsplit((parsed.scheme, netloc, path, query, ""))
+
+
+def _is_tracking_query_param(name: str) -> bool:
+    normalized = name.lower()
+    return normalized.startswith("utm_") or normalized in _TRACKING_QUERY_PARAMS
 
 
 class CitationIndex:
@@ -35,11 +85,12 @@ def add_citation(index_id: str, url: str, title: str = "", source: str = "") -> 
     Returns the citation number assigned to the URL.
     """
     idx = _CITATION_INDEXES[index_id]
-    if url in idx._url_to_num:
-        return idx._url_to_num[url]
+    canonical_url = _canonicalize_url(url)
+    if canonical_url in idx._url_to_num:
+        return idx._url_to_num[canonical_url]
     num = idx._next_num
     idx._next_num += 1
-    idx._url_to_num[url] = num
+    idx._url_to_num[canonical_url] = num
     idx._entries.append({"num": num, "url": url, "title": title, "source": source})
     return num
 
@@ -77,7 +128,7 @@ def merge_index(target_id: str, source_id: str) -> dict:
     skipped = 0
     for entry in source._entries:
         url = entry["url"]
-        if url in target._url_to_num:
+        if _canonicalize_url(url) in target._url_to_num:
             skipped += 1
         else:
             add_citation(target_id, url, title=entry["title"], source=entry["source"])

--- a/autosearch/core/context_compression.py
+++ b/autosearch/core/context_compression.py
@@ -9,6 +9,7 @@ Used by the consolidate_research MCP tool.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from autosearch.core.evidence import EvidenceProcessor
@@ -20,11 +21,21 @@ MAX_BRIEF_EVIDENCE = 5  # Include at most 5 top items in brief
 MAX_SNIPPET_CHARS = 120
 
 
+def _parse_published_at(value: Any) -> datetime | None:
+    """Parse optional publish timestamps from run_channel context dicts."""
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
 def _evidence_from_dict(d: dict[str, Any]) -> Evidence | None:
     """Reconstruct Evidence from slim dict (best-effort)."""
     try:
-        from datetime import UTC, datetime
-
         return Evidence(
             url=d.get("url", ""),
             title=d.get("title", ""),
@@ -37,6 +48,7 @@ def _evidence_from_dict(d: dict[str, Any]) -> Evidence | None:
             source_channel=d.get("source_channel") or d.get("source") or "unknown",
             score=float(d.get("score") or 0.0),
             fetched_at=datetime.now(UTC),
+            published_at=_parse_published_at(d.get("published_at")),
         )
     except Exception:
         return None
@@ -91,7 +103,7 @@ def compress_evidence(
     lines = [f"**Research Brief** — `{query}`\n"]
     lines.append(f"Processed {len(evidence_list)} items → kept top {len(evs)} by relevance.\n")
     lines.append(f"Sources: {', '.join(f'{c}({n})' for c, n in sorted(source_coverage.items()))}\n")
-    lines.append("\n**Top findings:**\n")
+    lines.append("\n**Top evidence snippets:**\n")
 
     for i, ev in enumerate(evs, 1):
         snippet = (ev.snippet or ev.content or "")[:MAX_SNIPPET_CHARS]

--- a/tests/test_citation_index.py
+++ b/tests/test_citation_index.py
@@ -56,3 +56,48 @@ def test_merge_combines_and_deduplicates():
     assert result["skipped_duplicates"] == 1
     urls = [e["url"] for e in ci._CITATION_INDEXES[target_id]._entries]
     assert "https://example.com/new" in urls
+
+
+def test_add_tracking_param_variants_return_same_number():
+    index_id = ci.create_index()
+    num1 = ci.add_citation(index_id, "https://example.com/a?utm_source=newsletter")
+    num2 = ci.add_citation(index_id, "https://example.com/a?utm_campaign=launch")
+
+    assert num1 == num2
+    assert len(ci._CITATION_INDEXES[index_id]._entries) == 1
+
+
+def test_add_fragment_variant_returns_same_number():
+    index_id = ci.create_index()
+    num1 = ci.add_citation(index_id, "https://example.com/a#section")
+    num2 = ci.add_citation(index_id, "https://example.com/a")
+
+    assert num1 == num2
+    assert len(ci._CITATION_INDEXES[index_id]._entries) == 1
+
+
+def test_add_trailing_slash_variant_returns_same_number():
+    index_id = ci.create_index()
+    num1 = ci.add_citation(index_id, "https://example.com/a/")
+    num2 = ci.add_citation(index_id, "https://example.com/a")
+
+    assert num1 == num2
+    assert len(ci._CITATION_INDEXES[index_id]._entries) == 1
+
+
+def test_add_arxiv_version_variant_returns_same_number():
+    index_id = ci.create_index()
+    num1 = ci.add_citation(index_id, "https://arxiv.org/abs/1234.5678v2")
+    num2 = ci.add_citation(index_id, "https://arxiv.org/abs/1234.5678")
+
+    assert num1 == num2
+    assert len(ci._CITATION_INDEXES[index_id]._entries) == 1
+
+
+def test_add_genuinely_different_paths_return_different_numbers():
+    index_id = ci.create_index()
+    num1 = ci.add_citation(index_id, "https://example.com/a")
+    num2 = ci.add_citation(index_id, "https://example.com/b")
+
+    assert num1 != num2
+    assert len(ci._CITATION_INDEXES[index_id]._entries) == 2

--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -1,0 +1,44 @@
+"""Regression tests for consolidate_research context compression."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from autosearch.core.context_compression import compress_evidence
+
+
+def test_compress_preserves_published_at_in_top_evidence() -> None:
+    published_at = "2026-04-17T12:00:00+00:00"
+
+    brief = compress_evidence(
+        [
+            {
+                "url": "https://arxiv.org/abs/2401.12345",
+                "title": "BM25 ranking explained",
+                "snippet": "BM25 ranking uses term frequency and inverse document frequency.",
+                "source": "arxiv",
+                "published_at": published_at,
+                "score": 0.7,
+            }
+        ],
+        query="BM25 ranking",
+    )
+
+    assert brief["top_evidence"][0]["published_at"] == datetime.fromisoformat(published_at)
+
+
+def test_compress_brief_uses_evidence_snippets_heading_not_findings() -> None:
+    brief = compress_evidence(
+        [
+            {
+                "url": "https://example.com/report",
+                "title": "Weekly report",
+                "snippet": "A raw excerpt from a source.",
+                "source": "web",
+            }
+        ],
+        query="weekly report",
+    )
+
+    assert "**Top evidence snippets:**" in brief["brief_text"]
+    assert "findings" not in brief["brief_text"].lower()


### PR DESCRIPTION
## Summary

Two report-quality bugs from the production-critical fix plan.

### F017 — consolidate_research drops published_at, mislabels findings

`autosearch/core/context_compression.py` rebuilt `Evidence` for `top_evidence` from input dicts but dropped `published_at`, so time-sensitive reports lost timestamps. The `brief_text` template also called raw snippets "Top findings" — implying validation when nothing was synthesized.

Now reads `published_at` from input (string or datetime) and passes it through. Heading renamed to "Top evidence snippets".

### F018 — citation_index didn't canonicalize URLs

`autosearch/skills/meta/citation-index/SKILL.md` promised tracking-param/fragment/arXiv-version canonicalization, but `add_citation` deduped by raw URL — same source got multiple citation numbers.

Added `_canonicalize_url()` (strip utm_*/fbclid/gclid/ref/mc_*/_ga/_gl, strip fragment, normalize trailing slash, strip arXiv `vN` suffix). Dedupe by canonical key; preserve original URL as the display URL so citations still link to what the user gave.

## Test plan

- [x] `published_at` round-trip (ISO string + datetime)
- [x] `brief_text` heading new wording
- [x] Citation dedupe across utm variations, fragment, trailing slash, arXiv version
- [x] Genuinely different paths still get separate citations
- [x] Full pytest 917 passed
- [x] Release gate PASSED
- [ ] CI green