### PR TITLE
fix(routing): Chinese UGC queries no longer route to academic channels (P0)

### DIFF
--- a/autosearch/core/channel_select.py
+++ b/autosearch/core/channel_select.py
@@ -8,11 +8,25 @@ from functools import lru_cache
 from pathlib import Path
 import re
 
+from autosearch.core.search_modes import detect_mode, has_chinese_ugc_intent
 from autosearch.skills.loader import SkillLoadError, _extract_frontmatter
 
 _SKILLS_ROOT = Path(__file__).resolve().parents[1] / "skills" / "channels"
 _MODE_LIMITS = {"fast": 5, "deep": 8}
 _GENERIC_WEB_DOMAIN = "generic-web"
+_CHINESE_NATIVE_DOMAINS = {"chinese-ugc", "cn-tech"}
+_CHINESE_NATIVE_GUARD_PRIORITY = (
+    "xiaohongshu",
+    "zhihu",
+    "weibo",
+    "tieba",
+    "bilibili",
+    "douyin",
+    "kr36",
+    "infoq_cn",
+    "v2ex",
+    "sogou_weixin",
+)
 _CJK_PATTERN = re.compile(r"[\u3400-\u9FFF]")
 _WORD_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)?", re.IGNORECASE)
 _DOMAIN_ALIASES: dict[str, str] = {
@@ -328,6 +342,120 @@ def _language_affinity(spec: ChannelRouteSpec, *, has_cjk: bool) -> int:
     return 1 if {"en", "mixed"} & query_languages else 0
 
 
+def _is_chinese_native_channel(spec: ChannelRouteSpec) -> bool:
+    return bool(_CHINESE_NATIVE_DOMAINS & set(spec.domains)) and bool(
+        {"zh", "mixed"} & set(spec.query_languages)
+    )
+
+
+def _needs_chinese_native_guard(query: str) -> bool:
+    detected = detect_mode(query)
+    return (detected is not None and detected.key == "chinese_ugc") or has_chinese_ugc_intent(query)
+
+
+def _rank_chinese_native_candidates(
+    catalog: tuple[ChannelRouteSpec, ...],
+    *,
+    query_lower: str,
+    query_tokens: set[str],
+    skip: set[str],
+) -> list[ChannelRouteSpec]:
+    priority_index = {name: index for index, name in enumerate(_CHINESE_NATIVE_GUARD_PRIORITY)}
+    fallback_index = len(priority_index)
+    candidates = [
+        spec for spec in catalog if spec.name not in skip and _is_chinese_native_channel(spec)
+    ]
+    return sorted(
+        candidates,
+        key=lambda spec: (
+            -_channel_match_score(spec, query_lower, query_tokens),
+            priority_index.get(spec.name, fallback_index),
+            spec.name,
+        ),
+    )
+
+
+def _apply_chinese_native_guard(
+    channels: list[str],
+    top_groups: list[str],
+    catalog: tuple[ChannelRouteSpec, ...],
+    *,
+    query_lower: str,
+    query_tokens: set[str],
+    skip: set[str],
+    limit: int,
+) -> tuple[list[str], list[str], bool]:
+    if not channels or limit <= 0:
+        return channels, top_groups, False
+
+    spec_by_name = {spec.name: spec for spec in catalog}
+    native_names = {spec.name for spec in catalog if _is_chinese_native_channel(spec)}
+    candidates = _rank_chinese_native_candidates(
+        catalog,
+        query_lower=query_lower,
+        query_tokens=query_tokens,
+        skip=skip,
+    )
+    changed = False
+
+    def domains_for(channel: str) -> tuple[str, ...]:
+        spec = spec_by_name.get(channel)
+        return spec.domains if spec else ()
+
+    def native_count() -> int:
+        return sum(1 for channel in channels if channel in native_names)
+
+    def academic_count() -> int:
+        return sum(1 for channel in channels if "academic" in domains_for(channel))
+
+    def add_candidate(candidate: str) -> bool:
+        nonlocal changed
+        if candidate in channels:
+            return False
+        if len(channels) < limit:
+            channels.append(candidate)
+            changed = True
+            return True
+
+        replace_index = next(
+            (
+                index
+                for index in range(len(channels) - 1, -1, -1)
+                if channels[index] not in native_names
+            ),
+            None,
+        )
+        if replace_index is None:
+            return False
+
+        channels[replace_index] = candidate
+        changed = True
+        return True
+
+    for spec in candidates:
+        if native_count() >= 2:
+            break
+        add_candidate(spec.name)
+
+    for spec in candidates:
+        if native_count() > academic_count():
+            break
+        add_candidate(spec.name)
+
+    if changed:
+        for domain in ("chinese-ugc", "cn-tech"):
+            if (
+                any(
+                    channel in channels and domain in domains_for(channel)
+                    for channel in native_names
+                )
+                and domain not in top_groups
+            ):
+                top_groups.append(domain)
+
+    return channels, top_groups, changed
+
+
 def _domain_score(
     domain: str,
     *,
@@ -418,6 +546,8 @@ def select_channels(
         if not added:
             break
 
+    channels = channels[:limit]
+
     if not channels:
         for spec in channels_by_domain.get(_GENERIC_WEB_DOMAIN, ()):
             if spec.name in seen or spec.name in skip or len(channels) >= limit:
@@ -426,11 +556,24 @@ def select_channels(
             seen.add(spec.name)
         top_groups = [_GENERIC_WEB_DOMAIN]
 
+    guard_applied = False
+    if _needs_chinese_native_guard(query):
+        channels, top_groups, guard_applied = _apply_chinese_native_guard(
+            channels,
+            top_groups,
+            catalog,
+            query_lower=query_lower,
+            query_tokens=query_tokens,
+            skip=skip,
+            limit=limit,
+        )
+
     rationale = (
         f"Groups: {top_groups or [_GENERIC_WEB_DOMAIN]}. "
         f"Mode: {mode} (limit {limit}). "
         "Selected from channel metadata with query-hint scoring. "
-        f"Selected {len(channels)} channels."
+        + ("Applied Chinese-native guard. " if guard_applied else "")
+        + f"Selected {len(channels)} channels."
     )
 
     return {

--- a/autosearch/core/search_modes.py
+++ b/autosearch/core/search_modes.py
@@ -16,10 +16,30 @@ Usage:
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 # ── Built-in modes ────────────────────────────────────────────────────────────
+
+_CJK_PATTERN = re.compile(r"[\u3400-\u9FFF]")
+_CHINESE_UGC_KEYWORDS = {
+    "体验",
+    "吐槽",
+    "真实",
+    "口碑",
+    "评价",
+    "分享",
+    "评测",
+    "用户反馈",
+    "网友",
+    "讨论",
+    "推荐",
+    "避雷",
+    "种草",
+    "拔草",
+    "真心话",
+}
 
 
 @dataclass
@@ -47,9 +67,10 @@ _BUILTIN_MODES: list[SearchModeConfig] = [
         label_en="Academic",
         keywords=[
             "论文",
-            "研究",
             "文献",
             "综述",
+            "期刊",
+            "学术",
             "paper",
             "research",
             "survey",
@@ -143,6 +164,8 @@ _BUILTIN_MODES: list[SearchModeConfig] = [
             "框架",
             "bug",
             "debug",
+            "python",
+            "async",
             "code",
             "implement",
             "library",
@@ -176,6 +199,7 @@ _BUILTIN_MODES: list[SearchModeConfig] = [
         keywords=[
             "产品",
             "竞品",
+            "公司信息",
             "用户反馈",
             "体验",
             "对比",
@@ -261,16 +285,37 @@ def get_mode(key: str) -> SearchModeConfig | None:
     return _get_all_modes().get(key)
 
 
+def _has_cjk(value: str) -> bool:
+    return bool(_CJK_PATTERN.search(value))
+
+
+def has_chinese_ugc_intent(query: str) -> bool:
+    """True when a CJK query asks for native user/community sentiment."""
+    if not _has_cjk(query):
+        return False
+    return any(keyword in query for keyword in _CHINESE_UGC_KEYWORDS)
+
+
 def detect_mode(query: str) -> SearchModeConfig | None:
     """Auto-detect the best mode for a query using keyword matching.
 
     Returns None if no mode matches (caller uses default behavior).
-    Priority: user custom > academic > developer > news > chinese_ugc > product
+    Priority: user custom > Chinese UGC override > academic > developer > news > chinese_ugc > product
     """
     # Custom modes checked first
     all_modes = _get_all_modes()
     custom_keys = [k for k, m in all_modes.items() if not m.is_system and m.enabled]
-    priority_keys = custom_keys + ["academic", "developer", "news", "chinese_ugc", "product"]
+    for key in custom_keys:
+        mode = all_modes.get(key)
+        if mode and mode.enabled and mode.matches_query(query):
+            return mode
+
+    if has_chinese_ugc_intent(query):
+        mode = all_modes.get("chinese_ugc")
+        if mode and mode.enabled:
+            return mode
+
+    priority_keys = ["academic", "developer", "news", "chinese_ugc", "product"]
 
     for key in priority_keys:
         mode = all_modes.get(key)

--- a/tests/contracts/test_channel_selection_contract.py
+++ b/tests/contracts/test_channel_selection_contract.py
@@ -1,0 +1,27 @@
+"""Contracts from autosearch:channel-selection meta skill."""
+
+from __future__ import annotations
+
+from autosearch.core.channel_select import select_channels
+
+
+def test_cjk_ugc_intent_enforces_chinese_native_guard() -> None:
+    result = select_channels(
+        "研究国内用户对 Cursor 的真实体验和吐槽",
+        channel_priority=["arxiv", "pubmed", "openalex", "crossref", "dblp"],
+        mode="fast",
+    )
+    chinese_native_channels = {
+        "xiaohongshu",
+        "zhihu",
+        "weibo",
+        "tieba",
+        "bilibili",
+        "douyin",
+        "kr36",
+        "infoq_cn",
+        "v2ex",
+        "sogou_weixin",
+    }
+
+    assert len([ch for ch in result["channels"] if ch in chinese_native_channels]) >= 2

--- a/tests/test_channel_select_chinese.py
+++ b/tests/test_channel_select_chinese.py
@@ -1,0 +1,42 @@
+"""Chinese-native channel selection regressions."""
+
+from __future__ import annotations
+
+import pytest
+
+from autosearch.core.channel_select import select_channels
+
+CHINESE_UGC_CHANNELS = {
+    "xiaohongshu",
+    "zhihu",
+    "weibo",
+    "tieba",
+    "bilibili",
+    "douyin",
+    "xueqiu",
+}
+ACADEMIC_CHANNELS = {"arxiv", "pubmed", "openalex", "crossref", "dblp"}
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "研究国内用户对 Cursor 的真实体验和吐槽",
+        "Cursor 用户口碑分享",
+        "国内 AI 编辑器评测",
+        "Cursor 吐槽",
+        "财经讨论 比亚迪股价",
+    ],
+)
+def test_cjk_ugc_queries_keep_chinese_ugc_channels(query: str) -> None:
+    result = select_channels(
+        query,
+        channel_priority=["arxiv", "pubmed", "openalex", "crossref", "dblp"],
+        mode="fast",
+    )
+    selected = set(result["channels"])
+    chinese_selected = selected & CHINESE_UGC_CHANNELS
+    academic_selected = selected & ACADEMIC_CHANNELS
+
+    assert len(chinese_selected) >= 2
+    assert len(academic_selected) < len(chinese_selected)

--- a/tests/test_search_modes.py
+++ b/tests/test_search_modes.py
@@ -1,0 +1,34 @@
+"""Tests for autosearch.core.search_modes."""
+
+from __future__ import annotations
+
+import pytest
+
+from autosearch.core import search_modes
+
+
+@pytest.fixture(autouse=True)
+def no_custom_modes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(search_modes, "_load_custom_modes", lambda: [])
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_mode"),
+    [
+        ("研究国内用户对 Cursor 的真实体验和吐槽", "chinese_ugc"),
+        ("Cursor 用户口碑分享", "chinese_ugc"),
+        ("国内 AI 编辑器评测", "chinese_ugc"),
+        ("transformer attention paper 2024", "academic"),
+        ("Cursor 吐槽", "chinese_ugc"),
+        ("BERT 综述", "academic"),
+        ("openai 最新政策", "news"),
+        ("python async pattern", "developer"),
+        ("cursor 公司信息", "product"),
+        ("财经讨论 比亚迪股价", "chinese_ugc"),
+    ],
+)
+def test_detect_mode_regressions(query: str, expected_mode: str) -> None:
+    mode = search_modes.detect_mode(query)
+
+    assert mode is not None
+    assert mode.key == expected_mode


### PR DESCRIPTION
## Summary

Reproduced: query "研究国内用户对 Cursor 的真实体验和吐槽" returned arxiv/pubmed/openalex/crossref/dblp — zero Chinese UGC channels. User asked for Chinese consumer reviews; system gave back English academic papers.

Two root causes:

1. **`search_modes.py`**: 研究 was in academic keywords. But it's a generic Chinese verb (research/study/look into), used constantly in product/consumer/news queries. Triggered academic mode for queries that have nothing to do with academia.
2. **`channel_select.py`**: fast_limit truncation could drop all Chinese-native channels when academic mode won the priority list. The meta skill spec mentions a "native guard" but the code didn't enforce it.

## Fix

- Remove 研究 from `_ACADEMIC_KEYWORDS`. Chinese academic still matches via 论文/期刊/学术/综述.
- Add `_CHINESE_UGC_KEYWORDS` (体验/吐槽/真实/口碑/评价/分享/评测/用户反馈/网友/讨论/推荐/避雷/种草/拔草/真心话). CJK + UGC keyword → short-circuit to `chinese_ugc` mode before academic check.
- `channel_select.py` native guard: chinese_ugc / CJK+UGC queries always keep ≥2 channels with `language=zh|mixed` AND `domains` matching `chinese-ugc`/`cn-tech` after truncation. Implements the meta skill spec rule that was previously documentation-only.

## Test plan

- [x] `tests/test_search_modes.py` — 10 query regression mix
- [x] `tests/test_channel_select_chinese.py` — for each CJK+UGC query, ≥2 Chinese channels selected
- [x] `tests/contracts/test_channel_selection_contract.py` — meta skill native guard enforced
- [x] Full pytest 967 passed
- [x] Release gate PASSED
- [ ] CI green