### PR TITLE
fix(release): pin twine>=6.1 in publish-pypi job too + bump 2026.04.25.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.25.4"
+    "version": "2026.04.25.5"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.25.4",
+      "version": "2026.04.25.5",
       "author": {
         "name": "0xmariowu"
       },
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.25.4"
+  "version": "2026.04.25.5"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.25.4",
+  "version": "2026.04.25.5",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           fi
 
       - name: Install twine
-        run: python -m pip install twine
+        run: python -m pip install --upgrade "twine>=6.1"
 
       - name: Publish to PyPI
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026.04.25.5 — 2026-04-25
+
+Second hotfix attempt for the `.25.3`/`.25.4` PyPI publish failure.
+`.25.4` pinned `twine>=6.1` in the **build** job but missed the
+**publish-pypi** job which had its own separate `pip install twine`
+without the pin — so the upload step grabbed older twine and rejected
+metadata-2.4 license-file/license-expression fields. Both `.25.3` and
+`.25.4` tags exist on GitHub but neither shipped to PyPI / npm / 
+GitHub Release.
+
+This release pins `twine>=6.1` in the publish-pypi job too. Same
+content as `.25.4` (which had all `.25.3` content + license metadata
+hotfix) — just the second half of the workflow fix.
+
 ## 2026.04.25.4 — 2026-04-25
 
 The "release plumbing hotfix" release — `2026.04.25.3` was tagged and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.4"
+version = "2026.04.25.5"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "autosearch"
-version = "2026.4.25.4"
+version = "2026.4.25.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Second hotfix for the `.25.3` / `.25.4` PyPI publish failures.

`#389` (`.25.4`) pinned `twine>=6.1` in the **build** job (which runs `twine check` to validate the wheel). But the **publish-pypi** job has its own separate `pip install twine` step that I missed — it grabbed unpinned (older) twine, which rejected metadata-2.4 `license-file` / `license-expression` fields and bailed before sending to PyPI.

So `.25.3` and `.25.4` both have GitHub tags but neither shipped to PyPI / npm / GitHub Release.

## Fix

```yaml
- name: Install twine
  run: python -m pip install --upgrade "twine>=6.1"
```

(was `pip install twine` unpinned)

This is the same `twine>=6.1` already pinned in the build job — just propagated to the publish job.

## Bump to .25.5

`.25.3` and `.25.4` tags exist but content never shipped. Skipping ahead to `.25.5` rather than re-tagging.

## Test plan

- [x] Local `python -m build` + `twine check dist/*` (with twine 6.1) PASS
- [x] Release gate PASSED (924 tests + version uniqueness + console-script match)
- [ ] CI green → tag `v2026.04.25.5` triggers fixed release.yml