### PR TITLE
docs(install/mcp-clients): align with real MCP schema and tool registration

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -121,19 +121,23 @@ AutoSearch writes this automatically during `init`. For manual setup:
 **Claude Code** (`~/.claude/mcp.json`):
 ```json
 {
-  "autosearch": {
-    "command": "autosearch-mcp",
-    "type": "stdio"
+  "mcpServers": {
+    "autosearch": {
+      "command": "autosearch-mcp",
+      "type": "stdio"
+    }
   }
 }
 ```
 
-**Cursor** (Settings → MCP):
+**Cursor** (`~/.cursor/mcp.json`):
 ```json
 {
-  "autosearch": {
-    "command": "autosearch-mcp",
-    "args": []
+  "mcpServers": {
+    "autosearch": {
+      "command": "autosearch-mcp",
+      "type": "stdio"
+    }
   }
 }
 ```

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -5,7 +5,7 @@ description: "Install AutoSearch as an MCP server in Claude Code, Cursor, and ot
 
 # AutoSearch as an MCP Server
 
-AutoSearch ships a standard [Model Context Protocol](https://modelcontextprotocol.io) stdio server that exposes the v2 tool-supplier toolkit — `list_skills`, `list_channels`, `run_clarify`, `select_channels_tool`, `run_channel`, plus `citation_create` / `citation_add` / `citation_export`, `doctor`, and `health` — to any MCP client. The host agent calls these tools and synthesizes the final answer itself; AutoSearch does not return a pre-baked report. Because the protocol is client-agnostic, the same server binary plugs into Claude Code, Cursor, Zed, Continue, and any other MCP-speaking surface without recompilation.
+AutoSearch ships a standard [Model Context Protocol](https://modelcontextprotocol.io) stdio server that exposes the v2 tool-supplier toolkit — `list_skills`, `list_channels`, `run_clarify`, `select_channels_tool`, `run_channel`, `delegate_subtask`, plus `citation_create` / `citation_add` / `citation_export`, `doctor`, and helper tools such as `health` — to any MCP client. The host agent calls these tools and synthesizes the final answer itself; AutoSearch does not return a pre-baked report. Because the protocol is client-agnostic, the same server binary plugs into Claude Code, Cursor, Zed, Continue, and any other MCP-speaking surface without recompilation.
 
 This page shows the config format for each supported client plus a one-minute verification routine.
 
@@ -128,22 +128,23 @@ Continue uses `~/.continue/config.json`:
 
 ## The v2 MCP tools
 
-The host agent drives a tool-supplier flow: discover skills, optionally clarify the user's intent, pick channels, run them, and synthesize the answer. The 10 required v2 tools:
+The host agent drives a tool-supplier flow: discover skills, optionally clarify the user's intent, pick channels, run them, and synthesize the answer. The 10 required v2 tools are the names in `_REQUIRED_MCP_TOOLS`; `health` is a helper, not a required install-contract tool.
 
-| Tool | Purpose |
-|---|---|
-| `list_skills` | Catalog of channel skills the agent can pick from. |
-| `list_channels` | Per-channel availability (status, methods, language, requires). |
-| `run_clarify` | Optional one-shot clarification turn before search starts. |
-| `select_channels_tool` | Helper that ranks candidate channels for a query. |
-| `run_channel` | Run one channel for one query; returns `status` (`ok` / `no_results` / `not_configured` / `unknown_channel` / `auth_failed` / `rate_limited` / `budget_exhausted` / `channel_error`), `evidence`, `unmet_requires`, `fix_hint`. The core retrieval call. |
-| `citation_create` | Open a citation collection for the current task. |
-| `citation_add` | Append a source URL + supporting evidence. |
-| `citation_export` | Export citations as `[N]`-numbered Markdown references. |
-| `doctor` | Channel-status snapshot (same data as the CLI, JSON-shaped). |
-| `health` | Structured liveness snapshot — version, tool counts, channel counts by status, secrets-file presence (key NAMES only, never values), runtime cooldown snapshot. |
+| Tool | Status | Purpose |
+|---|---|---|
+| `list_skills` | Required | Catalog of channel skills the agent can pick from. |
+| `run_clarify` | Required | Optional one-shot clarification turn before search starts. |
+| `run_channel` | Required | Run one channel for one query; returns `status` (`ok` / `no_results` / `not_configured` / `unknown_channel` / `auth_failed` / `rate_limited` / `budget_exhausted` / `channel_error`), `evidence`, `unmet_requires`, `fix_hint`. The core retrieval call. |
+| `list_channels` | Required | Per-channel availability (status, methods, language, requires). |
+| `doctor` | Required | Channel-status snapshot (same data as the CLI, JSON-shaped). |
+| `select_channels_tool` | Required | Helper that ranks candidate channels for a query. |
+| `delegate_subtask` | Required | Run one query across multiple channels concurrently for a bounded subtask. |
+| `citation_create` | Required | Open a citation collection for the current task. |
+| `citation_add` | Required | Append a source URL + supporting evidence. |
+| `citation_export` | Required | Export citations as `[N]`-numbered Markdown references. |
+| `health` | Helper | Structured liveness snapshot — version, tool counts, required-tool status, channel counts by status, secrets-file presence (key NAMES only, never values), runtime cooldown snapshot. |
 
-Beyond these, the server registers helpers like `consolidate_research`, `delegate_subtask`, `list_modes`, `select_channels_tool`, citation hardening (`citation_merge`), context controls (`context_retention_policy`), and several loop / planning helpers. The deprecated `research` tool is still registered for v1 callers but returns a deprecation response — new integrations should not depend on it.
+Beyond these, the server registers helpers like `consolidate_research`, `list_modes`, citation hardening (`citation_merge`), context controls (`context_retention_policy`), and several loop / planning helpers. The deprecated `research` tool is opt-in: it is only registered when `AUTOSEARCH_LEGACY_RESEARCH=1` is set, and new integrations should not depend on it.
 
 `run_channel` schema:
 
@@ -151,8 +152,8 @@ Beyond these, the server registers helpers like `consolidate_research`, `delegat
 |---|---|---|---|
 | `channel_name` | string | required | One of the channels reported by `list_channels`. |
 | `query` | string | required | Search query. Natural language, English or Chinese. |
+| `rationale` | string | `""` | Optional short rationale, used by some channels to tune ranking. |
 | `k` | int | 10 | Max evidence items to return. |
-| `method_id` | string | (auto) | Pin a specific method when a channel offers more than one. |
 
 ## Verifying the integration
 
@@ -168,7 +169,7 @@ from mcp.client.stdio import stdio_client
 REQUIRED_V2_TOOLS = {
     "list_skills", "list_channels", "run_clarify", "select_channels_tool",
     "run_channel", "citation_create", "citation_add", "citation_export",
-    "doctor", "health",
+    "doctor", "delegate_subtask",
 }
 
 async def main():


### PR DESCRIPTION
## Summary

Four drift points between published docs and actual code behavior:

- `docs/install.md` Claude Code + Cursor examples used a top-level `"autosearch"` config key — real schema is `mcpServers.autosearch`. Fixed both client examples.
- `docs/mcp-clients.md` required-tools table — synced to `_REQUIRED_MCP_TOOLS` (`delegate_subtask` is required; `health` is helper, not required).
- `docs/mcp-clients.md` `run_channel` schema — dropped non-existent `method_id`, added the real `rationale` field.
- `docs/mcp-clients.md` `research` tool — described as default-registered, but real registration is gated by `AUTOSEARCH_LEGACY_RESEARCH=1`. Updated to opt-in legacy description.

Docs-only PR; no code change.

## Test plan

- [x] Sanity grep checks (mcpServers in install.md, _REQUIRED_MCP_TOOLS match, rationale not method_id, AUTOSEARCH_LEGACY_RESEARCH mention)
- [x] Full pytest 910 passed (no code touched)
- [x] Release gate PASSED
- [ ] CI green