### PR TITLE
fix(release): switch publish-pypi to pypa/gh-action-pypi-publish + bump 2026.04.25.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.25.5"
+    "version": "2026.04.25.6"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.25.5",
+      "version": "2026.04.25.6",
       "author": {
         "name": "0xmariowu"
       },
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.25.5"
+  "version": "2026.04.25.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.25.5",
+  "version": "2026.04.25.6",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,14 +140,12 @@ jobs:
             exit 1
           fi
 
-      - name: Install twine
-        run: python -m pip install --upgrade "twine>=6.1"
-
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist
+          verbose: true
 
   create-github-release:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026.04.25.6 — 2026-04-25
+
+Third (and hopefully final) release-pipeline hotfix. `.25.4` and `.25.5`
+both pinned `twine>=6.1` but still failed at upload with the same
+`InvalidDistribution: unrecognized or malformed field 'license-file'`
+error — even though local `twine check --strict` passed on identical
+wheels. Cause appears to be GitHub's `ubuntu-latest` runner shadowing
+the user-installed twine with a system-installed older pkginfo on the
+fallback path.
+
+Switched the publish-pypi step to `pypa/gh-action-pypi-publish@release/v1`,
+the official PyPA action. It manages the upload toolchain internally
+and is the recommended path. No more manual twine version pinning.
+
+Same content as `.25.5` (which had `.25.3` content + license metadata
+hotfix + publish-pypi twine pin). Just the action change.
+
 ## 2026.04.25.5 — 2026-04-25
 
 Second hotfix attempt for the `.25.3`/`.25.4` PyPI publish failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.5"
+version = "2026.04.25.6"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "autosearch"
-version = "2026.4.25.5"
+version = "2026.4.25.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`.25.4` and `.25.5` both pinned `twine>=6.1` but still failed with the same `InvalidDistribution: unrecognized or malformed field 'license-file'` error at upload, even though local `twine check --strict` passed on identical wheels.

GitHub's `ubuntu-latest` runner appears to have an older pkginfo system-installed that shadows the user-local twine 6.2.0's pkginfo. Manual twine management isn't reliable.

## Fix

Switch to `pypa/gh-action-pypi-publish@release/v1` — the official PyPA action. It manages the upload toolchain internally and supports modern metadata 2.4. No more manual twine versions to pin.

```yaml
- name: Publish to PyPI
  uses: pypa/gh-action-pypi-publish@release/v1
  with:
    password: ${{ secrets.PYPI_API_TOKEN }}
    packages-dir: dist
    verbose: true
```

## Test plan

- [x] Local `python -m build` + `twine check dist/* --strict` pass on the new wheel
- [x] Release gate PASSED (924 tests + version uniqueness + console-script match)
- [ ] CI green → tag `v2026.04.25.6` triggers fixed release.yml using PyPA action