### PR TITLE
fix(pre-release): Gate 12 stats bound to commit + label-based open-PR gate (P1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
@@ -76,6 +77,11 @@ jobs:
 
       - name: Install autosearch (for release-gate CLI surface checks)
         run: pip install -e ".[dev]"
+
+      - name: Run pre-release checklist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/validate/pre_release_check.py
 
       - name: Run release-gate.sh --quick --pypi (version + uniqueness + lint + CLI surface)
         run: bash scripts/release-gate.sh --quick --pypi

--- a/scripts/bench/judge.py
+++ b/scripts/bench/judge.py
@@ -20,10 +20,13 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import dataclasses
+from datetime import UTC, datetime
 import json
 import os
 import random
+import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from typing import Iterable
 
@@ -32,6 +35,7 @@ import httpx
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 DEFAULT_MODEL = "claude-sonnet-4-6"
 DEFAULT_PARALLEL = 4
+ROOT = Path(__file__).resolve().parents[2]
 PAIRWISE_PROMPT = """You are judging two research reports that answer the same question.
 
 Read both reports carefully. Decide which one answers the question better.
@@ -226,6 +230,47 @@ def summarize(verdicts: Iterable[PairVerdict], a_label: str, b_label: str) -> di
     }
 
 
+def current_commit_sha() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def current_version() -> str:
+    with (ROOT / "pyproject.toml").open("rb") as f:
+        return str(tomllib.load(f)["project"]["version"])
+
+
+def add_report_metadata(
+    stats: dict[str, object],
+    *,
+    model: str,
+    parallel: int,
+    a_dir: Path,
+    b_dir: Path,
+) -> dict[str, object]:
+    return {
+        **stats,
+        "commit_sha": current_commit_sha(),
+        "version": current_version(),
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "test_config": {
+            "model": model,
+            "parallel": parallel,
+            "sample_size": stats["total"],
+            "a_label": stats["a_label"],
+            "b_label": stats["b_label"],
+            "a_dir": str(a_dir),
+            "b_dir": str(b_dir),
+        },
+    }
+
+
 def render_summary_markdown(stats: dict[str, object], verdicts: list[PairVerdict]) -> str:
     lines = [
         f"# Pairwise judge summary — {stats['a_label']} vs {stats['b_label']}",
@@ -312,7 +357,13 @@ def main(argv: list[str] | None = None) -> int:
             encoding="utf-8",
         )
 
-    stats = summarize(verdicts, args.a_label, args.b_label)
+    stats = add_report_metadata(
+        summarize(verdicts, args.a_label, args.b_label),
+        model=args.model,
+        parallel=args.parallel,
+        a_dir=args.a_dir,
+        b_dir=args.b_dir,
+    )
     (args.output_dir / "stats.json").write_text(
         json.dumps(stats, ensure_ascii=False, indent=2),
         encoding="utf-8",

--- a/scripts/validate/pre_release_check.py
+++ b/scripts/validate/pre_release_check.py
@@ -7,6 +7,7 @@ Exit 0 = all checks pass. Exit 1 = one or more fail.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import subprocess
@@ -65,26 +66,104 @@ def _check_mcp_tools() -> tuple[bool, str]:
     return ok, out.splitlines()[0] if out else "error"
 
 
-def _check_gate12_bench() -> tuple[bool, str]:
-    reports = sorted(ROOT.glob("reports/*/judge/stats.json"))
+def _current_head() -> tuple[bool, str]:
+    ok, out = _run("git_head", ["git", "rev-parse", "HEAD"])
+    if not ok:
+        return False, f"could not determine HEAD commit: {out}"
+    return True, out.splitlines()[0].strip()
+
+
+def _stats_sort_key(path: Path, stats: dict[str, object]) -> tuple[str, float]:
+    generated_at = stats.get("generated_at")
+    if not isinstance(generated_at, str):
+        generated_at = ""
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    return generated_at, mtime
+
+
+def _read_gate12_reports() -> list[tuple[Path, dict[str, object]]]:
+    reports: list[tuple[Path, dict[str, object]]] = []
+    for path in ROOT.glob("reports/*/judge/stats.json"):
+        stats = json.loads(path.read_text(encoding="utf-8"))
+        reports.append((path, stats))
+    return sorted(reports, key=lambda item: _stats_sort_key(item[0], item[1]))
+
+
+def _check_gate12_bench(*, allow_stale: bool = False) -> tuple[bool, str]:
+    paths = sorted(ROOT.glob("reports/*/judge/stats.json"))
+    if not paths:
+        return (
+            False,
+            "no Gate 12 bench results found (run scripts/bench/bench_augment_vs_bare.py first)",
+        )
+
+    head_ok, head = _current_head()
+    if not head_ok:
+        return False, head
+
+    try:
+        reports = _read_gate12_reports()
+    except Exception as exc:
+        return False, f"could not parse Gate 12 stats: {exc}"
+
     if not reports:
         return (
             False,
             "no Gate 12 bench results found (run scripts/bench/bench_augment_vs_bare.py first)",
         )
-    latest = reports[-1]
+
+    matching = [(path, stats) for path, stats in reports if stats.get("commit_sha") == head]
+    if matching:
+        latest, stats = matching[-1]
+        stale_prefix = ""
+    elif allow_stale:
+        latest, stats = reports[-1]
+        stale_commit = stats.get("commit_sha")
+        stale_prefix = (
+            f"WARNING: Gate 12 stale: stats are from commit {stale_commit or 'unknown'} "
+            f"but HEAD is {head}; "
+        )
+    else:
+        latest, stats = reports[-1]
+        stale_commit = stats.get("commit_sha")
+        if stale_commit:
+            return (
+                False,
+                f"Gate 12 stale: Gate 12 stats are from commit {stale_commit} "
+                f"but HEAD is {head}; rerun gate-12",
+            )
+        return (
+            False,
+            "Gate 12 stale: stats are missing commit_sha; rerun gate-12",
+        )
+
     try:
-        stats = json.loads(latest.read_text(encoding="utf-8"))
         win_rate = stats.get("a_win_rate", stats.get("augmented_win_rate", 0.0))
         ok = float(win_rate) >= 0.50
-        return ok, f"win_rate={float(win_rate):.1%} from {latest.parent.parent.name}"
+        return ok, f"{stale_prefix}win_rate={float(win_rate):.1%} from {latest.parent.parent.name}"
     except Exception as exc:
         return False, f"could not parse {latest}: {exc}"
 
 
+def _label_names(pr: dict[str, object]) -> set[str]:
+    labels = pr.get("labels") or []
+    names: set[str] = set()
+    if not isinstance(labels, list):
+        return names
+    for label in labels:
+        if isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.add(label["name"])
+        elif isinstance(label, str):
+            names.add(label)
+    return names
+
+
 def _check_open_prs() -> tuple[bool, str]:
     result = subprocess.run(
-        ["gh", "pr", "list", "--state", "open", "--json", "number,title"],
+        ["gh", "pr", "list", "--state", "open", "--json", "number,title,labels"],
         capture_output=True,
         text=True,
         cwd=ROOT,
@@ -94,10 +173,12 @@ def _check_open_prs() -> tuple[bool, str]:
         return True, "gh not available — skipping PR check"
     try:
         prs = json.loads(result.stdout)
-        if prs:
-            titles = [f"#{p['number']}" for p in prs[:3]]
-            return False, f"{len(prs)} open PRs: {', '.join(titles)}"
-        return True, "no open PRs"
+        blockers = [p for p in prs if "release-blocker" in _label_names(p)]
+        summary = f"{len(prs)} open PRs ({len(blockers)} release-blockers)"
+        if blockers:
+            titles = [f"#{p['number']}" for p in blockers[:3]]
+            return False, f"{summary}: {', '.join(titles)}"
+        return True, summary
     except Exception:
         return True, "could not parse gh output — skipping"
 
@@ -115,14 +196,22 @@ def _check_git_clean() -> tuple[bool, str]:
     return True, "working tree clean"
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run fast pre-release checks.")
+    parser.add_argument(
+        "--allow-stale-gate12",
+        action="store_true",
+        help="Allow Gate 12 stats from a different commit for emergency or dry-run checks.",
+    )
+    args = parser.parse_args(argv)
+
     checks = [
         ("Version 4-file consistency", _check_version_consistency),
         ("SKILL.md format compliance", _check_skill_format),
         ("Channel experience dirs", _check_experience_dirs),
         ("MCP tools registered", _check_mcp_tools),
-        ("Gate 12 bench ≥ 50%", _check_gate12_bench),
-        ("Open PRs = 0", _check_open_prs),
+        ("Gate 12 bench ≥ 50%", lambda: _check_gate12_bench(allow_stale=args.allow_stale_gate12)),
+        ("Open PR release blockers", _check_open_prs),
         ("Git working tree clean", _check_git_clean),
     ]
 

--- a/tests/bench/test_judge.py
+++ b/tests/bench/test_judge.py
@@ -188,6 +188,37 @@ def test_summarize_counts_wins_and_ties() -> None:
     assert stats["b_win_rate"] == pytest.approx(0.25)
 
 
+def test_add_report_metadata_records_generation_context(monkeypatch) -> None:
+    monkeypatch.setattr(JUDGE, "current_commit_sha", lambda: "head-sha")
+    monkeypatch.setattr(JUDGE, "current_version", lambda: "2026.04.25.3")
+    stats = JUDGE.summarize(
+        [JUDGE.PairVerdict(name="1", winner="a", reason="x", swapped=False)],
+        "augmented",
+        "bare",
+    )
+
+    enriched = JUDGE.add_report_metadata(
+        stats,
+        model="claude-sonnet-4-6",
+        parallel=8,
+        a_dir=Path("reports/a"),
+        b_dir=Path("reports/b"),
+    )
+
+    assert enriched["commit_sha"] == "head-sha"
+    assert enriched["version"] == "2026.04.25.3"
+    assert isinstance(enriched["generated_at"], str)
+    assert enriched["test_config"] == {
+        "model": "claude-sonnet-4-6",
+        "parallel": 8,
+        "sample_size": 1,
+        "a_label": "augmented",
+        "b_label": "bare",
+        "a_dir": "reports/a",
+        "b_dir": "reports/b",
+    }
+
+
 def test_render_summary_markdown_contains_labels_and_counts() -> None:
     verdicts = [
         JUDGE.PairVerdict(name="pair1.md", winner="a", reason="A has specifics", swapped=False),

--- a/tests/scripts/test_pre_release_check.py
+++ b/tests/scripts/test_pre_release_check.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _load_pre_release_check() -> ModuleType:
+    root = Path(__file__).resolve().parents[2]
+    path = root / "scripts" / "validate" / "pre_release_check.py"
+    module_name = "_pre_release_check_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECK = _load_pre_release_check()
+
+
+def _write_stats(
+    tmp_path: Path,
+    run_name: str,
+    *,
+    commit_sha: str | None,
+    win_rate: float = 0.60,
+    generated_at: str = "2026-04-25T00:00:00Z",
+) -> Path:
+    path = tmp_path / "reports" / run_name / "judge" / "stats.json"
+    path.parent.mkdir(parents=True)
+    stats: dict[str, object] = {
+        "total": 10,
+        "a_win_rate": win_rate,
+        "generated_at": generated_at,
+    }
+    if commit_sha is not None:
+        stats["commit_sha"] = commit_sha
+    path.write_text(json.dumps(stats), encoding="utf-8")
+    return path
+
+
+def _mock_git_head(monkeypatch, head: str = "head-sha") -> None:
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["git", "rev-parse", "HEAD"]
+        return SimpleNamespace(returncode=0, stdout=f"{head}\n", stderr="")
+
+    monkeypatch.setattr(CHECK.subprocess, "run", fake_run)
+
+
+def _mock_gh_prs(monkeypatch, prs: list[dict[str, object]]) -> None:
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["gh", "pr", "list", "--state", "open", "--json", "number,title,labels"]
+        return SimpleNamespace(returncode=0, stdout=json.dumps(prs), stderr="")
+
+    monkeypatch.setattr(CHECK.subprocess, "run", fake_run)
+
+
+def test_gate12_stats_matching_commit_pass(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(CHECK, "ROOT", tmp_path)
+    _mock_git_head(monkeypatch)
+    _write_stats(tmp_path, "matching", commit_sha="head-sha")
+
+    ok, msg = CHECK._check_gate12_bench()
+
+    assert ok is True
+    assert "win_rate=60.0%" in msg
+
+
+def test_gate12_stats_mismatched_commit_fail_stale(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(CHECK, "ROOT", tmp_path)
+    _mock_git_head(monkeypatch)
+    _write_stats(tmp_path, "stale", commit_sha="old-sha")
+
+    ok, msg = CHECK._check_gate12_bench()
+
+    assert ok is False
+    assert "Gate 12 stale" in msg
+    assert "old-sha" in msg
+    assert "head-sha" in msg
+
+
+def test_gate12_no_stats_fails(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(CHECK, "ROOT", tmp_path)
+
+    ok, msg = CHECK._check_gate12_bench()
+
+    assert ok is False
+    assert "no Gate 12 bench results found" in msg
+
+
+def test_gate12_allow_stale_passes_mismatch_with_warning(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(CHECK, "ROOT", tmp_path)
+    _mock_git_head(monkeypatch)
+    _write_stats(tmp_path, "stale", commit_sha="old-sha")
+
+    ok, msg = CHECK._check_gate12_bench(allow_stale=True)
+
+    assert ok is True
+    assert "WARNING: Gate 12 stale" in msg
+
+
+def test_allow_stale_gate12_cli_flag_is_wired(monkeypatch) -> None:
+    seen: dict[str, bool] = {}
+
+    monkeypatch.setattr(CHECK, "_check_version_consistency", lambda: (True, "ok"))
+    monkeypatch.setattr(CHECK, "_check_skill_format", lambda: (True, "ok"))
+    monkeypatch.setattr(CHECK, "_check_experience_dirs", lambda: (True, "ok"))
+    monkeypatch.setattr(CHECK, "_check_mcp_tools", lambda: (True, "ok"))
+    monkeypatch.setattr(CHECK, "_check_open_prs", lambda: (True, "ok"))
+    monkeypatch.setattr(CHECK, "_check_git_clean", lambda: (True, "ok"))
+
+    def fake_gate12(*, allow_stale: bool = False):
+        seen["allow_stale"] = allow_stale
+        return True, "ok"
+
+    monkeypatch.setattr(CHECK, "_check_gate12_bench", fake_gate12)
+
+    assert CHECK.main(["--allow-stale-gate12"]) == 0
+    assert seen == {"allow_stale": True}
+
+
+def test_gate12_prefers_latest_matching_head(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(CHECK, "ROOT", tmp_path)
+    _mock_git_head(monkeypatch)
+    _write_stats(
+        tmp_path,
+        "newer-stale",
+        commit_sha="old-sha",
+        generated_at="2026-04-25T02:00:00Z",
+    )
+    _write_stats(
+        tmp_path,
+        "older-matching",
+        commit_sha="head-sha",
+        generated_at="2026-04-25T01:00:00Z",
+    )
+
+    ok, msg = CHECK._check_gate12_bench()
+
+    assert ok is True
+    assert "from older-matching" in msg
+
+
+def test_open_pr_with_release_blocker_label_fails(monkeypatch) -> None:
+    _mock_gh_prs(
+        monkeypatch,
+        [
+            {
+                "number": 379,
+                "title": "must fix",
+                "labels": [{"name": "release-blocker"}],
+            }
+        ],
+    )
+
+    ok, msg = CHECK._check_open_prs()
+
+    assert ok is False
+    assert "1 open PRs (1 release-blockers)" in msg
+    assert "#379" in msg
+
+
+def test_open_pr_without_release_blocker_label_passes(monkeypatch) -> None:
+    _mock_gh_prs(
+        monkeypatch,
+        [
+            {
+                "number": 321,
+                "title": "external contribution",
+                "labels": [{"name": "external"}],
+            }
+        ],
+    )
+
+    ok, msg = CHECK._check_open_prs()
+
+    assert ok is True
+    assert msg == "1 open PRs (0 release-blockers)"
+
+
+def test_zero_open_prs_passes(monkeypatch) -> None:
+    _mock_gh_prs(monkeypatch, [])
+
+    ok, msg = CHECK._check_open_prs()
+
+    assert ok is True
+    assert msg == "0 open PRs (0 release-blockers)"


### PR DESCRIPTION
## Summary

`pre_release_check.py` had two policy bugs:

1. **Stale Gate 12 reports**: accepted any `reports/*/judge/stats.json` regardless of which commit produced it. 3-day-old Gate 12 from `2026-04-22-gate12-extended` was blessing 2026-04-25 HEAD even though every commit since changed behavior the report measured.
2. **Open PR policy**: hardcoded "Open PRs == 0" blocked on `#379, #321, #317` — informational/external PRs the user wants to keep open.

## Fix

### Gate 12 commit binding

`scripts/bench/judge.py` now writes `commit_sha`, `version`, `generated_at`, `test_config` to `stats.json`. `pre_release_check.py` verifies `commit_sha == HEAD`; mismatch → fail with clear "rerun gate-12" message. `--allow-stale-gate12` flag for emergencies.

### Label-based open-PR gating

Open PR with `release-blocker` label → fails the check. Without that label → informational only (counted but doesn't block). Summary: `N open PRs (M release-blockers)`.

### Wired into workflow

Release workflow now runs `pre_release_check.py` before `release-gate.sh --quick`. No more local-only enforcement.

## Test plan

- [x] `tests/scripts/test_pre_release_check.py` — Gate 12 stale / matching / missing / `--allow-stale-gate12`; open PR with/without `release-blocker` label
- [x] `tests/bench/test_judge.py` — stats.json schema includes new metadata
- [x] Full pytest 961 passed
- [x] Release gate PASSED
- [ ] CI green