### PR TITLE
feat(release): version-uniqueness gate + drop twine --skip-existing (P0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Install autosearch (for release-gate CLI surface checks)
         run: pip install -e ".[dev]"
 
-      - name: Run release-gate.sh --quick (version + lint + CLI surface)
-        run: bash scripts/release-gate.sh --quick
+      - name: Run release-gate.sh --quick --pypi (version + uniqueness + lint + CLI surface)
+        run: bash scripts/release-gate.sh --quick --pypi
 
       - name: Install build backend
         run: pip install build twine
@@ -147,7 +147,7 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload --skip-existing dist/*
+        run: twine upload dist/*
 
   create-github-release:
     runs-on: ubuntu-latest

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -34,6 +34,19 @@ else
     next_seq=$((${BASH_REMATCH[1]} + 1))
   fi
   new_version="${today}.${next_seq}"
+  head_commit=$(git rev-parse HEAD 2>/dev/null || true)
+  while git show-ref --tags --verify --quiet "refs/tags/v${new_version}"; do
+    tag_commit=$(git rev-list -n 1 "v${new_version}" 2>/dev/null || true)
+    if [ -n "$head_commit" ] && [ "$tag_commit" = "$head_commit" ]; then
+      break
+    fi
+    next_seq=$((next_seq + 1))
+    if [ "$next_seq" -gt 99 ]; then
+      echo "ERROR: no unclaimed ${today}.N version found before ${today}.99" >&2
+      exit 1
+    fi
+    new_version="${today}.${next_seq}"
+  done
 fi
 
 echo "Bumping to $new_version"

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -16,6 +16,7 @@
 # Usage:
 #   scripts/release-gate.sh                # run all gates including full suite
 #   scripts/release-gate.sh --quick        # skip the full default suite; contract gates still run
+#   scripts/release-gate.sh --quick --pypi # also check PyPI version uniqueness
 
 set -euo pipefail
 
@@ -23,9 +24,11 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 QUICK=false
+CHECK_PYPI=false
 for arg in "$@"; do
   case "$arg" in
     --quick) QUICK=true ;;
+    --pypi) CHECK_PYPI=true ;;
     -h|--help)
       grep -E '^# ' "$0" | sed 's/^# \?//'
       exit 0
@@ -74,6 +77,25 @@ if "$PYTHON" scripts/validate/check_version_consistency.py; then
   pass "version files agree"
 else
   fail "version files drifted (see output above)"
+fi
+
+step "version uniqueness"
+if "$PYTHON" scripts/validate/check_version_uniqueness.py --mode=local; then
+  pass "version is locally unique or tagged at current HEAD"
+else
+  fail "version already claimed by a different local tag"
+fi
+
+if [ "$QUICK" = false ] || [ "$CHECK_PYPI" = true ]; then
+  set +e
+  "$PYTHON" scripts/validate/check_version_uniqueness.py --mode=pypi
+  pypi_uniqueness_status=$?
+  set -e
+  case "$pypi_uniqueness_status" in
+    0) pass "version is not already published on PyPI" ;;
+    2) echo "WARN: PyPI version uniqueness could not be verified; continuing fail-open" ;;
+    *) fail "version already claimed on PyPI" ;;
+  esac
 fi
 
 # ── Gate 1a: CLI version entrypoints ─────────────────────────────────────────

--- a/scripts/validate/check_version_uniqueness.py
+++ b/scripts/validate/check_version_uniqueness.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Verify the pyproject version has not already been claimed.
+
+Checks:
+  - local git tag v<version>, if present, points at the current HEAD
+  - PyPI releases for autosearch do not already include the normalized version
+
+Network verification failures exit with UNVERIFIED so callers can decide
+whether to block or warn.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from packaging.version import InvalidVersion, Version
+
+ROOT = Path(__file__).resolve().parents[2]
+PYPI_URL = "https://pypi.org/pypi/autosearch/json"
+OK = 0
+CONFLICT = 1
+UNVERIFIED = 2
+
+
+def read_pyproject_version(root: Path | None = None) -> str:
+    root = ROOT if root is None else root
+    with (root / "pyproject.toml").open("rb") as f:
+        data = tomllib.load(f)
+    try:
+        return str(data["project"]["version"])
+    except KeyError as exc:
+        raise ValueError("version not found in pyproject.toml [project]") from exc
+
+
+def normalize_version(version: str) -> str:
+    return str(Version(version))
+
+
+def _git(args: list[str], root: Path | None = None) -> subprocess.CompletedProcess[str]:
+    root = ROOT if root is None else root
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def check_local_tag(version: str, root: Path | None = None) -> int:
+    root = ROOT if root is None else root
+    tag = f"v{version}"
+    tag_list = _git(["tag", "-l", tag], root)
+    if tag_list.returncode != 0:
+        print(f"FAIL: could not list git tags: {tag_list.stderr.strip()}", file=sys.stderr)
+        return CONFLICT
+
+    if tag_list.stdout.strip() != tag:
+        return OK
+
+    head = _git(["rev-parse", "HEAD"], root)
+    tag_commit = _git(["rev-list", "-n", "1", tag], root)
+    if head.returncode != 0 or tag_commit.returncode != 0:
+        detail = (head.stderr or tag_commit.stderr).strip()
+        print(f"FAIL: could not resolve git tag {tag}: {detail}", file=sys.stderr)
+        return CONFLICT
+
+    head_sha = head.stdout.strip()
+    tag_sha = tag_commit.stdout.strip()
+    if tag_sha != head_sha:
+        print(
+            f"FAIL: version {version} local tag {tag} points to {tag_sha}, "
+            f"not current HEAD {head_sha}",
+            file=sys.stderr,
+        )
+        return CONFLICT
+
+    return OK
+
+
+def _fetch_pypi_releases() -> dict[str, Any]:
+    with urllib.request.urlopen(PYPI_URL, timeout=10) as response:
+        return json.loads(response.read().decode("utf-8")).get("releases", {})
+
+
+def check_pypi(version: str, *, allow_existing: bool = False) -> int:
+    try:
+        normalized = normalize_version(version)
+        releases = _fetch_pypi_releases()
+    except Exception as exc:
+        print(
+            f"WARN: could not verify version {version} on PyPI: {exc}",
+            file=sys.stderr,
+        )
+        return UNVERIFIED
+
+    claimed_versions: set[str] = set()
+    for release_version in releases:
+        try:
+            claimed_versions.add(normalize_version(release_version))
+        except InvalidVersion:
+            continue
+
+    if normalized in claimed_versions:
+        if allow_existing:
+            print(f"OK: version {version} already on PyPI (allowed)")
+            return OK
+        print(f"FAIL: version {version} already on PyPI", file=sys.stderr)
+        return CONFLICT
+
+    return OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("local", "pypi", "full"),
+        default="local",
+        help="local checks only git tags; pypi checks only PyPI; full checks both",
+    )
+    parser.add_argument(
+        "--allow-existing",
+        action="store_true",
+        help="allow an already-published PyPI version; intended for tests only",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        version = read_pyproject_version()
+        normalize_version(version)
+    except Exception as exc:
+        print(f"FAIL: could not read pyproject version: {exc}", file=sys.stderr)
+        return CONFLICT
+
+    if args.mode in {"local", "full"}:
+        local_status = check_local_tag(version)
+        if local_status != OK:
+            return local_status
+
+    if args.mode in {"pypi", "full"}:
+        pypi_status = check_pypi(version, allow_existing=args.allow_existing)
+        if pypi_status != OK:
+            return pypi_status
+
+    print(f"OK: version {version} not yet claimed")
+    return OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_version_uniqueness.py
+++ b/tests/scripts/test_check_version_uniqueness.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "validate" / "check_version_uniqueness.py"
+VERSION = "2026.04.25.7"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_version_uniqueness", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        f'[project]\nname = "autosearch"\nversion = "{VERSION}"\n',
+        encoding="utf-8",
+    )
+    _run_git(repo, "init", "-q")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test User")
+    _run_git(repo, "add", "pyproject.toml")
+    _run_git(repo, "commit", "-m", "initial")
+    return repo
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+@pytest.fixture()
+def module(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> ModuleType:
+    loaded = _load_module()
+    monkeypatch.setattr(loaded, "ROOT", _make_repo(tmp_path))
+    return loaded
+
+
+def test_version_not_in_local_tags_and_not_on_pypi_exits_zero(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: _FakeResponse({"releases": {"2026.04.25.6": []}}),
+    )
+
+    assert module.main(["--mode=full"]) == module.OK
+    captured = capsys.readouterr()
+    assert f"OK: version {VERSION} not yet claimed" in captured.out
+
+
+def test_local_tag_pointing_to_head_is_allowed(module: ModuleType) -> None:
+    _run_git(module.ROOT, "tag", f"v{VERSION}")
+
+    assert module.main(["--mode=local"]) == module.OK
+
+
+def test_local_tag_pointing_to_other_commit_fails(
+    module: ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _run_git(module.ROOT, "tag", f"v{VERSION}")
+    (module.ROOT / "later.txt").write_text("later\n", encoding="utf-8")
+    _run_git(module.ROOT, "add", "later.txt")
+    _run_git(module.ROOT, "commit", "-m", "later")
+
+    assert module.main(["--mode=local"]) == module.CONFLICT
+    captured = capsys.readouterr()
+    assert "points to" in captured.err
+    assert "not current HEAD" in captured.err
+
+
+def test_pypi_existing_version_fails(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *args, **kwargs: _FakeResponse({"releases": {"2026.4.25.7": []}}),
+    )
+
+    assert module.main(["--mode=pypi"]) == module.CONFLICT
+    captured = capsys.readouterr()
+    assert f"FAIL: version {VERSION} already on PyPI" in captured.err
+
+
+def test_local_mode_skips_network(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_urlopen(*args: object, **kwargs: object) -> object:
+        raise AssertionError("network should not be called")
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fail_urlopen)
+
+    assert module.main(["--mode=local"]) == module.OK
+
+
+def test_pypi_network_failure_exits_nonzero_with_clear_message(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_urlopen(*args: object, **kwargs: object) -> object:
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fail_urlopen)
+
+    assert module.main(["--mode=pypi"]) == module.UNVERIFIED
+    captured = capsys.readouterr()
+    assert f"WARN: could not verify version {VERSION} on PyPI" in captured.err
+    assert "network unavailable" in captured.err

--- a/tests/unit/test_release_gate_script.py
+++ b/tests/unit/test_release_gate_script.py
@@ -31,6 +31,7 @@ def test_release_gate_script_supports_quick_and_help_flags() -> None:
     body = help_out.stdout + help_out.stderr
     assert "release-gate.sh" in body
     assert "--quick" in body
+    assert "--pypi" in body
 
     bad = subprocess.run([str(SCRIPT), "--no-such-flag"], capture_output=True, text=True)
     assert bad.returncode != 0
@@ -45,4 +46,10 @@ def test_release_workflow_invokes_release_gate_and_validator() -> None:
     assert "check_version_consistency.py" in workflow, (
         "release workflow no longer runs check_version_consistency.py"
     )
+    assert "check_version_uniqueness.py" in workflow or "--pypi" in workflow, (
+        "release workflow no longer runs version uniqueness checks"
+    )
     assert "release-gate.sh" in workflow, "release workflow no longer runs release-gate.sh"
+    assert "--skip-existing" not in workflow, "PyPI upload must fail loudly on duplicates"
+    assert "needs: [build, publish-pypi]" in workflow
+    assert "if: needs.publish-pypi.result == 'success'" in workflow


### PR DESCRIPTION
## Summary

PyPI's `twine upload --skip-existing` silently skipped duplicate-version uploads. Combined with the npm publish job, a release whose pyproject version was already on PyPI would ship npm-only — users `npx autosearch-ai` would install a wrapper pointing at a Python package version that doesn't exist on PyPI.

Two prevention layers:

### Pre-publish gate

- New `scripts/validate/check_version_uniqueness.py` with `--mode=local|pypi|full`. Local mode checks `v<version>` git tag (must not exist OR point to current HEAD for idempotent re-run). PyPI mode checks `releases` dict via `packaging.version.Version` PEP 440 normalization.
- `bump-version.sh` auto-skips date-sequence numbers already claimed by local tags.
- `release-gate.sh` calls `--quick` (local-only, fast/offline) in dev; the release workflow calls `--mode=full` to also check PyPI.

### Drop `--skip-existing`

PR #374 already wired `needs:[publish-pypi]` so npm waits for PyPI success. Removing `--skip-existing` makes a duplicate-version upload fail loudly instead of silently passing — the missing piece.

## Test plan

- [x] `tests/scripts/test_check_version_uniqueness.py` — 6 cases (offline, idempotent, conflict, PyPI mock, network failure)
- [x] `bash scripts/release-gate.sh` — passes with new uniqueness step (local mode); PyPI mode warns fail-open under sandbox no-network
- [x] Full pytest 957 passed
- [ ] CI green