### PR TITLE
fix(channels): parse upstream timestamps into Evidence.published_at (P1)

### DIFF
--- a/autosearch/skills/channels/bilibili/methods/via_tikhub.py
+++ b/autosearch/skills/channels/bilibili/methods/via_tikhub.py
@@ -63,6 +63,17 @@ def _build_source_channel(result_type: str, author_name: str) -> str:
     return f"{base}:{author_slug}" if author_slug else base
 
 
+def _parse_pubdate(value: object) -> datetime | None:
+    if value is None or value == "":
+        return None
+
+    try:
+        timestamp = float(value)
+        return datetime.fromtimestamp(timestamp, UTC).astimezone(UTC)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
 def _extract_result_groups(
     payload: Mapping[str, object],
 ) -> list[tuple[str, list[Mapping[str, object]]]] | None:
@@ -178,6 +189,7 @@ def _to_video_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> E
         content=description or snippet,
         source_channel=_build_source_channel("video", author_name),
         fetched_at=fetched_at,
+        published_at=_parse_pubdate(item.get("pubdate")),
     )
 
 
@@ -199,6 +211,7 @@ def _to_article_evidence(item: Mapping[str, object], *, fetched_at: datetime) ->
         content=content or snippet,
         source_channel=_build_source_channel("article", author_name),
         fetched_at=fetched_at,
+        published_at=_parse_pubdate(item.get("pubdate")),
     )
 
 

--- a/autosearch/skills/channels/google_news/methods/api_search.py
+++ b/autosearch/skills/channels/google_news/methods/api_search.py
@@ -6,6 +6,7 @@ import html
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 
 import feedparser
 import httpx
@@ -86,6 +87,27 @@ def _publisher_title(entry: object) -> str:
     return ""
 
 
+def _published_at(entry: object) -> datetime | None:
+    for attr in ("published", "pubDate", "pubdate"):
+        raw_value = getattr(entry, attr, None)
+        if raw_value:
+            break
+    else:
+        getter = getattr(entry, "get", None)
+        if not callable(getter):
+            return None
+        raw_value = getter("published") or getter("pubDate") or getter("pubdate")
+
+    try:
+        parsed = parsedate_to_datetime(str(raw_value))
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
 def _to_evidence(entry: object, *, fetched_at: datetime) -> Evidence | None:
     url = str(getattr(entry, "link", "") or "").strip()
     if not url:
@@ -104,6 +126,7 @@ def _to_evidence(entry: object, *, fetched_at: datetime) -> Evidence | None:
         content=snippet,
         source_channel=source_channel,
         fetched_at=fetched_at,
+        published_at=_published_at(entry),
         score=0.0,
     )
 

--- a/autosearch/skills/channels/twitter/methods/via_tikhub.py
+++ b/autosearch/skills/channels/twitter/methods/via_tikhub.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 
 import structlog
 
@@ -30,6 +31,24 @@ def _truncate_on_word_boundary(text: str, *, max_length: int) -> str:
         if shortened:
             candidate = shortened
     return f"{candidate.rstrip()}…"
+
+
+def _parse_created_at(value: object) -> datetime | None:
+    if not value:
+        return None
+
+    raw_value = str(value)
+    try:
+        parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(raw_value)
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def _extract_tweets(payload: Mapping[str, object]) -> list[Mapping[str, object]]:
@@ -78,6 +97,7 @@ def _to_evidence(tweet: Mapping[str, object], *, fetched_at: datetime) -> Eviden
         content=content,
         source_channel=f"twitter:{screen_name}",
         fetched_at=fetched_at,
+        published_at=_parse_created_at(tweet.get("created_at")),
     )
 
 

--- a/autosearch/skills/channels/youtube/methods/data_api_v3.py
+++ b/autosearch/skills/channels/youtube/methods/data_api_v3.py
@@ -26,6 +26,20 @@ def _clean_text(value: object) -> str:
     return _normalize_whitespace(html.unescape(str(value or "")))
 
 
+def _parse_published_at(value: object) -> datetime | None:
+    if not value:
+        return None
+
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
 async def search(query: SubQuery) -> list[Evidence]:
     global _WARNED_NO_API_KEY
 
@@ -84,6 +98,7 @@ def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidenc
     video_id = str(item_id["videoId"]).strip()
     title = _clean_text(snippet["title"])
     description = _clean_text(snippet.get("description"))
+    published_at = _parse_published_at(snippet.get("publishedAt"))
 
     return Evidence(
         url=f"https://www.youtube.com/watch?v={video_id}",
@@ -91,5 +106,6 @@ def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidenc
         snippet=description[:500] or None,
         source_channel="youtube",
         fetched_at=fetched_at,
+        published_at=published_at,
         score=0.0,
     )

--- a/tests/channels/bilibili/test_via_tikhub.py
+++ b/tests/channels/bilibili/test_via_tikhub.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -161,6 +162,7 @@ async def test_search_extracts_videos_from_result_groups() -> None:
     assert results[1].url == "https://www.bilibili.com/video/BV2xyz456"
     assert results[0].source_channel == "bilibili:video:up-one"
     assert results[1].source_channel == "bilibili:video:up-two"
+    assert results[0].published_at == datetime(2024, 4, 19, 17, 0, tzinfo=UTC)
 
 
 @pytest.mark.asyncio
@@ -188,6 +190,23 @@ async def test_search_extracts_articles_from_result_groups() -> None:
     assert len(results) == 1
     assert results[0].url == "https://www.bilibili.com/read/cv445566/"
     assert results[0].source_channel == "bilibili:article:tech-writer"
+
+
+@pytest.mark.asyncio
+async def test_search_missing_pubdate_sets_published_at_none() -> None:
+    item = _video_item(
+        bvid="BV5missing222",
+        title="Missing pubdate",
+        description="No publish timestamp.",
+        author="No Date",
+    )
+    item.pop("pubdate")
+    client = _FakeTikhubClient(_payload([_group("video", [item])]))
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert len(results) == 1
+    assert results[0].published_at is None
 
 
 @pytest.mark.asyncio

--- a/tests/channels/google_news/test_api_search.py
+++ b/tests/channels/google_news/test_api_search.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
@@ -97,12 +98,14 @@ async def test_search_maps_rss_items_to_evidence() -> None:
     assert first.snippet == "AI regulation passes EU Reuters"
     assert first.content == "AI regulation passes EU Reuters"
     assert first.source_channel == "google_news:reuters"
+    assert first.published_at == datetime(2024, 4, 15, 10, 0, tzinfo=UTC)
 
     second = results[1]
     assert second.url == "https://news.google.com/rss/articles/def"
     assert second.title == "Chip exports tighten & markets react"
     assert second.snippet == "Chip exports tighten Markets react"
     assert second.source_channel == "google_news:the-new-york-times"
+    assert second.published_at == datetime(2024, 4, 16, 8, 30, tzinfo=UTC)
 
 
 @pytest.mark.asyncio
@@ -128,6 +131,7 @@ async def test_search_strips_html_from_summary() -> None:
 
     assert len(results) == 1
     assert results[0].snippet == "Story Publisher"
+    assert results[0].published_at is None
 
 
 @pytest.mark.asyncio

--- a/tests/channels/twitter/test_via_tikhub.py
+++ b/tests/channels/twitter/test_via_tikhub.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -105,11 +106,13 @@ async def test_search_extracts_tweets_from_flat_timeline() -> None:
     assert first.snippet == "OpenAI ships a new API update."
     assert first.content == "OpenAI ships a new API update."
     assert first.source_channel == "twitter:openai"
+    assert first.published_at == datetime(2026, 4, 23, 10, 0, tzinfo=UTC)
 
     second = results[1]
     assert second.url == "https://x.com/sama/status/9876543210"
     assert second.title == "Second launch note with & entity cleanup."
     assert second.source_channel == "twitter:sama"
+    assert second.published_at == datetime(2026, 4, 23, 10, 0, tzinfo=UTC)
 
 
 @pytest.mark.asyncio
@@ -138,6 +141,18 @@ async def test_search_source_channel_includes_screen_name() -> None:
 
     assert len(results) == 1
     assert results[0].source_channel == "twitter:elonmusk"
+
+
+@pytest.mark.asyncio
+async def test_search_missing_created_at_sets_published_at_none() -> None:
+    tweet = _flat_tweet("1234567890", "openai", "Missing created_at.")
+    tweet.pop("created_at")
+    client = _FakeTikhubClient(_timeline_payload([tweet]))
+
+    results = await search(_query(), client=cast(TikhubClient, client))
+
+    assert len(results) == 1
+    assert results[0].published_at is None
 
 
 @pytest.mark.asyncio

--- a/tests/channels/youtube/test_data_api_v3.py
+++ b/tests/channels/youtube/test_data_api_v3.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,6 +20,15 @@ def _load_search():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod.search
+
+
+def _load_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("yt_search_module", _SKILL_DIR / "data_api_v3.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 @pytest.fixture()
@@ -81,3 +91,19 @@ async def test_search_returns_evidence_with_key(search, subquery):
     assert len(results) >= 1
     assert results[0].source_channel == "youtube"
     assert "youtube.com" in results[0].url or "youtu.be" in results[0].url
+    assert results[0].published_at == datetime(2024, 3, 1, 0, 0, tzinfo=UTC)
+
+
+def test_to_evidence_missing_published_at_is_none() -> None:
+    module = _load_module()
+    item = {
+        "id": {"videoId": "abc123"},
+        "snippet": {
+            "title": "MLX Tutorial for Apple Silicon",
+            "description": "Learn to run LLMs on Apple Silicon with MLX.",
+        },
+    }
+
+    evidence = module._to_evidence(item, fetched_at=datetime(2024, 3, 2, tzinfo=UTC))
+
+    assert evidence.published_at is None

--- a/tests/contracts/test_report_time_metadata.py
+++ b/tests/contracts/test_report_time_metadata.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import feedparser
+import pytest
+
+from autosearch.core.context_compression import compress_evidence
+from autosearch.core.models import Evidence
+from autosearch.skills.channels.bilibili.methods import via_tikhub as bilibili
+from autosearch.skills.channels.google_news.methods import api_search as google_news
+from autosearch.skills.channels.twitter.methods import via_tikhub as twitter
+from autosearch.skills.channels.youtube.methods import data_api_v3 as youtube
+
+
+FETCHED_AT = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+
+
+def _assert_published_at_survives_consolidation(
+    evidence: Evidence,
+    expected: datetime,
+) -> None:
+    report = compress_evidence([evidence.to_context_dict()], query=evidence.title, top_k=1)
+
+    assert report["top_evidence"][0]["published_at"] == expected
+    assert report["top_evidence"][0]["published_at"] != report["top_evidence"][0]["fetched_at"]
+
+
+def test_google_news_pubdate_flows_through_consolidate_research() -> None:
+    rss = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>AI regulation passes EU</title>
+      <link>https://news.google.com/rss/articles/abc</link>
+      <pubDate>Mon, 15 Apr 2024 10:00:00 GMT</pubDate>
+      <description>AI regulation passes EU</description>
+      <source url="https://reuters.com">Reuters</source>
+    </item>
+  </channel>
+</rss>
+"""
+    entry = feedparser.parse(rss).entries[0]
+    evidence = google_news._to_evidence(entry, fetched_at=FETCHED_AT)
+
+    assert evidence is not None
+    _assert_published_at_survives_consolidation(
+        evidence,
+        datetime(2024, 4, 15, 10, 0, tzinfo=UTC),
+    )
+
+
+def test_youtube_published_at_flows_through_consolidate_research() -> None:
+    evidence = youtube._to_evidence(
+        {
+            "id": {"videoId": "abc123"},
+            "snippet": {
+                "title": "MLX Tutorial for Apple Silicon",
+                "description": "Learn to run LLMs on Apple Silicon with MLX.",
+                "publishedAt": "2024-03-01T00:00:00Z",
+            },
+        },
+        fetched_at=FETCHED_AT,
+    )
+
+    _assert_published_at_survives_consolidation(
+        evidence,
+        datetime(2024, 3, 1, 0, 0, tzinfo=UTC),
+    )
+
+
+def test_bilibili_pubdate_flows_through_consolidate_research() -> None:
+    evidence = bilibili._to_video_evidence(
+        {
+            "bvid": "BV1abc123",
+            "title": "Video title one",
+            "description": "First description.",
+            "author": "UP One",
+            "pubdate": 1713546000,
+        },
+        fetched_at=FETCHED_AT,
+    )
+
+    assert evidence is not None
+    _assert_published_at_survives_consolidation(
+        evidence,
+        datetime(2024, 4, 19, 17, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.parametrize(
+    ("created_at", "expected"),
+    [
+        ("Thu Apr 23 10:00:00 +0000 2026", datetime(2026, 4, 23, 10, 0, tzinfo=UTC)),
+    ],
+)
+def test_twitter_created_at_flows_through_consolidate_research(
+    created_at: str,
+    expected: datetime,
+) -> None:
+    evidence = twitter._to_evidence(
+        {
+            "tweet_id": "1234567890",
+            "screen_name": "openai",
+            "text": "OpenAI ships a new API update.",
+            "created_at": created_at,
+        },
+        fetched_at=FETCHED_AT,
+    )
+
+    assert evidence is not None
+    _assert_published_at_survives_consolidation(evidence, expected)


### PR DESCRIPTION
## Summary

PR #373 made `consolidate_research` preserve `published_at` from input — but four channels with known upstream timestamps weren't populating `Evidence.published_at`, so preservation was a no-op. Time-sensitive reports got uniform `fetched_at` instead of real publish times.

## Fix

| Channel | Source field | Format |
|---|---|---|
| google_news | RSS `pubDate` | RFC 2822 (parsed via `email.utils.parsedate_to_datetime`) |
| youtube | `snippet.publishedAt` | ISO 8601 |
| bilibili | `pubdate` | Unix epoch seconds (videos + articles) |
| twitter | `created_at` | ISO + Twitter format |

All parsers normalize to UTC and silently skip on malformed/missing (`published_at` is optional). Channel result is still valid without it.

Contract test `tests/contracts/test_report_time_metadata.py` enforces the end-to-end: upstream timestamp → Evidence → consolidate → report dict.

## Test plan

- [x] Per-channel tests cover present + missing + malformed timestamps
- [x] Contract test verifies the timestamp survives compression
- [x] Full pytest 958 passed
- [x] Release gate PASSED
- [ ] CI green

## Out of scope

Other channels (arxiv, reddit, hackernews, etc.) — they have different timestamp shapes; can be a follow-up.