### PR TITLE
fix(secrets/e2b): redact more patterns + redact E2B reports + shell injection + unify parser (P1)

### DIFF
--- a/autosearch/core/redact.py
+++ b/autosearch/core/redact.py
@@ -12,6 +12,13 @@ from __future__ import annotations
 
 import re
 
+_SECRET_KEY_PATTERN = (
+    r"(?:"
+    r"[A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|COOKIES?|PASSWORD|PASSWD|AUTH|CREDENTIALS?|SESSION)[A-Z0-9_]*"
+    r"|XHS_COOKIES|SESSDATA|bili_jct|_uuid|buvid3|buvid4|DedeUserID(?:__ckMd5)?"
+    r")"
+)
+
 _SECRET_PATTERNS = [
     re.compile(r"sk-[A-Za-z0-9_-]{16,}"),
     re.compile(r"sk-ant-[A-Za-z0-9_-]{16,}"),
@@ -22,10 +29,21 @@ _SECRET_PATTERNS = [
     re.compile(r"tvly-[A-Za-z0-9_-]{16,}"),
     re.compile(r"exa-[A-Za-z0-9_-]{16,}"),
     re.compile(r"(?i)Bearer\s+[A-Za-z0-9._\-+/=~]+"),
-    re.compile(r"(?i)Cookie:\s*[^\n]+"),
     # Generic KEY=value where value looks token-shaped — preserve key name
     re.compile(r"([A-Z][A-Z0-9_]+_(KEY|TOKEN|SECRET|COOKIES?))=([^\s\"']{8,})"),
 ]
+
+_QUOTED_ENV_PATTERN = re.compile(
+    rf"(?P<prefix>\b{_SECRET_KEY_PATTERN}=)(?P<quote>['\"])(?P<value>[^'\"\r\n]*)(?P=quote)"
+)
+_JSON_SECRET_PATTERN = re.compile(
+    rf'(?P<prefix>"{_SECRET_KEY_PATTERN}"\s*:\s*")(?P<value>[^"\r\n]*)(?P<suffix>")'
+)
+_COOKIE_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<prefix>\b(?:XHS_COOKIES|SESSDATA|bili_jct|_uuid|buvid3|buvid4|DedeUserID(?:__ckMd5)?)=)(?P<value>[^'\"\s;]+)"
+)
+_COOKIE_HEADER_PATTERN = re.compile(r"(?im)(?P<prefix>\bCookie:\s*)(?P<cookies>[^\r\n]*)")
+_COOKIE_PAIR_PATTERN = re.compile(r"(?P<name>[^=;\s]+)=(?P<value>[^;]*)")
 
 
 def _replacer(match: re.Match) -> str:
@@ -34,11 +52,35 @@ def _replacer(match: re.Match) -> str:
     return "[REDACTED]"
 
 
+def _replace_quoted_env(match: re.Match) -> str:
+    return f"{match.group('prefix')}{match.group('quote')}[REDACTED]{match.group('quote')}"
+
+
+def _replace_json_secret(match: re.Match) -> str:
+    return f"{match.group('prefix')}[REDACTED]{match.group('suffix')}"
+
+
+def _replace_cookie_assignment(match: re.Match) -> str:
+    return f"{match.group('prefix')}[REDACTED]"
+
+
+def _replace_cookie_header(match: re.Match) -> str:
+    cookies = _COOKIE_PAIR_PATTERN.sub(
+        lambda cookie_match: f"{cookie_match.group('name')}=[REDACTED]",
+        match.group("cookies"),
+    )
+    return f"{match.group('prefix')}{cookies}"
+
+
 def redact(text: str) -> str:
     """Replace anything matching `_SECRET_PATTERNS` with `[REDACTED]`."""
     if not text:
         return text
     out = text
+    out = _COOKIE_HEADER_PATTERN.sub(_replace_cookie_header, out)
+    out = _QUOTED_ENV_PATTERN.sub(_replace_quoted_env, out)
+    out = _JSON_SECRET_PATTERN.sub(_replace_json_secret, out)
+    out = _COOKIE_ASSIGNMENT_PATTERN.sub(_replace_cookie_assignment, out)
     for pat in _SECRET_PATTERNS:
         out = pat.sub(_replacer, out)
     return out

--- a/scripts/e2b/bench_channels.py
+++ b/scripts/e2b/bench_channels.py
@@ -26,12 +26,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
+from autosearch.core.redact import redact
 from e2b_code_interpreter import Sandbox
 
 # Default T0 (always-on) channels + T1 youtube (needs key)
@@ -114,6 +117,30 @@ def collect_secrets() -> dict[str, str]:
     return {k: os.environ[k] for k in keys if os.environ.get(k)}
 
 
+def build_single_channel_bench_command(channel: str, query: str, mode: str) -> str:
+    return (
+        f"cd $HOME/work/autosearch && AUTOSEARCH_BENCH_MODE={shlex.quote(mode)} "
+        ".venv/bin/python tests/e2b/bench/single_channel_bench.py "
+        f"{shlex.quote(channel)} {shlex.quote(query)}"
+    )
+
+
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact(value)
+    if isinstance(value, dict):
+        return {key: _redact_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_value(item) for item in value]
+    return value
+
+
+def _redacted_tail(text: str | None, limit: int = 500) -> str:
+    return redact(text or "")[-limit:]
+
+
 def run_channel_bench(
     channel: str,
     queries: list[tuple[str, str]],
@@ -136,7 +163,11 @@ def run_channel_bench(
         log("sandbox.create")
         sbx = Sandbox.create("autosearch-py312", timeout=1800, envs=secrets)
     except Exception as exc:
-        return {"channel": channel, "status": "sandbox_create_failed", "error": str(exc)}
+        return {
+            "channel": channel,
+            "status": "sandbox_create_failed",
+            "error": redact(str(exc)),
+        }
 
     try:
         # Upload tarball
@@ -162,7 +193,7 @@ echo install_done
                 "channel": channel,
                 "status": "install_failed",
                 "exit": install_res.exit_code,
-                "stderr_tail": install_res.stderr[-500:],
+                "stderr_tail": _redacted_tail(install_res.stderr),
             }
 
         # Run each query
@@ -170,22 +201,19 @@ echo install_done
         for qid, qtext in queries:
             log(f"query {qid}: {qtext[:40]}...")
             t0 = time.monotonic()
-            cmd = (
-                f"cd $HOME/work/autosearch && AUTOSEARCH_BENCH_MODE={mode} "
-                f'.venv/bin/python tests/e2b/bench/single_channel_bench.py "{channel}" "{qtext}"'
-            )
+            cmd = build_single_channel_bench_command(channel, qtext, mode)
             res = sbx.commands.run(cmd, timeout=1500 if mode == "deep" else 600, envs=secrets)
             wall = time.monotonic() - t0
             stdout = res.stdout.strip()
             try:
-                parsed = json.loads(stdout.splitlines()[-1])
+                parsed = _redact_value(json.loads(stdout.splitlines()[-1]))
             except (json.JSONDecodeError, IndexError):
                 parsed = {
                     "channel": channel,
                     "query": qtext,
                     "status": "output_parse_failed",
-                    "stdout_tail": stdout[-500:],
-                    "stderr_tail": res.stderr[-500:],
+                    "stdout_tail": _redacted_tail(stdout),
+                    "stderr_tail": _redacted_tail(res.stderr),
                     "exit": res.exit_code,
                 }
             parsed["query_id"] = qid
@@ -205,7 +233,7 @@ echo install_done
         result = {
             "channel": channel,
             "status": "exception",
-            "error": f"{type(exc).__name__}: {exc}",
+            "error": redact(f"{type(exc).__name__}: {exc}"),
         }
     finally:
         try:
@@ -217,11 +245,11 @@ echo install_done
     # Persist per-channel card
     card_path = output_dir / "cards" / f"{channel}.json"
     card_path.parent.mkdir(parents=True, exist_ok=True)
-    card_path.write_text(json.dumps(result, indent=2))
+    card_path.write_text(json.dumps(_redact_value(result), indent=2))
 
     log_path = output_dir / "logs" / f"{channel}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log_path.write_text("\n".join(log_lines))
+    log_path.write_text(redact("\n".join(log_lines)))
 
     return result
 
@@ -237,7 +265,7 @@ def aggregate(results: list[dict], output_dir: Path) -> None:
                     "channel": r["channel"],
                     "query_id": "*",
                     "status": r.get("status"),
-                    "error": r.get("error") or r.get("stderr_tail") or "",
+                    "error": redact(r.get("error") or r.get("stderr_tail") or ""),
                     "evidence_count": None,
                     "wall_time": None,
                     "cost_usd": None,
@@ -265,11 +293,13 @@ def aggregate(results: list[dict], output_dir: Path) -> None:
     matrix_path = output_dir / "channel-matrix.json"
     matrix_path.write_text(
         json.dumps(
-            {
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "row_count": len(rows),
-                "rows": rows,
-            },
+            _redact_value(
+                {
+                    "generated_at": datetime.now(timezone.utc).isoformat(),
+                    "row_count": len(rows),
+                    "rows": rows,
+                }
+            ),
             indent=2,
         )
     )
@@ -313,7 +343,7 @@ def aggregate(results: list[dict], output_dir: Path) -> None:
         lines.append(f"| {rank} | {ch} | {ev_str} | {w_str} | {empty_str} | {c_str} | {note} |")
 
     leaderboard_path = output_dir / "channel-leaderboard.md"
-    leaderboard_path.write_text("\n".join(lines))
+    leaderboard_path.write_text(redact("\n".join(lines)))
 
     print("\n=== Aggregated ===")
     print(f"Matrix: {matrix_path}")

--- a/scripts/e2b/bench_variance.py
+++ b/scripts/e2b/bench_variance.py
@@ -12,13 +12,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import statistics
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
+from autosearch.core.redact import redact
 from e2b_code_interpreter import Sandbox
 
 
@@ -48,6 +51,30 @@ def collect_secrets() -> dict[str, str]:
     return {k: os.environ[k] for k in keys if os.environ.get(k)}
 
 
+def build_autosearch_query_command(query: str, mode: str) -> str:
+    return (
+        "cd $HOME/work/autosearch && AUTOSEARCH_PROVIDER_CHAIN=anthropic "
+        f".venv/bin/autosearch query {shlex.quote(query)} --mode {shlex.quote(mode)} "
+        "--no-stream --json 2>/tmp/autosearch.stderr"
+    )
+
+
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact(value)
+    if isinstance(value, dict):
+        return {key: _redact_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_value(item) for item in value]
+    return value
+
+
+def _redacted_tail(text: str | None, limit: int = 500) -> str:
+    return redact(text or "")[-limit:]
+
+
 def run_one(
     topic_id: str,
     query: str,
@@ -69,7 +96,7 @@ def run_one(
             "topic_id": topic_id,
             "run_idx": run_idx,
             "status": "sandbox_create_failed",
-            "error": str(exc),
+            "error": redact(str(exc)),
         }
 
     try:
@@ -92,16 +119,12 @@ echo install_done
                 "topic_id": topic_id,
                 "run_idx": run_idx,
                 "status": "install_failed",
-                "stderr_tail": res.stderr[-500:],
+                "stderr_tail": _redacted_tail(res.stderr),
             }
 
         t0 = time.monotonic()
         # --json envelope lands on stdout; keep stderr (log noise) separate.
-        cmd = (
-            f"cd $HOME/work/autosearch && AUTOSEARCH_PROVIDER_CHAIN=anthropic "
-            f'.venv/bin/autosearch query "{query}" --mode {mode} --no-stream --json '
-            f"2>/tmp/autosearch.stderr"
-        )
+        cmd = build_autosearch_query_command(query, mode)
         q_res = sbx.commands.run(cmd, timeout=1200, envs=secrets)
         wall = time.monotonic() - t0
 
@@ -118,6 +141,7 @@ echo install_done
                     parsed = json.loads(stdout[idx:])
                 except json.JSONDecodeError:
                     parsed = {}
+        parsed = _redact_value(parsed)
 
         result = {
             "cell_id": cell_id,
@@ -141,7 +165,7 @@ echo install_done
             "topic_id": topic_id,
             "run_idx": run_idx,
             "status": "exception",
-            "error": f"{type(exc).__name__}: {exc}",
+            "error": redact(f"{type(exc).__name__}: {exc}"),
         }
     finally:
         try:
@@ -151,7 +175,7 @@ echo install_done
 
     out = output_dir / "runs" / f"{cell_id}.json"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(result, indent=2, default=str))
+    out.write_text(json.dumps(_redact_value(result), indent=2, default=str))
     return result
 
 
@@ -196,11 +220,13 @@ def summarize(results: list[dict], output_dir: Path) -> None:
 
     (output_dir / "variance-raw.json").write_text(
         json.dumps(
-            {
-                "generated_at": datetime.now(timezone.utc).isoformat(),
-                "total_cells": len(results),
-                "by_topic": {tid: rs for tid, rs in by_topic.items()},
-            },
+            _redact_value(
+                {
+                    "generated_at": datetime.now(timezone.utc).isoformat(),
+                    "total_cells": len(results),
+                    "by_topic": {tid: rs for tid, rs in by_topic.items()},
+                }
+            ),
             indent=2,
             default=str,
         )

--- a/scripts/e2b/lib/reporter.py
+++ b/scripts/e2b/lib/reporter.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from autosearch.core.redact import redact
+
 
 MAX_OUTPUT_CHARS = 10_000
 
@@ -14,8 +16,8 @@ def write_task_result(phase_dir: Path, result: Mapping[str, Any]) -> None:
     _write_text(stem.with_suffix(".stderr.log"), result.get("stderr", ""))
 
     payload = dict(result)
-    payload["stdout"] = _truncate(str(payload.get("stdout", "")))
-    payload["stderr"] = _truncate(str(payload.get("stderr", "")))
+    payload["stdout"] = _truncate(redact(str(payload.get("stdout", ""))))
+    payload["stderr"] = _truncate(redact(str(payload.get("stderr", ""))))
     if "wall_seconds" in payload:
         payload["wall_seconds"] = round(float(payload["wall_seconds"]), 3)
     _write_json(stem.with_suffix(".json"), payload)
@@ -71,6 +73,18 @@ def json_ready(value: Any) -> Any:
     return value
 
 
+def redacted_json_ready(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact(value)
+    if isinstance(value, Path):
+        return redact(str(value))
+    if isinstance(value, dict):
+        return {key: redacted_json_ready(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redacted_json_ready(item) for item in value]
+    return value
+
+
 def summarize_phase(
     *,
     phase_id: str,
@@ -110,9 +124,10 @@ def _truncate(text: str) -> str:
 
 def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.write_text(
-        json.dumps(json_ready(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        json.dumps(redacted_json_ready(payload), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
 
 
 def _write_text(path: Path, content: Any) -> None:
-    path.write_text(str(content), encoding="utf-8")
+    path.write_text(redact(str(content)), encoding="utf-8")

--- a/scripts/e2b/lib/secrets.py
+++ b/scripts/e2b/lib/secrets.py
@@ -4,33 +4,19 @@ import os
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from autosearch.core.secrets_store import load_secrets as _load_runtime_secrets
+
 
 class SecretsError(ValueError):
     """Raised when the secrets env file cannot be parsed."""
 
 
 def load_secrets(path: Path) -> dict[str, str]:
-    """Load a simple KEY=VALUE env file without shell-style parsing."""
+    """Load secrets with the same shell-style parser used by runtime code."""
     if not path.exists():
         raise SecretsError(f"Secrets file not found: {path}")
 
-    secrets: dict[str, str] = {}
-    for line_no, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        stripped = raw_line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if "=" not in raw_line:
-            raise SecretsError(f"Invalid secrets line {line_no}: expected KEY=VALUE")
-
-        key, value = raw_line.split("=", 1)
-        key = key.strip()
-        if key.startswith("export "):
-            key = key[len("export ") :].strip()
-        if not key:
-            raise SecretsError(f"Invalid secrets line {line_no}: missing key")
-        secrets[key] = value
-
-    return secrets
+    return _load_runtime_secrets(path)
 
 
 def build_task_env(

--- a/tests/scripts/test_e2b_bench_commands.py
+++ b/tests/scripts/test_e2b_bench_commands.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+
+def _install_fake_e2b_module(monkeypatch) -> None:
+    fake = types.ModuleType("e2b_code_interpreter")
+    fake.Sandbox = object
+    monkeypatch.setitem(sys.modules, "e2b_code_interpreter", fake)
+
+
+def _make_workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "work" / "autosearch"
+    python_dir = root / ".venv" / "bin"
+    bench_dir = root / "tests" / "e2b" / "bench"
+    python_dir.mkdir(parents=True)
+    bench_dir.mkdir(parents=True)
+    (python_dir / "python").symlink_to(sys.executable)
+    (bench_dir / "single_channel_bench.py").write_text("", encoding="utf-8")
+    autosearch = python_dir / "autosearch"
+    autosearch.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    autosearch.chmod(0o755)
+    return root
+
+
+def test_channel_bench_command_quotes_malicious_channel(monkeypatch, tmp_path) -> None:
+    _install_fake_e2b_module(monkeypatch)
+    bench_channels = importlib.import_module("scripts.e2b.bench_channels")
+    _make_workspace(tmp_path)
+
+    cmd = bench_channels.build_single_channel_bench_command(
+        "my-chan; echo PWNED",
+        "plain query",
+        "fast",
+    )
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+
+    assert result.returncode == 0
+    assert "PWNED" not in result.stdout
+    assert "PWNED" not in result.stderr
+
+
+def test_variance_bench_command_quotes_malicious_query(monkeypatch, tmp_path) -> None:
+    _install_fake_e2b_module(monkeypatch)
+    bench_variance = importlib.import_module("scripts.e2b.bench_variance")
+    _make_workspace(tmp_path)
+
+    cmd = bench_variance.build_autosearch_query_command("query; echo PWNED", "fast")
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(tmp_path)},
+    )
+
+    assert result.returncode == 0
+    assert "PWNED" not in result.stdout
+    assert "PWNED" not in result.stderr

--- a/tests/scripts/test_e2b_reporter_redaction.py
+++ b/tests/scripts/test_e2b_reporter_redaction.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from scripts.e2b.lib.reporter import write_task_result
+
+
+def test_write_task_result_redacts_stdout_and_stderr_before_saving(tmp_path) -> None:
+    result = {
+        "id": "task",
+        "sandbox_idx": 1,
+        "sandbox_id": "sandbox",
+        "exit_code": 1,
+        "stdout": "ANTHROPIC_API_KEY=secret-xyz",
+        "stderr": '"ANTHROPIC_API_KEY": "secret-xyz"',
+        "wall_seconds": 0.1,
+        "passed": False,
+        "fail_reason": "Authorization: Bearer abc.def.ghi+/=tail",
+    }
+
+    write_task_result(tmp_path, result)
+
+    for path in tmp_path.iterdir():
+        content = path.read_text(encoding="utf-8")
+        assert "secret-xyz" not in content
+        assert "abc.def.ghi+/=tail" not in content
+        assert "[REDACTED]" in content

--- a/tests/scripts/test_e2b_secrets_parser.py
+++ b/tests/scripts/test_e2b_secrets_parser.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from autosearch.core.secrets_store import load_secrets as load_runtime_secrets
+from scripts.e2b.lib.secrets import load_secrets as load_e2b_secrets
+
+
+def test_e2b_secrets_parser_matches_runtime_parser(tmp_path) -> None:
+    secrets_file = tmp_path / "ai-secrets.env"
+    secrets_file.write_text(
+        "\n".join(
+            [
+                "XHS_COOKIES='a=b; c=d'",
+                "ANTHROPIC_API_KEY='sk-ant-test-value'",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert load_e2b_secrets(secrets_file) == load_runtime_secrets(secrets_file)
+    assert load_e2b_secrets(secrets_file)["XHS_COOKIES"] == "a=b; c=d"

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -41,7 +41,10 @@ def test_redact_strips_bearer_header() -> None:
 
 def test_redact_strips_cookie_header() -> None:
     out = redact("Cookie: SESSDATA=xxx; bili_jct=yyy")
-    assert "SESSDATA" not in out
+    assert "SESSDATA" in out
+    assert "bili_jct" in out
+    assert "xxx" not in out
+    assert "yyy" not in out
     assert "REDACTED" in out
 
 

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -27,3 +27,49 @@ def test_redact_bearer_jwt_style_token_redacts_full_token() -> None:
     assert "header.payload" not in out
     assert "SECRETTAIL" not in out
     assert "[REDACTED]" in out
+
+
+def test_redact_bearer_preserves_surrounding_text() -> None:
+    out = redact("I tested with Bearer abc.def.ghi+/=tail")
+
+    assert out == "I tested with [REDACTED]"
+
+
+def test_redact_quoted_env_secret_preserves_key() -> None:
+    out = redact("TIKHUB_API_KEY='secret-value-123'")
+
+    assert out == "TIKHUB_API_KEY='[REDACTED]'"
+    assert "secret-value-123" not in out
+
+
+def test_redact_json_secret_preserves_key() -> None:
+    out = redact('"ANTHROPIC_API_KEY": "sk-ant-secret-tail"')
+
+    assert out == '"ANTHROPIC_API_KEY": "[REDACTED]"'
+    assert "sk-ant-secret-tail" not in out
+
+
+def test_redact_cookie_header_preserves_cookie_names() -> None:
+    out = redact("Cookie: SESSDATA=xyz; bili_jct=abc")
+
+    assert out == "Cookie: SESSDATA=[REDACTED]; bili_jct=[REDACTED]"
+    assert "xyz" not in out
+    assert "abc" not in out
+
+
+def test_redact_normal_message_unchanged() -> None:
+    message = "Hello world, this is a normal message"
+
+    assert redact(message) == message
+
+
+def test_redact_non_secret_quoted_assignment_unchanged() -> None:
+    message = "The quoted_var='not_secret_test'"
+
+    assert redact(message) == message
+
+
+def test_redact_common_cookie_env_assignment() -> None:
+    out = redact("SESSDATA=xyz; _uuid=abc")
+
+    assert out == "SESSDATA=[REDACTED]; _uuid=[REDACTED]"


### PR DESCRIPTION
## Summary

Three secrets-hygiene gaps from the v2 audit: redaction missed common secret-leak shapes, E2B reports persisted unredacted output, and bench scripts had shell injection.

### Redaction (autosearch/core/redact.py)

PR #370 fixed Bearer char class; v2 audit found redaction still missed:
- `KEY='value'` / `KEY="value"` quoted env
- `"KEY": "value"` JSON form
- `Cookie: name=value; name2=value2` headers
- Direct cookie-env assignments (`XHS_COOKIES=...`, `SESSDATA=...`)

### E2B redaction (scripts/e2b/*)

`reporter.py`, `bench_channels.py`, `bench_variance.py` saved subprocess stdout/stderr/cmd to JSON reports without redaction — secrets in error output leaked into archived reports. All persisted output now runs through `redact()` before write; truncation after redaction (truncating first risked missing past-cut leaks).

### Shell injection (scripts/e2b/bench_*)

Bench scripts built shell strings with f-string interpolation of `channel` and `query` args. Malicious channel name `my-chan; echo PWNED` could break out. Applied `shlex.quote()` to every interpolated value.

### Parser unification (scripts/e2b/lib/secrets.py)

E2B used `split('=', 1)`; runtime uses `shlex.split()`. Cookie `XHS_COOKIES='a=b; c=d'` parsed differently — E2B runs didn't have the secret runtime expected. E2B now delegates to `autosearch.core.secrets_store.load_secrets()`.

## Test plan

- [x] `tests/unit/test_redact.py` extended — quoted env, JSON, Cookie header, direct cookie-env, no over-redact of normal text
- [x] `tests/scripts/test_e2b_reporter_redaction.py` — fake secret in stdout doesn't appear in saved report
- [x] `tests/scripts/test_e2b_bench_commands.py` — injection attempt doesn't echo PWNED
- [x] `tests/scripts/test_e2b_secrets_parser.py` — E2B and runtime produce same dict
- [x] Full pytest 962 passed
- [x] Release gate PASSED
- [ ] CI green