### PR TITLE
fix(channels/tieba): captcha/anti-scrape page raises TransientError not ChannelAuthError

### DIFF
--- a/autosearch/skills/channels/tieba/SKILL.md
+++ b/autosearch/skills/channels/tieba/SKILL.md
@@ -42,3 +42,5 @@ Uses `tieba.baidu.com/f/search/res` search endpoint with HTML parsing via trafil
 - Evidence items have non-empty title and url.
 - No crash on empty or malformed HTML response.
 - Source channel field matches "tieba".
+- Baidu safety verification / captcha pages are anti-scrape blocks; treat them as transient platform blocks, not user auth failures.
+- Production use should treat Tieba as anti-scrape-prone and not rely on it as an always-available channel.

--- a/autosearch/skills/channels/tieba/methods/api_search.py
+++ b/autosearch/skills/channels/tieba/methods/api_search.py
@@ -1,4 +1,4 @@
-"""百度贴吧搜索渠道 — 免费，无需 API key。"""
+"""Baidu Tieba search channel; captcha safety pages are anti-scrape blocks."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 import httpx
 import structlog
 
-from autosearch.channels.base import raise_as_channel_error
+from autosearch.channels.base import TransientError, raise_as_channel_error
 from autosearch.core.models import Evidence, SubQuery
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="tieba")
@@ -16,6 +16,14 @@ LOGGER = structlog.get_logger(__name__).bind(component="channel", channel="tieba
 _SEARCH_URL = "https://tieba.baidu.com/f/search/res"
 _HTTP_TIMEOUT = 15.0
 _MAX_RESULTS = 10
+_SAFETY_VERIFY_MARKERS = (
+    "百度安全验证",
+    "wappass.baidu.com",
+    "safetyverify",
+    "verify.baidu.com",
+    "captcha",
+    "安全验证",
+)
 
 _HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
@@ -43,9 +51,32 @@ async def _search_tieba(query: str) -> list[Evidence]:
         timeout=_HTTP_TIMEOUT, headers=_HEADERS, follow_redirects=True
     ) as client:
         resp = await client.get(_SEARCH_URL, params=params)
+        _raise_if_safety_verification_response(resp)
         resp.raise_for_status()
 
     return _parse_results(resp.text)
+
+
+def _raise_if_safety_verification_response(resp: httpx.Response) -> None:
+    if resp.status_code != 403:
+        return
+    if not _looks_like_safety_verification(resp):
+        return
+    raise TransientError("tieba anti-scrape safety verification returned HTTP 403")
+
+
+def _looks_like_safety_verification(resp: httpx.Response) -> bool:
+    body = resp.text.lower()
+    if any(marker.lower() in body for marker in _SAFETY_VERIFY_MARKERS):
+        return True
+
+    content_type = resp.headers.get("content-type", "").lower()
+    is_html = "html" in content_type or "<html" in body
+    if not is_html:
+        return False
+
+    challenge_terms = ("验证码", "安全验证", "人机", "challenge", "captcha", "verify")
+    return any(term in body for term in challenge_terms)
 
 
 def _parse_results(html: str) -> list[Evidence]:

--- a/tests/channels/tieba/test_api_search.py
+++ b/tests/channels/tieba/test_api_search.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 _SKILL_DIR = Path(__file__).parents[3] / "autosearch/skills/channels/tieba/methods"
+_FIXTURE_DIR = Path(__file__).parents[3] / "tests/fixtures"
 
 
 def _load_search():
@@ -44,7 +45,9 @@ _TIEBA_HTML = """
 @pytest.mark.asyncio()
 async def test_search_returns_evidence(search, subquery):
     mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = 200
     mock_resp.text = _TIEBA_HTML
+    mock_resp.headers = {}
     mock_resp.raise_for_status = MagicMock()
 
     with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_resp):
@@ -76,6 +79,38 @@ async def test_search_returns_empty_on_http_error(search, subquery):
 
 
 @pytest.mark.asyncio()
+async def test_search_raises_transient_error_on_baidu_safety_verification(search, subquery):
+    from autosearch.channels.base import TransientError
+
+    request = httpx.Request("GET", "https://tieba.baidu.com/f/search/res")
+    body = (_FIXTURE_DIR / "tieba_baidu_safety_verify.html").read_text(encoding="utf-8")
+    response = httpx.Response(
+        403,
+        text=body,
+        headers={"content-type": "text/html; charset=utf-8"},
+        request=request,
+    )
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=response):
+        with pytest.raises(TransientError) as excinfo:
+            await search(subquery)
+
+    assert excinfo.type is TransientError
+
+
+@pytest.mark.asyncio()
+async def test_search_still_raises_auth_error_on_plain_403(search, subquery):
+    from autosearch.channels.base import ChannelAuthError
+
+    request = httpx.Request("GET", "https://tieba.baidu.com/f/search/res")
+    response = httpx.Response(403, text="forbidden", request=request)
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=response):
+        with pytest.raises(ChannelAuthError):
+            await search(subquery)
+
+
+@pytest.mark.asyncio()
 async def test_search_deduplicates_urls(search, subquery):
     html = """
     <a href="/p/123">贴一</a>
@@ -83,7 +118,9 @@ async def test_search_deduplicates_urls(search, subquery):
     <a href="/p/456">贴二</a>
     """
     mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = 200
     mock_resp.text = html
+    mock_resp.headers = {}
     mock_resp.raise_for_status = MagicMock()
 
     with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_resp):

--- a/tests/fixtures/tieba_baidu_safety_verify.html
+++ b/tests/fixtures/tieba_baidu_safety_verify.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>百度安全验证</title>
+  </head>
+  <body>
+    <h1>百度安全验证</h1>
+    <form action="https://wappass.baidu.com/static/captcha/tuxing.html">
+      <input type="hidden" name="safetyverify" value="1">
+      <p>请完成验证码后继续访问。</p>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Tieba live returns 403 with a Baidu safety-verification captcha page (百度安全验证). The default 403 mapping classified this as `ChannelAuthError → auth_failed`, telling users their config was wrong when actually the platform was just blocking the scrape. No user-fixable action.

Now detects the safety page (markers: `百度安全验证`, `wappass.baidu.com`, `safetyverify`) before `raise_for_status` and raises `TransientError` instead. User sees a transient-channel signal; cooldown/retry logic handles the rest. SKILL.md flagged as anti-scrape-prone.

## Test plan

- [x] HTML fixture for Baidu safety page
- [x] 403 with safety body → `TransientError`
- [x] 403 with normal auth body → `ChannelAuthError` (legit path preserved)
- [x] 200 with valid results → returns evidence
- [x] Full pytest 912 passed
- [x] Release gate PASSED
- [ ] CI green