### PR TITLE
fix(release): pin setuptools+twine + license metadata + bump 2026.04.25.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.25.3"
+    "version": "2026.04.25.4"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.25.3",
+      "version": "2026.04.25.4",
       "author": {
         "name": "0xmariowu"
       },
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.25.3"
+  "version": "2026.04.25.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.25.3",
+  "version": "2026.04.25.4",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         run: bash scripts/release-gate.sh --quick
 
       - name: Install build backend
-        run: pip install build twine
+        run: pip install --upgrade "build>=1.2" "twine>=6.1" "setuptools>=80"
 
       - name: Build sdist + wheel
         run: python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2026.04.25.4 — 2026-04-25
+
+The "release plumbing hotfix" release — `2026.04.25.3` was tagged and
+the GitHub workflow ran, but `twine upload` rejected the wheel with
+`Invalid distribution metadata: unrecognized or malformed field
+'license-file'`. Older setuptools (75-77 range) wrote a metadata 2.4
+field that older twine clients didn't accept. The PyPI / npm /
+GitHub Release for `.25.3` never actually shipped.
+
+This release contains all `.25.3` changes (the "production-critical
+sweep" — see the `.25.3` entry below for the full list of 21 features
+from the 5-agent audit) plus the release-plumbing hotfix:
+
+- `pyproject.toml`: explicit `license = "MIT"` (PEP 639 SPDX) and
+  `license-files = ["LICENSE"]`. `[build-system].requires` bumped to
+  `setuptools>=80` so build environments use a clean metadata-2.4
+  generator.
+- `.github/workflows/release.yml`: pin `--upgrade build>=1.2`,
+  `twine>=6.1`, `setuptools>=80` in the build job. Twine 6.1+ knows
+  about metadata 2.4 license-file fields.
+
+Verified locally with `python -m build` + `twine check dist/*` after
+the fix (both wheel and sdist PASS).
+
 ## 2026.04.25.3 — 2026-04-25
 
 The "production-critical sweep" release — twelve PRs landing 21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=80", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,6 +7,8 @@ name = "autosearch"
 version = "2026.04.25.3"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
   "beautifulsoup4>=4.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.3"
+version = "2026.04.25.4"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "autosearch"
-version = "2026.4.25.3"
+version = "2026.4.25.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Emergency hotfix combined with version bump: `v2026.04.25.3` was tagged but the release workflow failed in `twine upload` with `Invalid distribution metadata: unrecognized or malformed field 'license-file'`. The PyPI / npm / GitHub Release for `.25.3` never actually shipped — users who tried to install got the still-stale `.25.2`.

Cause: setuptools (between 75-77) writes a PEP 639 metadata-2.4 `license-file` field, and the twine version pulled in by the workflow's unpinned `pip install build twine` didn't recognize it.

## Two-part fix

### pyproject.toml

- Explicit `license = "MIT"` (PEP 639 SPDX form)
- `license-files = ["LICENSE"]`
- `[build-system].requires = ["setuptools>=80", "wheel"]` — newer setuptools writes clean metadata that newer twine handles

### .github/workflows/release.yml

```yaml
- name: Install build backend
  run: pip install --upgrade "build>=1.2" "twine>=6.1" "setuptools>=80"
```

Twine 6.1+ supports PEP 639 metadata-2.4 properly.

## Bump to 2026.04.25.4

`.25.3` was tagged in remote but never shipped. Skipping ahead to `.25.4` rather than re-tagging — destructive operations on shared tags are risky and the new `check_version_uniqueness.py` (PR #381 if/when merged) would catch any retag attempt anyway.

This PR contains:
1. `fix(release): pin setuptools>=80 + twine>=6.1 + explicit license metadata` — the actual hotfix
2. `chore: bump version to 2026.04.25.4` — version bump

CHANGELOG entry for `.25.4` describes the situation and lists the rolled-up `.25.3` content (twelve PRs from the production-critical sweep) plus the hotfix itself.

## Test plan

- [x] Local `python -m build` + `twine check dist/*` both PASS for the new wheel
- [x] Release gate PASSED (924 tests + version-consistency + console-script version match)
- [x] Sanity: rebuilt console script reports `2026.4.25.4` matching pyproject `2026.04.25.4`
- [ ] CI green → auto-merge → tag `v2026.04.25.4` triggers fixed release.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2026.04.25.4
  * Enhanced build and distribution tooling with updated package dependencies for improved reliability
  * Updated project metadata with explicit license configuration to ensure proper package installation and compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->