### PR TITLE
fix(cli/docs): Claude Code MCP config uses 'claude mcp add' or project .mcp.json (P0)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -1,13 +1,14 @@
 # Source: gpt-researcher/cli.py:L28-L216 (adapted)
 import json
 import sys
-from typing import Annotated
+from typing import Annotated, Literal
 
 import httpx
 import typer
 from pydantic import ValidationError
 
 from autosearch import __version__
+from autosearch.cli.mcp_config_writers import MCPConfigWriteError
 from autosearch.core.environment_probe import probe_environment
 from autosearch.core.models import SearchMode
 from autosearch.core.scope_clarifier import ScopeClarifier
@@ -178,6 +179,20 @@ def mcp() -> None:
 
 @app.command()
 def init(
+    client: Annotated[
+        str | None,
+        typer.Option(
+            "--client",
+            help="Limit MCP client config writes to one client (claude/cursor/zed).",
+        ),
+    ] = None,
+    scope: Annotated[
+        Literal["project"] | None,
+        typer.Option(
+            "--scope",
+            help="MCP config scope. Currently only `project` is used for Claude Code fallback.",
+        ),
+    ] = None,
     check_channels: Annotated[
         bool,
         typer.Option(
@@ -206,7 +221,15 @@ def init(
 
     if dry_run:
         typer.echo("Dry-run: showing MCP client writes only (no files will be modified).\n")
-        for line in _auto_configure_mcp(dry_run=True).split("; "):
+        try:
+            mcp_status = _auto_configure_mcp(dry_run=True, client=client, scope=scope)
+        except ValueError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        except MCPConfigWriteError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
+        for line in mcp_status.split("; "):
             typer.echo(f"  {line}")
         return
 
@@ -254,7 +277,14 @@ def init(
             typer.echo(f"  ○  {provider:<24} [Not found]")
 
     # ── Auto-write MCP config ─────────────────────────────────────────────────
-    mcp_status = _auto_configure_mcp()
+    try:
+        mcp_status = _auto_configure_mcp(client=client, scope=scope)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+    except MCPConfigWriteError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
     typer.echo(f"  ✅ MCP server                   [{mcp_status}]")
 
     # ── Channel summary ───────────────────────────────────────────────────────
@@ -289,7 +319,12 @@ def init(
     typer.echo("")
 
 
-def _auto_configure_mcp(dry_run: bool = False) -> str:
+def _auto_configure_mcp(
+    dry_run: bool = False,
+    *,
+    client: str | None = None,
+    scope: Literal["project"] | None = None,
+) -> str:
     """Write the autosearch MCP entry to every supported client's config file.
 
     Each client gets its own writer (Claude Code, Cursor, Zed) so the entry
@@ -297,9 +332,22 @@ def _auto_configure_mcp(dry_run: bool = False) -> str:
     client cannot load. Skips clients whose config dir doesn't exist (i.e. the
     user hasn't installed them).
     """
-    from autosearch.cli.mcp_config_writers import write_for_clients
+    from autosearch.cli.mcp_config_writers import WRITERS, write_for_clients
 
-    results = write_for_clients(dry_run=dry_run)
+    if client is not None and client not in WRITERS:
+        raise ValueError(f"unknown client {client!r}. Known: {', '.join(sorted(WRITERS))}")
+    if client == "claude" and scope is None:
+        writer = WRITERS["claude"]
+        has_claude_cli = getattr(writer, "has_claude_cli", lambda: False)
+        if not has_claude_cli():
+            raise MCPConfigWriteError(
+                "Claude Code MCP is not configured: `claude` CLI is not on PATH, and "
+                "AutoSearch will not write the stale ~/.claude/mcp.json path. Run "
+                "`claude mcp add --transport stdio autosearch -- autosearch-mcp` or "
+                "`autosearch init --client claude --scope project` to write ./.mcp.json."
+            )
+
+    results = write_for_clients(clients=[client] if client else None, dry_run=dry_run, scope=scope)
 
     parts: list[str] = []
     for r in results:

--- a/autosearch/cli/mcp_config_writers.py
+++ b/autosearch/cli/mcp_config_writers.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,6 +35,7 @@ WriteStatus = Literal[
     "skipped",  # parent dir doesn't exist (client not installed)
     "backup-and-replaced",  # existing file was unparseable, backed up + rewritten
 ]
+ConfigScope = Literal["project"]
 
 
 @dataclass(slots=True)
@@ -41,6 +44,10 @@ class WriteResult:
     path: Path
     status: WriteStatus
     backup_path: Path | None = None
+
+
+class MCPConfigWriteError(RuntimeError):
+    """Raised when a client-specific MCP config cannot be written safely."""
 
 
 def _autosearch_entry(server_command: str) -> dict[str, object]:
@@ -87,7 +94,9 @@ class _BaseWriter:
         server_command: str = "autosearch-mcp",
         dry_run: bool = False,
         path_override: Path | None = None,
+        scope: ConfigScope | None = None,
     ) -> WriteResult:
+        _ = scope
         path = path_override or self.default_path()
         if not path.parent.exists():
             return WriteResult(client=self.name, path=path, status="skipped")
@@ -175,7 +184,146 @@ class ClaudeCodeWriter(_BaseWriter):
     namespace_key = "mcpServers"
 
     def default_path(self) -> Path:
-        return Path.home() / ".claude" / "mcp.json"
+        return Path.cwd() / ".mcp.json"
+
+    def _legacy_config_dir(self) -> Path:
+        return Path.home() / ".claude"
+
+    def has_claude_cli(self) -> bool:
+        return shutil.which("claude") is not None
+
+    def _run_claude_mcp_add(
+        self,
+        *,
+        server_command: str,
+        scope: ConfigScope | None = None,
+    ) -> None:
+        command = ["claude", "mcp", "add", "--transport", "stdio"]
+        if scope is not None:
+            command.extend(["--scope", scope])
+        command.extend(["autosearch", "--", server_command])
+        try:
+            subprocess.run(command, check=True, capture_output=True, text=True)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            stderr = getattr(exc, "stderr", "") or str(exc)
+            raise MCPConfigWriteError(
+                f"Failed to configure Claude Code MCP via `claude mcp add`: {stderr.strip()}"
+            ) from exc
+
+    def write(
+        self,
+        *,
+        server_command: str = "autosearch-mcp",
+        dry_run: bool = False,
+        path_override: Path | None = None,
+        scope: ConfigScope | None = None,
+    ) -> WriteResult:
+        if self.has_claude_cli():
+            if not dry_run:
+                self._run_claude_mcp_add(server_command=server_command, scope=scope)
+            return WriteResult(client=self.name, path=Path("claude mcp"), status="written")
+
+        if scope == "project":
+            return super().write(
+                server_command=server_command,
+                dry_run=dry_run,
+                path_override=path_override or self.default_path(),
+                scope=scope,
+            )
+
+        if path_override is None and not self._legacy_config_dir().exists():
+            return WriteResult(
+                client=self.name,
+                path=self.default_path(),
+                status="skipped",
+            )
+
+        raise MCPConfigWriteError(
+            "Claude Code MCP is not configured: `claude` CLI is not on PATH, and "
+            "AutoSearch will not write the stale ~/.claude/mcp.json path. Run "
+            "`claude mcp add --transport stdio autosearch -- autosearch-mcp` or "
+            "`autosearch init --client claude --scope project` to write ./.mcp.json."
+        )
+
+    def _run_claude_mcp_list_json(self) -> object:
+        try:
+            result = subprocess.run(
+                ["claude", "mcp", "list", "--json"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            stderr = getattr(exc, "stderr", "") or str(exc)
+            raise MCPConfigWriteError(
+                f"Failed to inspect Claude Code MCP config via `claude mcp list --json`: "
+                f"{stderr.strip()}"
+            ) from exc
+        return json.loads(result.stdout or "null")
+
+    def _entry_has_expected_command(self, entry: object, server_command: str) -> bool:
+        if not isinstance(entry, dict):
+            return False
+        command = entry.get("command")
+        if command == server_command:
+            return True
+        if isinstance(command, list) and command and command[0] == server_command:
+            return True
+        args = entry.get("args")
+        return (
+            command is None and isinstance(args, list) and bool(args) and args[0] == server_command
+        )
+
+    def _claude_list_has_autosearch(self, data: object, server_command: str) -> bool:
+        if isinstance(data, list):
+            return any(self._claude_list_has_autosearch(item, server_command) for item in data)
+        if not isinstance(data, dict):
+            return False
+
+        servers = data.get("mcpServers") or data.get("servers")
+        if isinstance(servers, dict):
+            if self._entry_has_expected_command(servers.get("autosearch"), server_command):
+                return True
+        elif isinstance(servers, list):
+            if any(self._claude_list_has_autosearch(item, server_command) for item in servers):
+                return True
+
+        if data.get("name") == "autosearch":
+            return self._entry_has_expected_command(data, server_command)
+
+        entry = data.get("autosearch")
+        return self._entry_has_expected_command(entry, server_command)
+
+    def verify(
+        self,
+        *,
+        server_command: str = "autosearch-mcp",
+        path_override: Path | None = None,
+    ) -> tuple[bool, str]:
+        if self.has_claude_cli():
+            try:
+                data = self._run_claude_mcp_list_json()
+            except (json.JSONDecodeError, MCPConfigWriteError) as exc:
+                return False, str(exc)
+            if self._claude_list_has_autosearch(data, server_command):
+                return True, "`claude mcp list --json`: autosearch -> autosearch-mcp"
+            return (
+                False,
+                "Claude Code MCP not configured; run `claude mcp add --transport stdio "
+                "autosearch -- autosearch-mcp` or `autosearch init --client claude --scope project`",
+            )
+
+        ok, message = super().verify(
+            server_command=server_command,
+            path_override=path_override or self.default_path(),
+        )
+        if ok:
+            return ok, message
+        return (
+            False,
+            f"{message}. Claude Code MCP not configured; run `claude mcp add --transport stdio "
+            "autosearch -- autosearch-mcp` or `autosearch init --client claude --scope project`",
+        )
 
 
 class CursorWriter(_BaseWriter):
@@ -318,6 +466,7 @@ def write_for_clients(
     *,
     server_command: str = "autosearch-mcp",
     dry_run: bool = False,
+    scope: ConfigScope | None = None,
 ) -> list[WriteResult]:
     """Run the writer for each named client (or all known clients if None)."""
     targets = clients if clients else list(WRITERS.keys())
@@ -326,5 +475,5 @@ def write_for_clients(
         writer = WRITERS.get(client_name)
         if writer is None:
             continue
-        results.append(writer.write(server_command=server_command, dry_run=dry_run))
+        results.append(writer.write(server_command=server_command, dry_run=dry_run, scope=scope))
     return results

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,7 +45,8 @@ pipx install autosearch && autosearch init
 This will:
 - Detect available LLM providers (Anthropic, OpenAI, Gemini, claude CLI)
 - Create `~/.autosearch/config.yaml`
-- Auto-write MCP server config to `~/.claude/mcp.json` and `~/.cursor/mcp.json`
+- Auto-configure MCP clients. Claude Code uses `claude mcp add` when available;
+  `autosearch init --client claude --scope project` writes project-bound `.mcp.json`.
 
 ### Step 3: Check status
 
@@ -118,17 +119,18 @@ autosearch configure YOUTUBE_API_KEY <your-key>
 
 AutoSearch writes this automatically during `init`. For manual setup:
 
-**Claude Code** (`~/.claude/mcp.json`):
-```json
-{
-  "mcpServers": {
-    "autosearch": {
-      "command": "autosearch-mcp",
-      "type": "stdio"
-    }
-  }
-}
+**Claude Code**:
+```bash
+claude mcp add --transport stdio autosearch -- autosearch-mcp
 ```
+
+For project-bound config without the `claude` CLI, run:
+
+```bash
+autosearch init --client claude --scope project
+```
+
+That writes `<project>/.mcp.json`.
 
 **Cursor** (`~/.cursor/mcp.json`):
 ```json

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -24,20 +24,21 @@ If the command is not found, your MCP client won't be able to launch it either â
 
 ## Claude Code
 
-Claude Code reads `~/.claude/mcp.json` globally and `<project>/.mcp.json` per-project. Add an `mcpServers.autosearch` entry:
+Use Claude Code's MCP command to add AutoSearch:
 
-```json
-{
-  "mcpServers": {
-    "autosearch": {
-      "command": "autosearch-mcp",
-      "env": {
-        "ANTHROPIC_API_KEY": "sk-ant-..."
-      }
-    }
-  }
-}
+```bash
+claude mcp add --transport stdio autosearch -- autosearch-mcp
 ```
+
+Claude Code stores local/user scoped MCP config in `~/.claude.json`, and shared
+project config in `<project>/.mcp.json`. If the `claude` CLI is not available
+and you want project-bound config, run:
+
+```bash
+autosearch init --client claude --scope project
+```
+
+That writes `<project>/.mcp.json`.
 
 You can also point the CLI at a specific config for one invocation:
 

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -67,7 +67,7 @@ def test_init_dry_run_shows_writes_without_touching_filesystem(tmp_path, monkeyp
     (tmp_path / ".claude").mkdir()
     (tmp_path / ".cursor").mkdir()
 
-    result = runner.invoke(cli_main.app, ["init", "--dry-run"])
+    result = runner.invoke(cli_main.app, ["init", "--dry-run", "--scope", "project"])
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
     assert "Dry-run" in result.stdout
     assert "claude" in result.stdout and "cursor" in result.stdout
@@ -81,8 +81,9 @@ def test_mcp_check_with_client_passes_when_writer_was_run(tmp_path, monkeypatch)
     from autosearch.cli.mcp_config_writers import ClaudeCodeWriter
 
     monkeypatch.setenv("HOME", str(tmp_path))
-    (tmp_path / ".claude").mkdir()
-    ClaudeCodeWriter().write()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("autosearch.cli.mcp_config_writers.shutil.which", lambda command: None)
+    ClaudeCodeWriter().write(scope="project")
 
     result = runner.invoke(cli_main.app, ["mcp-check", "--client", "claude"])
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
@@ -92,6 +93,8 @@ def test_mcp_check_with_client_passes_when_writer_was_run(tmp_path, monkeypatch)
 
 def test_mcp_check_with_client_fails_when_entry_missing(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("autosearch.cli.mcp_config_writers.shutil.which", lambda command: None)
     (tmp_path / ".claude").mkdir()
     # Write a config that has the WRONG shape (entry at root, like the old bug)
     (tmp_path / ".claude" / "mcp.json").write_text(
@@ -101,10 +104,7 @@ def test_mcp_check_with_client_fails_when_entry_missing(tmp_path, monkeypatch) -
     result = runner.invoke(cli_main.app, ["mcp-check", "--client", "claude"])
     assert result.exit_code != 0
     output = result.stdout + (result.stderr or "")
-    # Either "missing `mcpServers` object" (when namespace absent) or
-    # "missing `mcpServers.autosearch` entry" (when namespace present but no entry)
-    # — both prove verify() rejected the broken config.
-    assert "mcpServers" in output and "missing" in output
+    assert "Claude Code MCP not configured" in output
 
 
 def test_mcp_check_rejects_unknown_client(tmp_path, monkeypatch) -> None:

--- a/tests/unit/test_mcp_config_writers.py
+++ b/tests/unit/test_mcp_config_writers.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from pathlib import Path
 
+import pytest
+from typer.testing import CliRunner
+
+from autosearch.cli import main as cli_main
 from autosearch.cli.mcp_config_writers import (
+    MCPConfigWriteError,
     WRITERS,
     ClaudeCodeWriter,
     CursorWriter,
@@ -14,17 +20,49 @@ from autosearch.cli.mcp_config_writers import (
 )
 
 
+@pytest.fixture(autouse=True)
+def no_claude_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("autosearch.cli.mcp_config_writers.shutil.which", lambda command: None)
+
+
 def _read(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_claude_writer_uses_mcpServers_namespace(tmp_path: Path) -> None:
+def test_claude_writer_calls_claude_mcp_add_when_cli_is_on_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        calls.append(command)
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(
+        "autosearch.cli.mcp_config_writers.shutil.which",
+        lambda command: "/usr/bin/claude" if command == "claude" else None,
+    )
+    monkeypatch.setattr("autosearch.cli.mcp_config_writers.subprocess.run", fake_run)
+
+    result = ClaudeCodeWriter().write()
+
+    assert result.status == "written"
+    assert calls == [
+        ["claude", "mcp", "add", "--transport", "stdio", "autosearch", "--", "autosearch-mcp"]
+    ]
+
+
+def test_claude_writer_writes_project_mcp_json_without_cli_when_project_scope(
+    tmp_path: Path,
+) -> None:
     """Regression: previous writer dumped {'autosearch': ...} at root, which
     Claude Code silently ignored. Schema must be `mcpServers.<name>`."""
-    target = tmp_path / "claude_dir" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
 
-    result = ClaudeCodeWriter().write(path_override=target)
+    result = ClaudeCodeWriter().write(path_override=target, scope="project")
     assert result.status == "written"
 
     data = _read(target)
@@ -33,6 +71,19 @@ def test_claude_writer_uses_mcpServers_namespace(tmp_path: Path) -> None:
         "command": "autosearch-mcp",
         "type": "stdio",
     }
+
+
+def test_claude_writer_errors_without_cli_and_without_explicit_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude").mkdir()
+
+    with pytest.raises(MCPConfigWriteError, match="stale ~/.claude/mcp.json"):
+        ClaudeCodeWriter().write()
+
+    assert not (tmp_path / ".claude" / "mcp.json").exists()
 
 
 def test_cursor_writer_also_uses_mcpServers_namespace(tmp_path: Path) -> None:
@@ -59,8 +110,7 @@ def test_zed_writer_uses_context_servers_namespace(tmp_path: Path) -> None:
 def test_writer_preserves_unrelated_keys(tmp_path: Path) -> None:
     """Critical: real configs contain other servers / settings the user owns.
     Our write must merge, never clobber."""
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
     target.write_text(
         json.dumps(
             {
@@ -73,7 +123,7 @@ def test_writer_preserves_unrelated_keys(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    ClaudeCodeWriter().write(path_override=target)
+    ClaudeCodeWriter().write(path_override=target, scope="project")
 
     data = _read(target)
     assert data["userSetting"] == "do-not-touch"
@@ -82,12 +132,11 @@ def test_writer_preserves_unrelated_keys(tmp_path: Path) -> None:
 
 
 def test_writer_already_set_is_idempotent(tmp_path: Path) -> None:
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
     writer = ClaudeCodeWriter()
 
-    first = writer.write(path_override=target)
-    second = writer.write(path_override=target)
+    first = writer.write(path_override=target, scope="project")
+    second = writer.write(path_override=target, scope="project")
 
     assert first.status == "written"
     assert second.status == "already-set"
@@ -96,7 +145,7 @@ def test_writer_already_set_is_idempotent(tmp_path: Path) -> None:
 def test_writer_skipped_when_parent_dir_missing(tmp_path: Path) -> None:
     target = tmp_path / "absent_client_dir" / "mcp.json"
     # parent never created
-    result = ClaudeCodeWriter().write(path_override=target)
+    result = ClaudeCodeWriter().write(path_override=target, scope="project")
     assert result.status == "skipped"
     assert not target.exists()
 
@@ -104,11 +153,10 @@ def test_writer_skipped_when_parent_dir_missing(tmp_path: Path) -> None:
 def test_writer_backs_up_corrupt_json_and_rewrites(tmp_path: Path) -> None:
     """Million-user safety: never silently overwrite a user's config. If the
     file is unparseable, move it to <name>.bak.<ts> first."""
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
     target.write_text("{this is not json", encoding="utf-8")
 
-    result = ClaudeCodeWriter().write(path_override=target)
+    result = ClaudeCodeWriter().write(path_override=target, scope="project")
     assert result.status == "backup-and-replaced"
     assert result.backup_path is not None
     assert result.backup_path.exists()
@@ -119,28 +167,25 @@ def test_writer_backs_up_corrupt_json_and_rewrites(tmp_path: Path) -> None:
 
 
 def test_dry_run_does_not_modify_anything(tmp_path: Path) -> None:
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
 
-    result = ClaudeCodeWriter().write(path_override=target, dry_run=True)
+    result = ClaudeCodeWriter().write(path_override=target, dry_run=True, scope="project")
     assert result.status == "written"
     assert not target.exists(), "dry-run must not touch the filesystem"
 
 
 def test_dry_run_reports_backup_for_corrupt_file_without_renaming(tmp_path: Path) -> None:
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
     target.write_text("garbage", encoding="utf-8")
 
-    result = ClaudeCodeWriter().write(path_override=target, dry_run=True)
+    result = ClaudeCodeWriter().write(path_override=target, dry_run=True, scope="project")
     assert result.status == "backup-and-replaced"
     # original still in place, no backup created
     assert target.read_text(encoding="utf-8") == "garbage"
 
 
 def test_verify_returns_false_when_entry_missing(tmp_path: Path) -> None:
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
     target.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
 
     ok, msg = ClaudeCodeWriter().verify(path_override=target)
@@ -151,8 +196,7 @@ def test_verify_returns_false_when_entry_missing(tmp_path: Path) -> None:
 def test_verify_detects_wrong_namespace(tmp_path: Path) -> None:
     """The exact bug the old writer caused: entry at root, no `mcpServers`
     namespace. verify() should catch it."""
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
     target.write_text(
         json.dumps({"autosearch": {"command": "autosearch-mcp"}}),
         encoding="utf-8",
@@ -163,10 +207,9 @@ def test_verify_detects_wrong_namespace(tmp_path: Path) -> None:
 
 
 def test_verify_passes_after_writer_runs(tmp_path: Path) -> None:
-    target = tmp_path / "claude" / "mcp.json"
-    target.parent.mkdir()
+    target = tmp_path / ".mcp.json"
     writer = ClaudeCodeWriter()
-    writer.write(path_override=target)
+    writer.write(path_override=target, scope="project")
 
     ok, msg = writer.verify(path_override=target)
     assert ok is True
@@ -177,11 +220,11 @@ def test_write_for_clients_runs_each_known_writer(tmp_path: Path, monkeypatch) -
     """The orchestrator hits every registered client (skipping those whose
     config dir doesn't exist) without crashing."""
     monkeypatch.setenv("HOME", str(tmp_path))
-    (tmp_path / ".claude").mkdir()
+    monkeypatch.chdir(tmp_path)
     (tmp_path / ".cursor").mkdir()
     # zed dir intentionally missing
 
-    results = write_for_clients()
+    results = write_for_clients(scope="project")
     by_client = {r.client: r for r in results}
     assert by_client["claude"].status == "written"
     assert by_client["cursor"].status == "written"
@@ -190,6 +233,54 @@ def test_write_for_clients_runs_each_known_writer(tmp_path: Path, monkeypatch) -
 
 def test_writers_registry_lists_three_clients() -> None:
     assert set(WRITERS) == {"claude", "cursor", "zed"}
+
+
+def test_mcp_check_reports_configured_when_claude_cli_lists_autosearch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = CliRunner()
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        assert command == ["claude", "mcp", "list", "--json"]
+        assert kwargs["check"] is True
+        return SimpleNamespace(
+            stdout=json.dumps(
+                {"mcpServers": {"autosearch": {"command": "autosearch-mcp", "type": "stdio"}}}
+            )
+        )
+
+    monkeypatch.setattr(
+        "autosearch.cli.mcp_config_writers.shutil.which",
+        lambda command: "/usr/bin/claude" if command == "claude" else None,
+    )
+    monkeypatch.setattr("autosearch.cli.mcp_config_writers.subprocess.run", fake_run)
+
+    result = runner.invoke(cli_main.app, ["mcp-check", "--client", "claude"])
+
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "Client config check (claude)" in result.stdout
+    assert "autosearch -> autosearch-mcp" in result.stdout
+
+
+def test_mcp_check_ignores_legacy_claude_mcp_json_false_positive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = CliRunner()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    legacy = tmp_path / ".claude" / "mcp.json"
+    legacy.parent.mkdir()
+    legacy.write_text(
+        json.dumps({"mcpServers": {"autosearch": {"command": "autosearch-mcp"}}}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(cli_main.app, ["mcp-check", "--client", "claude"])
+
+    assert result.exit_code != 0
+    output = result.stdout + (result.stderr or "")
+    assert "Claude Code MCP not configured" in output
 
 
 # ── Zed JSONC handling ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`ClaudeCodeWriter` wrote MCP config to `~/.claude/mcp.json`, and `mcp-check --client claude` looked there too. But per Claude Code official docs (https://code.claude.com/docs/en/mcp), Claude Code reads `~/.claude.json` (user scope) or `<project>/.mcp.json` (project scope) — NOT `~/.claude/mcp.json`. So `autosearch init --client claude` wrote to a path Claude Code never reads, and `mcp-check` reported "configured" when it actually wasn't. Silent install failure for every Claude Code user.

## Fix

- **Writer**: prefer shelling out to `claude mcp add --transport stdio autosearch -- autosearch-mcp` (canonical). Fall back to writing `./.mcp.json` only when `--scope project` passed and `claude` CLI absent. Refuse to write the stale `~/.claude/mcp.json`.
- **mcp-check**: use `claude mcp list --json` when `claude` available; fall back to project `./.mcp.json`. Treat legacy `~/.claude/mcp.json` as not-configured.
- **Docs**: replaced the old edit-`~/.claude/mcp.json` instruction with `claude mcp add` (canonical) + `--scope project` (project-bound).

## Test plan

- [x] `tests/unit/test_mcp_config_writers.py` covers: claude CLI detected → `claude mcp add`; no CLI + project scope → `./.mcp.json`; no CLI + no scope → error; legacy `~/.claude/mcp.json` ignored
- [x] `tests/unit/test_cli_main.py` mcp-check uses `claude mcp list` or project file
- [x] Full pytest 955 passed
- [x] Release gate PASSED
- [ ] CI green

## Out of scope

Migration script for users with stale `~/.claude/mcp.json` — they'll get not-configured signal and can re-run init.