### PR TITLE
fix(release): marketplace metadata sync + npm/PyPI publish atomicity + console version gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.06.7"
+    "version": "2026.04.25.2"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.06.7",
+      "version": "2026.04.25.2",
       "author": {
         "name": "0xmariowu"
       },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,15 @@ concurrency:
 permissions: {}
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+      npm_version: ${{ steps.npm-version.outputs.npm_version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -85,32 +89,83 @@ jobs:
       - name: Check wheel metadata
         run: twine check dist/*
 
-      - name: Check PyPI token availability
-        id: pypi
+      - name: Derive npm version
+        id: npm-version
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          # Single source of truth for the pyproject→npm mapping lives in
+          # scripts/validate/check_version_consistency.py:derive_npm_version
+          # so workflow summaries and publishes cannot drift.
+          NPM_VERSION=$(python - <<'PY'
+          import importlib.util
+          import os
+
+          spec = importlib.util.spec_from_file_location(
+              "cv", "scripts/validate/check_version_consistency.py"
+          )
+          mod = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(mod)
+          print(mod.derive_npm_version(os.environ["VERSION"]))
+          PY
+          )
+          echo "npm_version=$NPM_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-dist
+          path: dist/*
+          if-no-files-found: error
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Require PyPI token
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          if [ -n "$PYPI_TOKEN" ]; then
-            echo "has_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          if [ -z "$PYPI_TOKEN" ]; then
+            echo "::error::PYPI_API_TOKEN secret is required; refusing split npm-only release."
+            exit 1
           fi
 
+      - name: Install twine
+        run: python -m pip install twine
+
       - name: Publish to PyPI
-        if: steps.pypi.outputs.has_token == 'true'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload --skip-existing dist/*
 
-      - name: Note PyPI skip
-        if: steps.pypi.outputs.has_token != 'true'
-        run: echo "PYPI_API_TOKEN secret not set — skipping PyPI publish, creating GitHub Release only."
+  create-github-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, publish-pypi]
+    permissions:
+      contents: write
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: python-dist
+          path: dist
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.build.outputs.tag }}
         run: |
           if gh release view "$TAG" > /dev/null 2>&1; then
             gh release upload "$TAG" dist/* --clobber
@@ -121,6 +176,19 @@ jobs:
               dist/*
           fi
 
+  publish-npm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, publish-pypi]
+    if: needs.publish-pypi.result == 'success'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ needs.build.outputs.tag }}
+          fetch-depth: 0
+
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
@@ -130,20 +198,9 @@ jobs:
       - name: Publish npm wrapper
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          VERSION: ${{ steps.tag.outputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
+          NPM_VERSION: ${{ needs.build.outputs.npm_version }}
         run: |
-          # Single source of truth for the pyproject→npm mapping lives in
-          # scripts/validate/check_version_consistency.py:derive_npm_version
-          # so a publish here matches what npm/package.json on disk should hold.
-          NPM_VERSION=$(python -c "
-          import importlib.util
-          spec = importlib.util.spec_from_file_location(
-              'cv', 'scripts/validate/check_version_consistency.py'
-          )
-          mod = importlib.util.module_from_spec(spec)
-          spec.loader.exec_module(mod)
-          print(mod.derive_npm_version('$VERSION'))
-          ")
           # Intra-day pyproject bumps (YYYY.MM.DD.1 → YYYY.MM.DD.2) map to the
           # same npm version. The npm tarball only depends on the base date,
           # so if it's already published we skip rather than fail the whole
@@ -158,27 +215,24 @@ jobs:
           npm version "$NPM_VERSION" --no-git-tag-version --allow-same-version
           npm publish --access public
 
+  summary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [build, publish-pypi, create-github-release, publish-npm]
+    if: needs.publish-pypi.result == 'success' && needs.publish-npm.result == 'success' && needs.create-github-release.result == 'success'
+    permissions: {}
+    steps:
       - name: Summary
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
-          VERSION: ${{ steps.tag.outputs.version }}
-          PYPI_TOKEN_SET: ${{ steps.pypi.outputs.has_token }}
+          TAG: ${{ needs.build.outputs.tag }}
+          VERSION: ${{ needs.build.outputs.version }}
+          NPM_VERSION: ${{ needs.build.outputs.npm_version }}
           SERVER_URL: ${{ github.server_url }}
           REPO: ${{ github.repository }}
         run: |
-          YEAR=$(echo "$VERSION" | cut -d. -f1)
-          MONTH=$(echo "$VERSION" | cut -d. -f2 | sed 's/^0*//')
-          DAY=$(echo "$VERSION" | cut -d. -f3 | sed 's/^0*//')
-          SEQ=$(echo "$VERSION" | cut -d. -f4)
-          MMDD=$(( MONTH * 100 + DAY ))
-          NPM_VERSION="$YEAR.$MMDD.$SEQ"
           {
             echo "## Released $VERSION"
             echo "- GitHub Release: $SERVER_URL/$REPO/releases/tag/$TAG"
-            if [ "$PYPI_TOKEN_SET" = "true" ]; then
-              echo "- PyPI: https://pypi.org/project/autosearch/$VERSION/"
-            else
-              echo "- PyPI: skipped (no PYPI_API_TOKEN secret)"
-            fi
+            echo "- PyPI: https://pypi.org/project/autosearch/$VERSION/"
             echo "- npm: https://www.npmjs.com/package/autosearch-ai/v/$NPM_VERSION"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/testing/TEST_PLAN.md
+++ b/docs/testing/TEST_PLAN.md
@@ -41,6 +41,11 @@ This is a **maturity mismatch**: we have high test count but low test honesty.
 **Smoke (process-level)**
 
 - `autosearch --version` subprocess exits 0 with correct version string
+- Release version truth uses two local entrypoints before publish:
+  `.venv/bin/autosearch --version` and
+  `python -m autosearch.cli.main --version` must both match
+  `pyproject.toml`. A fresh-install smoke remains the final source of truth for
+  the packaged console script.
 - `autosearch query "..."` subprocess with `DemoChannel` + mocked LLM env → exits 0, stdout contains `## References` and `## Sources`
 - `autosearch serve --port ...` starts, `GET /health` returns 200, `GET /v1/models` returns expected JSON, then shuts down cleanly
 - `autosearch-mcp` JSON-RPC handshake: `initialize` → `tools/list` → `tools/call research` works

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,7 +8,7 @@
 # Updates (when files exist):
 #   - pyproject.toml         (version = "...")
 #   - .claude-plugin/plugin.json         (JSON "version")
-#   - .claude-plugin/marketplace.json    (JSON "version")
+#   - .claude-plugin/marketplace.json    (JSON "version", metadata.version, plugins[0].version)
 #   - CHANGELOG.md                        (prepend empty entry if missing)
 #
 # Usage:
@@ -59,6 +59,12 @@ import json, sys
 path, new_version = sys.argv[1], sys.argv[2]
 with open(path) as f: d = json.load(f)
 d['version'] = new_version
+if path == '.claude-plugin/marketplace.json':
+    d.setdefault('metadata', {})['version'] = new_version
+    plugins = d.setdefault('plugins', [])
+    if not plugins:
+        plugins.append({})
+    plugins[0]['version'] = new_version
 with open(path, 'w') as f: json.dump(d, f, indent=2, ensure_ascii=False); f.write('\n')
 PY
   echo "  updated $path"

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -76,6 +76,57 @@ else
   fail "version files drifted (see output above)"
 fi
 
+# ── Gate 1a: CLI version entrypoints ─────────────────────────────────────────
+step "CLI version entrypoints"
+EXPECTED_VERSION=$("$PYTHON" - <<'PY'
+import tomllib
+
+with open("pyproject.toml", "rb") as f:
+    print(tomllib.load(f)["project"]["version"])
+PY
+)
+
+_check_version_output() {
+  local label="$1"
+  shift
+  local output
+  output=$("$@" --version) || fail "$label --version exited non-zero"
+  output=$(printf '%s\n' "$output" | tr -d '\r' | tail -n 1)
+  "$PYTHON" - "$EXPECTED_VERSION" "$output" "$label" <<'PY' || fail "$label --version mismatch"
+import sys
+
+from packaging.version import Version
+
+expected_raw, actual_raw, label = sys.argv[1:4]
+actual_token = actual_raw.split()[-1] if actual_raw.split() else ""
+
+try:
+    expected = Version(expected_raw)
+    actual = Version(actual_token)
+except Exception as exc:
+    print(
+        f"FAIL: {label} --version could not be parsed: {actual_raw!r} "
+        f"(expected {expected_raw!r}): {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if actual != expected:
+    print(
+        f"FAIL: {label} --version reported {actual_raw}, expected {expected_raw}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+  pass "$label --version matches pyproject.toml"
+}
+
+if [ ! -x "$AUTOSEARCH" ]; then
+  fail "autosearch CLI not installed in $REPO_ROOT/.venv (run: uv pip install -e .)"
+fi
+_check_version_output "$AUTOSEARCH" "$AUTOSEARCH"
+_check_version_output "python -m autosearch.cli.main" "$PYTHON" -m autosearch.cli.main
+
 # ── Gate 1b: uv lockfile freshness (Bug 5 / fix-plan v8 follow-up) ──────────
 # Without this gate, uv.lock can lag behind pyproject for days; any `uv run`
 # silently rewrites it and pollutes the working tree, and CI agents pick up

--- a/scripts/validate/check_version_consistency.py
+++ b/scripts/validate/check_version_consistency.py
@@ -5,6 +5,8 @@ Files checked:
   - pyproject.toml                     [project] version  → canonical (CalVer YYYY.MM.DD.N)
   - .claude-plugin/plugin.json         version            → must equal pyproject
   - .claude-plugin/marketplace.json    version            → must equal pyproject
+  - .claude-plugin/marketplace.json    metadata.version   → must equal pyproject
+  - .claude-plugin/marketplace.json    plugins[0].version → must equal pyproject
   - CHANGELOG.md                       first ## heading   → must equal pyproject
   - npm/package.json                   version            → must equal `derive_npm_version(pyproject)`
 
@@ -44,6 +46,24 @@ def _read_json_version(path: Path) -> str:
     return str(v)
 
 
+def _read_marketplace_versions(path: Path) -> dict[str, str]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    versions = {
+        "marketplace.json version": data.get("version"),
+        "marketplace.json metadata.version": data.get("metadata", {}).get("version"),
+    }
+    plugins = data.get("plugins")
+    if isinstance(plugins, list) and plugins:
+        versions["marketplace.json plugins[0].version"] = plugins[0].get("version")
+    else:
+        versions["marketplace.json plugins[0].version"] = None
+
+    missing = [label for label, value in versions.items() if not value]
+    if missing:
+        raise ValueError(f"version not found in {path}: {', '.join(missing)}")
+    return {label: str(value) for label, value in versions.items()}
+
+
 def _read_changelog() -> str:
     text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     m = re.search(r"^## (\S+)", text, re.MULTILINE)
@@ -74,13 +94,18 @@ def main() -> int:
     for label, fn in [
         ("pyproject.toml", _read_pyproject),
         ("plugin.json", lambda: _read_json_version(ROOT / ".claude-plugin/plugin.json")),
-        ("marketplace.json", lambda: _read_json_version(ROOT / ".claude-plugin/marketplace.json")),
         ("CHANGELOG.md", _read_changelog),
     ]:
         try:
             sources[label] = fn()
         except Exception as exc:
             errors.append(f"  {label}: {exc}")
+
+    marketplace_path = ROOT / ".claude-plugin/marketplace.json"
+    try:
+        sources.update(_read_marketplace_versions(marketplace_path))
+    except Exception as exc:
+        errors.append(f"  marketplace.json: {exc}")
 
     npm_path = ROOT / "npm" / "package.json"
     npm_version: str | None = None


### PR DESCRIPTION
## Summary

Three release-pipeline holes from the production-critical fix plan.

### F012 — marketplace.json metadata version drift

`.claude-plugin/marketplace.json` had three version fields. `bump-version.sh` only updated the top-level. `metadata.version` and `plugins[0].version` were stale → official plugin tag gates would fail.

Synced all three; extended `bump-version.sh` to write all three on every bump; extended `check_version_consistency.py` to validate.

### F013 — release.yml split publish hazard

PyPI publish could skip on missing `PYPI_API_TOKEN`, but npm continued — releases shipped npm-only and `npx autosearch-ai` users couldn't install the Python pkg. Now PyPI is required, npm `needs:` PyPI success.

Also fixed the npm version derivation in release-summary (was producing strings like `2026.425.1`).

### F014 — release-gate didn't catch console-script staleness

`autosearch doctor --json` imports source directly, so a stale editable install's console script wrapper went undetected. New release-gate steps run `.venv/bin/autosearch --version` and `python -m autosearch.cli.main --version`, compare to `pyproject.toml` via `packaging.version` normalization (PEP 440 normalizes leading zeros, so string comparison wouldn't have worked — `2026.04.25.2` vs `2026.4.25.2`).

`docs/testing/TEST_PLAN.md` notes that `python -m` and fresh-install smoke are the source of truth for version-face freshness.

## Test plan

- [x] `python3 -c "import json; d=json.load(open('.claude-plugin/marketplace.json')); assert d['version']==d['metadata']['version']==d['plugins'][0]['version']"`
- [x] `bash scripts/release-gate.sh` PASSED including new console + module version checks
- [x] `python scripts/validate/check_version_consistency.py` PASSED
- [x] Full pytest 910 passed
- [ ] CI green