### PR TITLE
docs(quickstart): npm install does NOT auto-init; smoke test guards no-postinstall (P2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ You ask your AI to research something. It answers from training data cutoff —
 **AutoSearch fixes this in one line.**
 
 ```bash
-npx autosearch-ai
+npx autosearch-ai --yes
 ```
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 ```
+
+The npm wrapper runs install/init only when you invoke it explicitly. Plain
+`npm install -g autosearch-ai` does not auto-run `init`; avoiding npm
+install-time scripts is intentional supply-chain hardening.
 
 Or paste into your AI Agent (Claude Code, Cursor, etc.):
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,8 +27,9 @@ Install AutoSearch and configure the MCP server so the user's agent has access t
 ### Step 1: Install AutoSearch
 
 ```bash
-# Option 1: npx — one command, no setup required (recommended)
-npx autosearch-ai
+# Option 1: npm wrapper — explicit install + init, no npm postinstall hook
+npm install -g autosearch-ai
+npx autosearch-ai --yes
 
 # Option 2: curl install script
 curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
@@ -40,7 +41,15 @@ pip install autosearch && autosearch init
 pipx install autosearch && autosearch init
 ```
 
-> The curl option runs `autosearch init` automatically. The npx option prints the install URL it's about to fetch and waits for `y` to confirm — pass `--yes` (or `-y`) to skip the prompt for non-interactive automation.
+> The npm package does not run `init` automatically during `npm install`.
+> That is intentional: npm lifecycle scripts can execute code at install time,
+> which is a known supply-chain risk. Run `npx autosearch-ai --yes` for an
+> explicit one-shot install + init, or run `autosearch init` if the Python CLI
+> is already on PATH.
+>
+> The curl option runs `autosearch init` automatically. Without `--yes`, the
+> npx option prints the install URL it's about to fetch and waits for `y` to
+> confirm.
 
 This will:
 - Detect available LLM providers (Anthropic, OpenAI, Gemini, claude CLI)

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,9 +7,16 @@ description: "First search in 5 minutes"
 
 ```bash
 npm install -g autosearch-ai
+npx autosearch-ai --yes        # explicit one-shot install + init
+# OR
+autosearch init                # if you have the Python CLI on PATH
 ```
 
-`init` runs automatically after install and configures the MCP server. You should see:
+`init` is an explicit step, not an npm postinstall hook. AutoSearch avoids
+running lifecycle scripts during npm install because automatic install-time
+execution is a known supply-chain risk.
+
+The explicit init step configures the MCP server. You should see:
 
 ```
 ✅ Python 3.12+              [OK]

--- a/tests/smoke/test_npm_wrapper.py
+++ b/tests/smoke/test_npm_wrapper.py
@@ -1,0 +1,69 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NPM_DIR = ROOT / "npm"
+PACKAGE_JSON = NPM_DIR / "package.json"
+WRAPPER_BIN = "./bin/autosearch-ai.js"
+AUTO_INSTALL_SCRIPTS = {"preinstall", "install", "postinstall"}
+
+
+def read_package_json() -> dict:
+    return json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+
+
+def test_npm_package_has_no_install_lifecycle_scripts() -> None:
+    package = read_package_json()
+
+    scripts = package.get("scripts") or {}
+    assert isinstance(scripts, dict)
+    assert AUTO_INSTALL_SCRIPTS.isdisjoint(scripts)
+
+
+def test_npm_bin_points_at_wrapper_script() -> None:
+    package = read_package_json()
+
+    assert package["bin"]["autosearch-ai"] == WRAPPER_BIN
+    assert (NPM_DIR / WRAPPER_BIN).resolve().is_file()
+
+
+def test_npm_pack_dry_run_has_no_install_lifecycle_scripts(
+    tmp_path: Path,
+) -> None:
+    env = os.environ.copy()
+    env["npm_config_cache"] = str(tmp_path / "npm-cache")
+
+    result = subprocess.run(
+        [
+            "npm",
+            "pack",
+            "--dry-run",
+            "--json",
+            "--prefix",
+            "npm",
+            "./npm",
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    combined_output = result.stdout + result.stderr
+    assert result.returncode == 0, combined_output
+
+    pack_output = json.loads(result.stdout)
+    assert len(pack_output) == 1
+
+    package = read_package_json()
+    scripts = package.get("scripts") or {}
+    assert AUTO_INSTALL_SCRIPTS.isdisjoint(scripts)
+
+    packed_files = {entry["path"] for entry in pack_output[0]["files"]}
+    assert "package.json" in packed_files
+    assert "bin/autosearch-ai.js" in packed_files


### PR DESCRIPTION
## Summary

Quickstart docs claimed `npm install -g autosearch-ai` would automatically run `init`. But `npm/package.json` has NO `postinstall` script (intentional — npm lifecycle auto-execution is a known supply-chain vector). Users followed the docs, ran the install, then wondered why nothing happened.

## Fix

### Docs

`docs/quickstart.mdx`, `docs/install.md`, `README.md` — replace the auto-init language with:
```
npm install -g autosearch-ai
npx autosearch-ai --yes        # explicit one-shot install + init
# OR
autosearch init                # if Python CLI is on PATH
```

Note that no-postinstall is the secure choice, not an oversight.

### Drift guard

`tests/smoke/test_npm_wrapper.py` asserts:
- `package.json` has no `preinstall` / `install` / `postinstall` scripts
- `bin.autosearch-ai` correctly points at the wrapper
- `npm pack --dry-run --json` shows no auto-execute scripts

If someone later adds a postinstall, the test fails and forces docs sync.

## Test plan

- [x] Smoke test 3 passed
- [x] Full pytest 954 passed
- [x] Release gate PASSED
- [ ] CI green