### PR TITLE
fix(release): add checkout to create-github-release job + bump 2026.04.25.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.25.6"
+    "version": "2026.04.25.7"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.25.6",
+      "version": "2026.04.25.7",
       "author": {
         "name": "0xmariowu"
       },
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.25.6"
+  "version": "2026.04.25.7"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.25.6",
+  "version": "2026.04.25.7",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ needs.build.outputs.tag }}
+          fetch-depth: 0
+
       - name: Download Python distributions
         uses: actions/download-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026.04.25.7 — 2026-04-25
+
+GitHub Release auto-creation hotfix on top of `.25.6`. The
+`.25.6` workflow successfully published to PyPI and npm using the
+PyPA action, but the `create-github-release` job lacked
+`actions/checkout` — `gh release create` failed with "fatal: not a
+git repository" because the runner had no `.git` context. The GH
+Release was created manually for `.25.6`. This release adds the
+missing checkout step so future releases auto-create the GH Release
+end-to-end.
+
+`.25.6` content (already on PyPI / npm):
+- All `.25.3`–`.25.5` rollup (twelve PRs from the production-critical
+  sweep audit)
+- License metadata + `setuptools>=80` / `twine>=6.1` / PyPA action
+
 ## 2026.04.25.6 — 2026-04-25
 
 Third (and hopefully final) release-pipeline hotfix. `.25.4` and `.25.5`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.6"
+version = "2026.04.25.7"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "autosearch"
-version = "2026.4.25.6"
+version = "2026.4.25.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

`.25.6` succeeded at PyPI publish (via the PyPA action) and npm publish, but `create-github-release` job failed with `fatal: not a git repository` — the job lacked `actions/checkout` so `gh release create` had no git context. I created the `.25.6` GH Release manually.

This release adds the missing checkout to the workflow so future tags create GitHub Release end-to-end without manual intervention.

## Test plan

- [x] Release gate PASSED locally
- [x] Wheel + sdist build cleanly
- [ ] CI green → tag `v2026.04.25.7` triggers full release flow → all 4 jobs (build / publish-pypi / create-github-release / publish-npm) succeed