### PR TITLE
fix(doctor/list_channels): apply TikHub proxy shim consistently with runtime (P1)

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -12,14 +12,13 @@ import structlog
 
 from autosearch.core.models import Evidence, SubQuery
 from autosearch.core.rate_limiter import RateLimiter
+from autosearch.core.requires import resolve_requires
 from autosearch.skills.loader import MethodSpec, QualityHint, WhenToUse, load_all
 
 if TYPE_CHECKING:
     from autosearch.observability.channel_health import ChannelHealth
 
 LOGGER = structlog.get_logger(__name__).bind(component="channel_registry")
-_TIKHUB_API_KEY_TOKEN = "env:TIKHUB_API_KEY"
-_TIKHUB_PROXY_FALLBACK = {"AUTOSEARCH_PROXY_URL", "AUTOSEARCH_PROXY_TOKEN"}
 
 
 class ChannelRegistryError(ValueError):
@@ -411,21 +410,13 @@ class ChannelRegistry:
 
     @staticmethod
     def _resolve_requires(requires: list[str], env: Environment) -> list[str]:
-        unmet: list[str] = []
-        for token in requires:
-            kind, value = token.split(":", maxsplit=1)
-            if kind == "cookie" and value not in env.cookies:
-                unmet.append(token)
-            elif kind == "mcp" and value not in env.mcp_servers:
-                unmet.append(token)
-            elif kind == "env" and value not in env.env_keys:
-                if token == _TIKHUB_API_KEY_TOKEN and _TIKHUB_PROXY_FALLBACK.issubset(env.env_keys):
-                    continue
-                unmet.append(token)
-            elif kind == "binary" and value not in env.binaries:
-                unmet.append(token)
-
-        return unmet
+        return resolve_requires(
+            requires,
+            env_keys=env.env_keys,
+            cookies=env.cookies,
+            mcp_servers=env.mcp_servers,
+            binaries=env.binaries,
+        )
 
     def register(self, channel: Channel) -> None:
         self._channels[channel.name] = channel

--- a/autosearch/core/doctor.py
+++ b/autosearch/core/doctor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from autosearch.core.requires import resolve_requires
 from autosearch.skills import SkillLoadError, load_all
 
 # Maps unmet env var names → actionable fix commands (1:1 from Agent-Reach cookie_extract.py)
@@ -74,7 +75,7 @@ def scan_channels(channels_root: Path | None = None) -> list[ChannelStatus]:
         all_unmet: list[str] = []
         available_methods = 0
         for method in spec.methods:
-            unmet = [token for token in method.requires if not _token_satisfied(token, env_keys)]
+            unmet = resolve_requires(method.requires, env_keys=env_keys)
             # A method whose impl file does not exist on disk cannot run, no
             # matter how many env keys are satisfied. Treat it as unmet so a
             # half-scaffolded channel never reports as available.
@@ -256,14 +257,6 @@ def _fix_hint(unmet_requires: list[str]) -> str:
     if configure_hints:
         return configure_hints[0]
     return ""
-
-
-def _token_satisfied(token: str, env_keys: set[str]) -> bool:
-    kind, _, value = token.partition(":")
-    if kind == "env":
-        return value in env_keys
-    # cookie / mcp / binary: treat as unsatisfied unless env override exists
-    return False
 
 
 def _current_env_keys() -> set[str]:

--- a/autosearch/core/requires.py
+++ b/autosearch/core/requires.py
@@ -1,0 +1,41 @@
+"""Shared resolution for SKILL.md ``requires`` tokens."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+TIKHUB_API_KEY_TOKEN = "env:TIKHUB_API_KEY"
+TIKHUB_PROXY_FALLBACK_ENV_KEYS = frozenset({"AUTOSEARCH_PROXY_URL", "AUTOSEARCH_PROXY_TOKEN"})
+
+
+def resolve_requires(
+    requires: Iterable[str],
+    *,
+    env_keys: Iterable[str] = (),
+    cookies: Iterable[str] = (),
+    mcp_servers: Iterable[str] = (),
+    binaries: Iterable[str] = (),
+) -> list[str]:
+    """Return unmet ``requires`` tokens for the current environment."""
+    available_env_keys = set(env_keys)
+    available_cookies = set(cookies)
+    available_mcp_servers = set(mcp_servers)
+    available_binaries = set(binaries)
+
+    unmet: list[str] = []
+    for token in requires:
+        kind, value = token.split(":", maxsplit=1)
+        if kind == "cookie" and value not in available_cookies:
+            unmet.append(token)
+        elif kind == "mcp" and value not in available_mcp_servers:
+            unmet.append(token)
+        elif kind == "env" and value not in available_env_keys:
+            if token == TIKHUB_API_KEY_TOKEN and TIKHUB_PROXY_FALLBACK_ENV_KEYS.issubset(
+                available_env_keys
+            ):
+                continue
+            unmet.append(token)
+        elif kind == "binary" and value not in available_binaries:
+            unmet.append(token)
+
+    return unmet

--- a/docs/install.md
+++ b/docs/install.md
@@ -82,10 +82,19 @@ Status: 27/40 channels ready
 
 **Ask the user which optional channels they want**, then use these commands:
 
-#### Chinese social media (TikHub key required)
+#### Chinese social media (TikHub auth)
 ```bash
 autosearch configure TIKHUB_API_KEY <your-key>
 # Unlocks: xiaohongshu, douyin, weibo, zhihu, twitter, tiktok, bilibili, and more
+```
+
+If you use an AutoSearch TikHub proxy, configure the proxy URL and token instead.
+Together, `AUTOSEARCH_PROXY_URL` and `AUTOSEARCH_PROXY_TOKEN` satisfy TikHub
+channel availability without `TIKHUB_API_KEY`:
+
+```bash
+autosearch configure AUTOSEARCH_PROXY_URL <proxy-url>
+autosearch configure AUTOSEARCH_PROXY_TOKEN <proxy-token>
 ```
 
 #### Xiaohongshu with your own account (no TikHub fee)

--- a/tests/test_mcp_list_channels_tikhub_proxy.py
+++ b/tests/test_mcp_list_channels_tikhub_proxy.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _isolate_tikhub_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AUTOSEARCH_LLM_MODE", "dummy")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(tmp_path / "missing-secrets.env"))
+    monkeypatch.delenv("TIKHUB_API_KEY", raising=False)
+    monkeypatch.delenv("AUTOSEARCH_PROXY_URL", raising=False)
+    monkeypatch.delenv("AUTOSEARCH_PROXY_TOKEN", raising=False)
+
+
+def _list_channels_zhihu() -> dict:
+    from autosearch.mcp.server import create_server
+
+    server = create_server()
+    data = server._tool_manager._tools["list_channels"].fn()
+    channels = {channel["name"]: channel for channel in data["channels"]}
+    return channels["zhihu"]
+
+
+def test_mcp_list_channels_tikhub_proxy_marks_zhihu_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_tikhub_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("AUTOSEARCH_PROXY_URL", "https://x")
+    monkeypatch.setenv("AUTOSEARCH_PROXY_TOKEN", "y")
+
+    channel = _list_channels_zhihu()
+
+    assert channel["status"] == "ok"
+    assert channel["unmet_requires"] == []
+    assert "TIKHUB_API_KEY" not in channel["fix_hint"]
+
+
+def test_mcp_list_channels_tikhub_api_key_marks_zhihu_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_tikhub_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("TIKHUB_API_KEY", "tk-test")
+
+    channel = _list_channels_zhihu()
+
+    assert channel["status"] == "ok"
+    assert channel["unmet_requires"] == []
+
+
+def test_mcp_list_channels_zhihu_off_without_tikhub_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_tikhub_env(monkeypatch, tmp_path)
+
+    channel = _list_channels_zhihu()
+
+    assert channel["status"] == "off"
+    assert channel["unmet_requires"] == ["env:TIKHUB_API_KEY"]
+    assert channel["fix_hint"] == "autosearch configure TIKHUB_API_KEY <your-key>"

--- a/tests/unit/test_doctor_tikhub_proxy.py
+++ b/tests/unit/test_doctor_tikhub_proxy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autosearch.core.doctor import ChannelStatus, scan_channels
+
+
+def _isolate_tikhub_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(tmp_path / "missing-secrets.env"))
+    monkeypatch.delenv("TIKHUB_API_KEY", raising=False)
+    monkeypatch.delenv("AUTOSEARCH_PROXY_URL", raising=False)
+    monkeypatch.delenv("AUTOSEARCH_PROXY_TOKEN", raising=False)
+
+
+def _zhihu_status() -> ChannelStatus:
+    statuses = {status.channel: status for status in scan_channels()}
+    return statuses["zhihu"]
+
+
+def test_doctor_tikhub_proxy_satisfies_zhihu_requires(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_tikhub_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("AUTOSEARCH_PROXY_URL", "https://x")
+    monkeypatch.setenv("AUTOSEARCH_PROXY_TOKEN", "y")
+
+    status = _zhihu_status()
+
+    assert status.status == "ok"
+    assert status.unmet_requires == []
+    assert "TIKHUB_API_KEY" not in status.fix_hint
+
+
+def test_doctor_tikhub_api_key_still_satisfies_zhihu_requires(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_tikhub_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("TIKHUB_API_KEY", "tk-test")
+
+    status = _zhihu_status()
+
+    assert status.status == "ok"
+    assert status.unmet_requires == []
+
+
+def test_doctor_zhihu_not_configured_without_tikhub_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_tikhub_env(monkeypatch, tmp_path)
+
+    status = _zhihu_status()
+
+    assert status.status == "off"
+    assert status.unmet_requires == ["env:TIKHUB_API_KEY"]
+    assert status.fix_hint == "autosearch configure TIKHUB_API_KEY <your-key>"


### PR DESCRIPTION
## Summary

PRs #366 + #368 made the runtime accept `AUTOSEARCH_PROXY_URL + AUTOSEARCH_PROXY_TOKEN` as a substitute for `TIKHUB_API_KEY`. But `doctor.py` and `list_channels` checked SKILL.md `requires` directly without the proxy shim — so `autosearch doctor --json` told users to "configure TIKHUB_API_KEY" even when the proxy path was already working at runtime. Inconsistent UX between the diagnostic surface and actual channel calls.

## Fix

Extracted the requires-resolution logic into `autosearch/core/requires.py` (single source of truth). `ChannelRegistry._resolve_requires()` and `doctor.scan_channels()` both delegate to it. `list_channels` already uses `scan_channels`, so it benefits automatically.

Now runtime, doctor, and list_channels all report the same channel availability for any combination of TikHub auth env vars.

## Test plan

- [x] `tests/unit/test_doctor_tikhub_proxy.py` — proxy-only / api-key-only / neither matrix
- [x] `tests/test_mcp_list_channels_tikhub_proxy.py` — same matrix at MCP boundary
- [x] Full pytest 957 passed
- [x] Release gate PASSED
- [ ] CI green