### PR TITLE
chore: bump version to 2026.04.25.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.25.7"
+    "version": "2026.04.25.8"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.25.7",
+      "version": "2026.04.25.8",
       "author": {
         "name": "0xmariowu"
       },
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.25.7"
+  "version": "2026.04.25.8"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.25.7",
+  "version": "2026.04.25.8",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026.04.25.8 — 2026-04-25
+
+Ships PR #387 — the Gate 12 / pre-release-check / open-PR-label
+work that was open while the `.25.4`–`.25.7` release-pipeline
+hotfixes landed.
+
+- `scripts/bench/judge.py`: Gate 12 stats now include `commit_sha`,
+  `version`, `generated_at`, `test_config` provenance.
+- `scripts/validate/pre_release_check.py`: requires Gate 12
+  `commit_sha == HEAD`; supports `--allow-stale-gate12` override;
+  open PR gate switched from "any open PR blocks" to
+  "PR labeled `release-blocker` blocks".
+- `.github/workflows/release.yml`: pre-release check is now a
+  release-job step.
+
 ## 2026.04.25.7 — 2026-04-25
 
 GitHub Release auto-creation hotfix on top of `.25.6`. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.7"
+version = "2026.04.25.8"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 
 [[package]]
 name = "autosearch"
-version = "2026.4.25.7"
+version = "2026.4.25.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Ships PR #387 (Gate 12 metadata + pre-release-check open-PR labels) — was open while the `.25.4`–`.25.7` release-pipeline hotfixes landed.

## Test plan

- [x] Release gate PASSED (924 tests + version uniqueness + console-script match)
- [ ] CI green → tag `v2026.04.25.8` → release.yml ships PyPI/npm/GH Release