### PR TITLE
fix(mcp): typed run_channel statuses + delegate_subtask details + experience query_shape

### DIFF
--- a/autosearch/core/channel_status.py
+++ b/autosearch/core/channel_status.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from autosearch.channels.base import (
+    BudgetExhausted,
+    ChannelAuthError,
+    MethodUnavailable,
+    PermanentError,
+    RateLimited,
+    TransientError,
+)
+from autosearch.core.redact import redact
+
+
+@dataclass(frozen=True)
+class ChannelFailureStatus:
+    status: str
+    reason: str
+    fix_hint: str | None = None
+    unmet_requires: list[str] = field(default_factory=list)
+
+
+_MISSING_CONFIG_MARKERS = (
+    "not configured",
+    "missing config",
+    "missing required",
+    "missing env",
+    "missing key",
+    "requirements unmet",
+    "unmet require",
+    "no available search methods",
+)
+
+
+def _method_unavailable_status(exc: MethodUnavailable) -> str:
+    message = str(exc).lower()
+    if any(marker in message for marker in _MISSING_CONFIG_MARKERS):
+        return "not_configured"
+    return "channel_unavailable"
+
+
+def exception_to_channel_status(exc: Exception) -> ChannelFailureStatus:
+    """Map channel exceptions to MCP-facing status fields."""
+
+    if isinstance(exc, BudgetExhausted):
+        status = "budget_exhausted"
+        fix_hint = "Top up the provider balance or switch to a free channel."
+    elif isinstance(exc, ChannelAuthError):
+        status = "auth_failed"
+        fix_hint = "Refresh the channel login or configure a valid API key."
+    elif isinstance(exc, RateLimited):
+        status = "rate_limited"
+        fix_hint = "Wait before retrying or reduce parallel channel fan-out."
+    elif isinstance(exc, TransientError):
+        status = "transient_error"
+        fix_hint = "Retry this channel later."
+    elif isinstance(exc, MethodUnavailable):
+        status = _method_unavailable_status(exc)
+        fix_hint = (
+            "Configure the channel requirements and retry."
+            if status == "not_configured"
+            else "Try another channel or retry after methods recover."
+        )
+    elif isinstance(exc, PermanentError):
+        status = "channel_error"
+        fix_hint = "Do not retry blindly; check for schema drift or a permanent upstream failure."
+    else:
+        status = "channel_error"
+        fix_hint = None
+
+    return ChannelFailureStatus(
+        status=status,
+        reason=redact(f"{status}: {type(exc).__name__}: {exc}"),
+        fix_hint=fix_hint,
+    )

--- a/autosearch/core/delegate.py
+++ b/autosearch/core/delegate.py
@@ -11,6 +11,7 @@ class SubtaskResult:
     evidence_by_channel: dict[str, list[dict]] = field(default_factory=dict)
     summary: str = ""
     failed_channels: list[str] = field(default_factory=list)
+    failed_channel_details: list[dict] = field(default_factory=list)
     budget_used: dict[str, int] = field(default_factory=dict)
 
 
@@ -50,7 +51,19 @@ async def run_subtask(
 
     for name, outcome in outcomes:
         if isinstance(outcome, Exception):
+            from autosearch.core.channel_status import exception_to_channel_status  # noqa: PLC0415
+
+            failure = exception_to_channel_status(outcome)
             result.failed_channels.append(name)
+            result.failed_channel_details.append(
+                {
+                    "channel": name,
+                    "status": failure.status,
+                    "reason": failure.reason,
+                    "fix_hint": failure.fix_hint,
+                    "unmet_requires": failure.unmet_requires,
+                }
+            )
         else:
             result.evidence_by_channel[name] = outcome
             result.budget_used[name] = len(outcome)

--- a/autosearch/core/experience_compact.py
+++ b/autosearch/core/experience_compact.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from autosearch.core.experience_privacy import query_shape_label, shape_from_legacy_query
 from autosearch.skills.experience import _parse_datetime, _runtime_skill_dir
 
 
@@ -56,6 +57,17 @@ def _read_events(patterns_path: Path) -> list[dict[str, Any]]:
             except json.JSONDecodeError:
                 continue
             if isinstance(payload, dict):
+                channel = str(payload.get("channel") or payload.get("skill") or "unknown")
+                outcome = str(payload.get("outcome") or "unknown")
+                if "query_shape" not in payload and "query" in payload:
+                    legacy_shape = shape_from_legacy_query(
+                        payload.get("query"),
+                        channel=channel,
+                        outcome=outcome,
+                    )
+                    if legacy_shape is not None:
+                        payload["query_shape"] = legacy_shape
+                payload.pop("query", None)
                 events.append(payload)
     return events
 
@@ -97,6 +109,8 @@ def compact(skill_name: str) -> bool:
                 )
 
             good_query = _clean_text(event.get("good_query"))
+            if good_query is None:
+                good_query = query_shape_label(event.get("query_shape"))
             if good_query is not None:
                 good_queries[good_query] += 1
                 good_query_last_seen[good_query] = _update_last_verified(

--- a/autosearch/core/experience_privacy.py
+++ b/autosearch/core/experience_privacy.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _is_cjk(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        0x3400 <= codepoint <= 0x4DBF
+        or 0x4E00 <= codepoint <= 0x9FFF
+        or 0xF900 <= codepoint <= 0xFAFF
+        or 0x3040 <= codepoint <= 0x30FF
+        or 0xAC00 <= codepoint <= 0xD7AF
+    )
+
+
+def _is_latin(char: str) -> bool:
+    return ("A" <= char <= "Z") or ("a" <= char <= "z") or (0x00C0 <= ord(char) <= 0x00FF)
+
+
+def detect_query_language(query: str) -> str:
+    """Return a coarse language class without storing query content."""
+
+    has_latin = False
+    has_other_alpha = False
+    for char in query:
+        if _is_cjk(char):
+            return "cjk"
+        if _is_latin(char):
+            has_latin = True
+        elif char.isalpha():
+            has_other_alpha = True
+
+    if has_latin and not has_other_alpha:
+        return "latin"
+    if has_latin and has_other_alpha:
+        return "mixed"
+    return "other"
+
+
+def query_shape(query: str, *, channel: str, outcome: str) -> dict[str, str]:
+    length = len(query)
+    if length < 20:
+        length_bucket = "short"
+    elif length < 60:
+        length_bucket = "medium"
+    else:
+        length_bucket = "long"
+
+    return {
+        "length_bucket": length_bucket,
+        "language": detect_query_language(query),
+        "channel": channel,
+        "outcome": outcome,
+    }
+
+
+def shape_from_legacy_query(value: Any, *, channel: str, outcome: str) -> dict[str, str] | None:
+    if not isinstance(value, str):
+        return None
+    return query_shape(value, channel=channel, outcome=outcome)
+
+
+def query_shape_label(shape: Any) -> str | None:
+    if not isinstance(shape, dict):
+        return None
+    length_bucket = shape.get("length_bucket")
+    language = shape.get("language")
+    channel = shape.get("channel")
+    outcome = shape.get("outcome")
+    if not all(isinstance(v, str) and v for v in (length_bucket, language, channel, outcome)):
+        return None
+    return f"{channel}:{outcome}:{length_bucket}:{language}"

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -60,6 +60,9 @@ class RunChannelResponse(BaseModel):
       - `budget_exhausted`: paid quota / wallet is empty (TikHub 402, etc).
         Distinct from rate_limited because the fix is "top up balance",
         not "wait and retry" (Bug 3 / fix-plan v8 follow-up).
+      - `transient_error`: retryable transport or upstream failure.
+      - `channel_unavailable`: channel is configured, but no method is usable
+        right now.
       - `channel_error`: any other unexpected failure.
     """
 
@@ -671,7 +674,9 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
 
         from datetime import UTC, datetime
 
+        from autosearch.core.channel_status import exception_to_channel_status
         from autosearch.core.experience_compact import compact
+        from autosearch.core.experience_privacy import query_shape
         from autosearch.skills.experience import (
             append_event,
             load_experience_digest,
@@ -690,7 +695,8 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
                 channel_name,
                 {
                     "skill": channel_name,
-                    "query": query,
+                    "channel": channel_name,
+                    "query_shape": query_shape(query, channel=channel_name, outcome="error"),
                     "outcome": "error",
                     "count_returned": 0,
                     "count_total": 0,
@@ -699,32 +705,14 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             )
             if should_compact(channel_name):
                 compact(channel_name)
-            from autosearch.channels.base import (
-                BudgetExhausted,
-                ChannelAuthError,
-                RateLimited,
-            )
-            from autosearch.core.redact import redact
-
-            # Bug 1 (fix-plan): map known typed channel errors to distinct
-            # status values so an authentication failure / rate limit doesn't
-            # masquerade as "channel_error" or — worse — empty results.
-            # Bug 3 (fix-plan v8 follow-up): split budget_exhausted from
-            # rate_limited so the agent can tell the user "top up" rather
-            # than "wait and retry".
-            if isinstance(exc, BudgetExhausted):
-                status = "budget_exhausted"
-            elif isinstance(exc, ChannelAuthError):
-                status = "auth_failed"
-            elif isinstance(exc, RateLimited):
-                status = "rate_limited"
-            else:
-                status = "channel_error"
+            failure = exception_to_channel_status(exc)
             return RunChannelResponse(
                 channel=channel_name,
                 ok=False,
-                status=status,
-                reason=redact(f"{status}: {type(exc).__name__}: {exc}"),
+                status=failure.status,
+                reason=failure.reason,
+                unmet_requires=failure.unmet_requires,
+                fix_hint=failure.fix_hint,
             )
 
         # Quality pipeline: URL dedup → SimHash near-dedup → BM25 relevance rerank
@@ -739,7 +727,8 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             channel_name,
             {
                 "skill": channel_name,
-                "query": query,
+                "channel": channel_name,
+                "query_shape": query_shape(query, channel=channel_name, outcome="success"),
                 "outcome": "success",
                 "count_returned": len(returned),
                 "count_total": total,
@@ -902,7 +891,7 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
         """Run a query across multiple channels concurrently.
 
         Use when you want to search several channels in parallel for the same query.
-        Returns {evidence_by_channel, summary, failed_channels, budget_used}.
+        Returns {evidence_by_channel, summary, failed_channels, failed_channel_details, budget_used}.
         """
         from autosearch.core.delegate import run_subtask  # noqa: PLC0415
 
@@ -911,6 +900,7 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             "evidence_by_channel": result.evidence_by_channel,
             "summary": result.summary,
             "failed_channels": result.failed_channels,
+            "failed_channel_details": result.failed_channel_details,
             "budget_used": result.budget_used,
         }
 

--- a/autosearch/observability/channel_health.py
+++ b/autosearch/observability/channel_health.py
@@ -15,7 +15,8 @@ class FailureCategory(StrEnum):
     """
 
     QUOTA_EXHAUSTED = "quota"  # budget exhausted → cooldown 24h, degrade to free channel
-    AUTH_FAILURE = "auth"  # cookie/session invalid → no cooldown, prompt autosearch login
+    AUTH_FAILURE = "auth"  # cookie/session invalid → long cooldown, prompt user action
+    PERMANENT_FAILURE = "permanent"  # schema drift / permanent upstream failure → long cooldown
     NETWORK_ERROR = "network"  # timeout/connection → cooldown 5min, retry
     PLATFORM_BLOCK = "block"  # platform anti-bot block → cooldown 1h, degrade
 
@@ -23,10 +24,29 @@ class FailureCategory(StrEnum):
 # Per-category cooldown durations (seconds)
 _CATEGORY_COOLDOWN: dict[FailureCategory, int] = {
     FailureCategory.QUOTA_EXHAUSTED: 86400,  # 24h
-    FailureCategory.AUTH_FAILURE: 0,  # no cooldown, needs user action
+    FailureCategory.AUTH_FAILURE: 86400,  # 24h, needs user action
+    FailureCategory.PERMANENT_FAILURE: 86400,  # 24h, waiting alone won't fix schema/auth
     FailureCategory.NETWORK_ERROR: 300,  # 5min
     FailureCategory.PLATFORM_BLOCK: 3600,  # 1h
 }
+
+
+def _failure_category_from_error(error: str | None) -> FailureCategory | None:
+    if error is None:
+        return None
+    normalized = error.lower()
+    if normalized in {"auth_failed", "channelautherror"} or "auth" in normalized:
+        return FailureCategory.AUTH_FAILURE
+    if normalized in {"budget_exhausted", "budgetexhausted", "quota"}:
+        return FailureCategory.QUOTA_EXHAUSTED
+    if (
+        normalized in {"permanent", "permanenterror", "permanent_failure"}
+        or "permanent" in normalized
+    ):
+        return FailureCategory.PERMANENT_FAILURE
+    if normalized in {"transient_error", "transienterror", "rate_limited", "ratelimited"}:
+        return FailureCategory.NETWORK_ERROR
+    return None
 
 
 @dataclass(slots=True)
@@ -82,6 +102,19 @@ class ChannelHealth:
             return
 
         state.fail_count += 1
+        category = _failure_category_from_error(error)
+        if category is not None:
+            state.last_failure_category = category
+            cooldown = (
+                self._cooldown_seconds
+                if category is FailureCategory.NETWORK_ERROR
+                else _CATEGORY_COOLDOWN.get(category, self._cooldown_seconds)
+            )
+            if cooldown > 0:
+                state.cooldown_until = now + cooldown
+                state.consecutive_failures.clear()
+            return
+
         state.consecutive_failures.append(now)
         while (
             state.consecutive_failures

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -134,7 +134,7 @@ The host agent drives a tool-supplier flow: discover skills, optionally clarify 
 |---|---|---|
 | `list_skills` | Required | Catalog of channel skills the agent can pick from. |
 | `run_clarify` | Required | Optional one-shot clarification turn before search starts. |
-| `run_channel` | Required | Run one channel for one query; returns `status` (`ok` / `no_results` / `not_configured` / `unknown_channel` / `auth_failed` / `rate_limited` / `budget_exhausted` / `channel_error`), `evidence`, `unmet_requires`, `fix_hint`. The core retrieval call. |
+| `run_channel` | Required | Run one channel for one query; returns `status` (`ok` / `no_results` / `not_configured` / `unknown_channel` / `auth_failed` / `rate_limited` / `budget_exhausted` / `transient_error` / `channel_unavailable` / `channel_error`), `evidence`, `unmet_requires`, `fix_hint`. The core retrieval call. |
 | `list_channels` | Required | Per-channel availability (status, methods, language, requires). |
 | `doctor` | Required | Channel-status snapshot (same data as the CLI, JSON-shaped). |
 | `select_channels_tool` | Required | Helper that ranks candidate channels for a query. |
@@ -208,6 +208,8 @@ The same handshake lands under `tests/e2b/matrix.yaml::F004_S4_mcp_stdio` in CI,
 | `run_channel` returns `status="auth_failed"` | Upstream rejected the request — 401/403, expired cookie, invalid API key, or a flagged account (XHS `code=300011`) | Follow the `fix_hint` (typically `autosearch login <channel>` with a different account, or `autosearch configure <KEY> <new-value>`) |
 | `run_channel` returns `status="rate_limited"` | The declared per-minute / per-hour limit was exceeded for that channel + method | Lower the agent's parallel-channel fan-out, or wait a minute before retrying |
 | `run_channel` returns `status="budget_exhausted"` | Paid quota / wallet is empty (TikHub 402, OpenAI `insufficient_quota`, etc.) | Top up the provider's balance — retrying without refilling will loop on the same error |
+| `run_channel` returns `status="transient_error"` | Retryable transport or upstream failure | Retry the same channel later, or continue with other channels and come back if coverage is weak |
+| `run_channel` returns `status="channel_unavailable"` | The channel is configured, but no method is usable right now | Try another channel; retry later if the unavailable method is expected to recover |
 | `run_channel` returns `status="channel_error"` with a redacted `reason` | Upstream channel hiccup; secret-shaped strings are scrubbed before reaching the response | Retry; if persistent, check `autosearch doctor --json` and the upstream provider's status page |
 
 ## Where to go next

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 
 import pytest
 
+from autosearch.channels.base import (
+    BudgetExhausted,
+    ChannelAuthError,
+    MethodUnavailable,
+    RateLimited,
+)
 from autosearch.core.delegate import run_subtask
 
 
@@ -39,6 +45,8 @@ async def test_failed_channel_recorded_not_raised():
     assert "ok" in result.evidence_by_channel
     assert "bad" in result.failed_channels
     assert "bad" not in result.evidence_by_channel
+    assert result.failed_channel_details[0]["channel"] == "bad"
+    assert result.failed_channel_details[0]["status"] == "channel_error"
 
 
 @pytest.mark.asyncio
@@ -48,3 +56,65 @@ async def test_max_per_channel_limits_evidence():
 
     result = await run_subtask("task", ["ch"], "query", max_per_channel=3, _search_fn=_search)
     assert len(result.evidence_by_channel["ch"]) <= 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "expected_status"),
+    [
+        (ChannelAuthError("HTTP 403"), "auth_failed"),
+        (RateLimited("HTTP 429"), "rate_limited"),
+        (BudgetExhausted("wallet empty"), "budget_exhausted"),
+        (MethodUnavailable("missing config: TOKEN required"), "not_configured"),
+        (MethodUnavailable("exhausted all fallback methods"), "channel_unavailable"),
+    ],
+)
+async def test_failed_channel_details_preserve_typed_statuses(
+    exc: Exception,
+    expected_status: str,
+) -> None:
+    async def _search(_channel_name: str) -> list[dict]:
+        raise exc
+
+    result = await run_subtask("task", ["bad"], "query", _search_fn=_search)
+
+    assert result.failed_channels == ["bad"]
+    assert result.failed_channel_details[0]["channel"] == "bad"
+    assert result.failed_channel_details[0]["status"] == expected_status
+    assert result.failed_channel_details[0]["reason"]
+    assert "fix_hint" in result.failed_channel_details[0]
+    if expected_status == "auth_failed":
+        assert result.failed_channel_details[0]["fix_hint"]
+
+
+@pytest.mark.asyncio
+async def test_delegate_subtask_mcp_response_includes_failed_channel_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autosearch.core.delegate import SubtaskResult
+    from autosearch.mcp.server import create_server
+
+    async def _fake_run_subtask(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        return SubtaskResult(
+            failed_channels=["bad"],
+            failed_channel_details=[
+                {
+                    "channel": "bad",
+                    "status": "auth_failed",
+                    "reason": "auth_failed: ChannelAuthError: HTTP 403",
+                    "fix_hint": "Refresh the channel login or configure a valid API key.",
+                    "unmet_requires": [],
+                }
+            ],
+        )
+
+    monkeypatch.setattr("autosearch.core.delegate.run_subtask", _fake_run_subtask)
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+
+    payload = await server._tool_manager.call_tool(  # noqa: SLF001
+        "delegate_subtask",
+        {"task_description": "task", "channels": ["bad"], "query": "query"},
+    )
+
+    assert payload["failed_channels"] == ["bad"]
+    assert payload["failed_channel_details"][0]["status"] == "auth_failed"

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -97,6 +97,36 @@ def test_compact_reads_events_and_writes_experience_md_with_structure(
     assert len(digest.splitlines()) <= 120
 
 
+def test_compact_converts_legacy_raw_query_to_shape_without_promoting_text(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    skill_dir = _make_skill_root(tmp_path, monkeypatch)
+    patterns_dir = skill_dir / "experience"
+    patterns_dir.mkdir()
+    patterns_path = patterns_dir / "patterns.jsonl"
+    raw_query = "private customer renewal problem"
+    events = [
+        {
+            "ts": f"2026-04-22T00:0{idx}:00+00:00",
+            "skill": "demo",
+            "outcome": "success",
+            "query": raw_query,
+        }
+        for idx in range(3)
+    ]
+    patterns_path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+    assert compact("demo") is True
+
+    digest = skill_dir.joinpath("experience.md").read_text(encoding="utf-8")
+    assert raw_query not in digest
+    assert "demo:success:medium:latin" in digest
+
+
 def test_should_compact_returns_true_when_event_count_meets_threshold(
     tmp_path,
     monkeypatch,

--- a/tests/test_run_channel_experience.py
+++ b/tests/test_run_channel_experience.py
@@ -99,7 +99,7 @@ async def test_run_channel_appends_to_patterns_jsonl_after_execution(
     tm = server._tool_manager  # noqa: SLF001
     response = await tm.call_tool(
         "run_channel",
-        {"channel_name": "bilibili", "query": "test query", "k": 1},
+        {"channel_name": "bilibili", "query": "private launch question", "k": 1},
     )
 
     assert isinstance(response, RunChannelResponse)
@@ -108,13 +108,56 @@ async def test_run_channel_appends_to_patterns_jsonl_after_execution(
     patterns_path = skill_dir / "experience" / "patterns.jsonl"
     lines = patterns_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
+    assert "private launch question" not in lines[0]
     payload = json.loads(lines[0])
     assert payload["skill"] == "bilibili"
-    assert payload["query"] == "test query"
+    assert "query" not in payload
+    assert payload["channel"] == "bilibili"
+    assert payload["query_shape"] == {
+        "length_bucket": "medium",
+        "language": "latin",
+        "channel": "bilibili",
+        "outcome": "success",
+    }
     assert payload["outcome"] == "success"
     assert payload["count_total"] == 2
     assert payload["count_returned"] == 1
     assert datetime.fromisoformat(payload["ts"]).tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_experience_compact_uses_query_shape_without_raw_query(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autosearch.core.experience_compact import compact
+
+    skill_dir = _make_skill_dir(tmp_path, monkeypatch)
+    channel = _CapturingChannel(
+        "bilibili",
+        [_make_evidence("https://example.com/a", "Item A", "bilibili")],
+    )
+    monkeypatch.setattr("autosearch.mcp.server._build_channels", lambda: [channel])
+
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager  # noqa: SLF001
+    raw_query = "sensitive account launch details"
+    for _ in range(3):
+        response = await tm.call_tool(
+            "run_channel",
+            {"channel_name": "bilibili", "query": raw_query, "k": 1},
+        )
+        assert response.ok is True
+
+    patterns_path = skill_dir / "experience" / "patterns.jsonl"
+    body = patterns_path.read_text(encoding="utf-8")
+    assert raw_query not in body
+    assert '"query_shape"' in body
+
+    assert compact("bilibili") is True
+    digest = skill_dir.joinpath("experience.md").read_text(encoding="utf-8")
+    assert raw_query not in digest
+    assert "bilibili:success:medium:latin" in digest
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_channel_health.py
+++ b/tests/unit/test_channel_health.py
@@ -64,6 +64,35 @@ def test_cooldown_expires_after_configured_seconds() -> None:
     assert health.is_in_cooldown("stub", "echo") is False
 
 
+def test_auth_and_permanent_failures_enter_long_cooldown() -> None:
+    clock = FakeClock()
+    health = ChannelHealth(now=clock, cooldown_seconds=30)
+
+    health.record("stub", "auth", success=False, latency_ms=1.0, error="ChannelAuthError")
+    health.record("stub", "permanent", success=False, latency_ms=1.0, error="PermanentError")
+
+    clock.advance(31)
+
+    assert health.is_in_cooldown("stub", "auth") is True
+    assert health.is_in_cooldown("stub", "permanent") is True
+
+
+def test_transient_and_rate_limited_failures_use_short_cooldown() -> None:
+    clock = FakeClock()
+    health = ChannelHealth(now=clock, cooldown_seconds=30)
+
+    health.record("stub", "transient", success=False, latency_ms=1.0, error="TransientError")
+    health.record("stub", "rate", success=False, latency_ms=1.0, error="RateLimited")
+
+    assert health.is_in_cooldown("stub", "transient") is True
+    assert health.is_in_cooldown("stub", "rate") is True
+
+    clock.advance(31)
+
+    assert health.is_in_cooldown("stub", "transient") is False
+    assert health.is_in_cooldown("stub", "rate") is False
+
+
 def test_is_in_cooldown_method_specific_vs_any() -> None:
     clock = FakeClock()
     health = ChannelHealth(now=clock)

--- a/tests/unit/test_run_channel_typed_status.py
+++ b/tests/unit/test_run_channel_typed_status.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import pytest
 
 import autosearch.mcp.server as mcp_server
-from autosearch.channels.base import ChannelAuthError, RateLimited
+from autosearch.channels.base import (
+    ChannelAuthError,
+    MethodUnavailable,
+    PermanentError,
+    RateLimited,
+    TransientError,
+)
 from autosearch.core.channel_runtime import reset_channel_runtime
 
 
@@ -78,6 +84,46 @@ async def test_rate_limit_returns_status_rate_limited(_stub_channel) -> None:
     result = await _call_run_channel("github")
     assert result.ok is False
     assert result.status == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_transient_error_returns_status_transient_error(_stub_channel) -> None:
+    _stub_channel(_RaisingChannel("github", TransientError("temporary upstream failure")))
+    result = await _call_run_channel("github")
+    assert result.ok is False
+    assert result.status == "transient_error"
+
+
+@pytest.mark.asyncio
+async def test_permanent_error_remains_channel_error_with_discriminating_reason(
+    _stub_channel,
+) -> None:
+    _stub_channel(_RaisingChannel("github", PermanentError("schema drift in payload")))
+    result = await _call_run_channel("github")
+    assert result.ok is False
+    assert result.status == "channel_error"
+    assert result.reason is not None
+    assert "PermanentError" in result.reason
+
+
+@pytest.mark.asyncio
+async def test_method_unavailable_missing_config_returns_not_configured(_stub_channel) -> None:
+    _stub_channel(
+        _RaisingChannel("github", MethodUnavailable("missing config: GITHUB_TOKEN is required"))
+    )
+    result = await _call_run_channel("github")
+    assert result.ok is False
+    assert result.status == "not_configured"
+
+
+@pytest.mark.asyncio
+async def test_method_unavailable_runtime_exhaustion_returns_channel_unavailable(
+    _stub_channel,
+) -> None:
+    _stub_channel(_RaisingChannel("github", MethodUnavailable("exhausted all fallback methods")))
+    result = await _call_run_channel("github")
+    assert result.ok is False
+    assert result.status == "channel_unavailable"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three production-critical fixes that all touch `autosearch/mcp/server.py`, bundled into one PR but as three commits since they're independent logical changes.

### F020 — `run_channel` typed status mapping

`TransientError`, `PermanentError`, `MethodUnavailable` were all squashed into `channel_error`. Host agent couldn't tell "retry me" from "this channel is broken" from "no methods available". Added a shared exception→status mapper (`autosearch/core/channel_status.py`):

- `TransientError` → `transient_error` (host can backoff + retry)
- `MethodUnavailable` → `not_configured` (config msg) or `channel_unavailable`
- `PermanentError` → `channel_error` (reason carries the discriminator)

Wired `channel_health` cooldown to use the categorized failure: auth + permanent get long cooldown (waiting won't fix); transient + rate-limited use short cooldown.

### F009 — `delegate_subtask` preserves typed statuses

`delegate_subtask` previously squashed all exceptions into `failed_channels: list[str]`. Agent got channel names with no status / reason / fix_hint. Now uses the same shared mapper to populate `failed_channel_details: list[dict]` with `{channel, status, reason, fix_hint, unmet_requires}`. Legacy `failed_channels` field stays for backward compat.

### F019 — Experience layer privacy

`run_channel` was writing raw `query` strings to `~/.autosearch/experience/.../patterns.jsonl`. That's user content / PII on disk; the compact path then embedded it into summaries. Replaced raw query with `query_shape`:

- `length_bucket`: short (<20) / medium (<60) / long (≥60)
- `language`: cjk / latin / mixed (library-free heuristic)
- All other fields (channel, outcome, counts, ts) kept

`experience_compact` consumes `query_shape` and strips any legacy raw `query` field on read (backward-compat).

## Test plan

- [x] `tests/unit/test_run_channel_typed_status.py` covers `transient_error` / `channel_unavailable` paths
- [x] `tests/unit/test_channel_health.py` covers categorized cooldown
- [x] `tests/test_delegate.py` covers `failed_channel_details` for each typed exception
- [x] `tests/test_run_channel_experience.py` asserts no raw query in patterns.jsonl
- [x] Full pytest 924 passed
- [x] Release gate PASSED
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Channel failures now provide structured diagnostic information including status types, helpful remediation hints, and detailed reasons.
  * Queries are now anonymized in system logs and analytics using metadata (length, language, channel, outcome) instead of raw text.
  * Improved channel reliability through intelligent cooldown periods based on failure type (permanent vs transient issues).

* **Documentation**
  * Updated troubleshooting guide with guidance for new channel failure types and recommended recovery actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->