### PR TITLE
fix(channels/xhs): SKILL.md requires matches what 'autosearch login xhs' writes

### DIFF
--- a/autosearch/skills/channels/xiaohongshu/SKILL.md
+++ b/autosearch/skills/channels/xiaohongshu/SKILL.md
@@ -9,7 +9,7 @@ languages: [zh, mixed]
 methods:
   - id: via_signsrv
     impl: methods/via_signsrv.py
-    requires: [env:AUTOSEARCH_SIGNSRV_URL, env:AUTOSEARCH_SERVICE_TOKEN, env:XHS_A1_COOKIE]
+    requires: [env:AUTOSEARCH_SIGNSRV_URL, env:AUTOSEARCH_SERVICE_TOKEN, env:XHS_COOKIES]
     rate_limit: {per_min: 60, per_hour: 1000}
   - id: via_tikhub
     impl: methods/via_tikhub.py

--- a/tests/unit/test_channel_skill_scaffolds.py
+++ b/tests/unit/test_channel_skill_scaffolds.py
@@ -346,3 +346,32 @@ def test_compile_from_skills_marks_shipped_channels_available_without_keys() -> 
         assert len(metadata.methods) == len(spec.methods)
         assert all(method.available is False for method in metadata.methods)
         assert all(method.unmet_requires == ["impl_missing"] for method in metadata.methods)
+
+
+def test_xiaohongshu_signsrv_available_with_login_cookie_secret_names() -> None:
+    env = Environment(
+        env_keys={
+            "AUTOSEARCH_SIGNSRV_URL",
+            "AUTOSEARCH_SERVICE_TOKEN",
+            "XHS_COOKIES",
+        }
+    )
+    registry = ChannelRegistry.compile_from_skills(_channels_root(), env)
+    methods = {method.id: method for method in registry.metadata("xiaohongshu").methods}
+
+    assert methods["via_signsrv"].available is True
+    assert methods["via_signsrv"].unmet_requires == []
+
+
+def test_xiaohongshu_signsrv_unavailable_without_login_cookie_secret() -> None:
+    env = Environment(
+        env_keys={
+            "AUTOSEARCH_SIGNSRV_URL",
+            "AUTOSEARCH_SERVICE_TOKEN",
+        }
+    )
+    registry = ChannelRegistry.compile_from_skills(_channels_root(), env)
+    methods = {method.id: method for method in registry.metadata("xiaohongshu").methods}
+
+    assert methods["via_signsrv"].available is False
+    assert methods["via_signsrv"].unmet_requires == ["env:XHS_COOKIES"]


### PR DESCRIPTION
## Summary

`autosearch/skills/channels/xiaohongshu/SKILL.md` declared `via_signsrv.requires: [..., env:XHS_A1_COOKIE]`, but the `autosearch login xhs` command writes `XHS_COOKIES` (the canonical cookie name the runtime actually reads). Users running the documented login flow saw `status=not_configured` for `via_signsrv` because the requires gate referenced a name nothing wrote.

Smallest fix: update SKILL.md `via_signsrv.requires` to `env:XHS_COOKIES`. Runtime read path was already correct.

## Test plan

- [x] `tests/unit/test_channel_skill_scaffolds.py` — `AUTOSEARCH_SIGNSRV_URL + AUTOSEARCH_SERVICE_TOKEN + XHS_COOKIES` makes `via_signsrv` available; missing `XHS_COOKIES` keeps it unavailable
- [x] Full pytest 912 passed
- [x] Release gate PASSED
- [ ] CI green