### PR TITLE
docs: unify install paths to npx + AI agent + curl, drop --yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,21 @@ You ask your AI to research something. It answers from training data cutoff —
 - "Summarize the Twitter discussion on this topic" → **blocked**, no public API
 - "Compare opinions on Hacker News vs Chinese tech forums" → two platforms, manual aggregation
 
-**AutoSearch fixes this in one line.**
+**AutoSearch fixes this in one line.** Pick the path that matches you:
+
+**Have Node?** (most common — works on macOS, Linux, Windows)
 
 ```bash
-npx autosearch-ai --yes
+npx autosearch-ai
 ```
+
+**Using Claude Code / Cursor / Zed?** Paste this into your AI agent:
+
+```
+Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosearch/main/docs/install.md
+```
+
+**Shell user on macOS / Linux?**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
@@ -44,12 +54,6 @@ curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/i
 The npm wrapper runs install/init only when you invoke it explicitly. Plain
 `npm install -g autosearch-ai` does not auto-run `init`; avoiding npm
 install-time scripts is intentional supply-chain hardening.
-
-Or paste into your AI Agent (Claude Code, Cursor, etc.):
-
-```
-Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosearch/main/docs/install.md
-```
 
 After install, your Agent searches 40 channels simultaneously — academic papers, developer communities, Chinese social media, and Linux DO forum threads — results deduplicated and ranked, every result includes a source URL.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -31,20 +31,24 @@
 - "帮我整理一下推特上对这个技术的讨论" → **看不到**，Twitter 没有公开 API
 - "这个话题在知乎和 Reddit 上分别是什么观点" → 要跑两个平台，结果还得手动汇总
 
-**AutoSearch 把这件事变成一句话：**
+**AutoSearch 把这件事变成一句话。** 挑一条适合你的：
+
+**机器有 Node？**（最常见——macOS / Linux / Windows 都行）
 
 ```bash
 npx autosearch-ai
 ```
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
-```
-
-或者复制给你的 AI Agent（Claude Code、Cursor 等）：
+**在用 Claude Code / Cursor / Zed？** 把这一行粘给你的 AI Agent：
 
 ```
 Help me install AutoSearch: https://raw.githubusercontent.com/0xmariowu/Autosearch/main/docs/install.md
+```
+
+**macOS / Linux shell 老用户？**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 ```
 
 安装后你的 Agent 能同时搜 40 个渠道——学术论文、开发者社区、中文社媒、Linux DO 论坛帖子，结果去重排序，每条结果都有来源链接。

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,11 +27,10 @@ Install AutoSearch and configure the MCP server so the user's agent has access t
 ### Step 1: Install AutoSearch
 
 ```bash
-# Option 1: npm wrapper — explicit install + init, no npm postinstall hook
-npm install -g autosearch-ai
-npx autosearch-ai --yes
+# Option 1: npm wrapper — one-shot install + init (cross-platform)
+npx autosearch-ai
 
-# Option 2: curl install script
+# Option 2: curl install script (macOS / Linux only)
 curl -fsSL https://raw.githubusercontent.com/0xmariowu/Autosearch/main/scripts/install.sh | bash
 
 # Option 3: pip
@@ -43,13 +42,14 @@ pipx install autosearch && autosearch init
 
 > The npm package does not run `init` automatically during `npm install`.
 > That is intentional: npm lifecycle scripts can execute code at install time,
-> which is a known supply-chain risk. Run `npx autosearch-ai --yes` for an
-> explicit one-shot install + init, or run `autosearch init` if the Python CLI
-> is already on PATH.
+> which is a known supply-chain risk. `npx autosearch-ai` triggers an explicit
+> install + init flow with a y/N confirmation before fetching anything; the CI
+> escape hatch is `npx autosearch-ai --yes` (do not put `--yes` in user-facing
+> docs). Plain `npm install -g autosearch-ai` installs the wrapper but does
+> not run `init` — use `npx autosearch-ai` for the one-shot flow, or run
+> `autosearch init` if the Python CLI is already on PATH.
 >
-> The curl option runs `autosearch init` automatically. Without `--yes`, the
-> npx option prints the install URL it's about to fetch and waits for `y` to
-> confirm.
+> The curl option runs `autosearch init` automatically.
 
 This will:
 - Detect available LLM providers (Anthropic, OpenAI, Gemini, claude CLI)

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -6,15 +6,16 @@ description: "First search in 5 minutes"
 ## 1. Install
 
 ```bash
-npm install -g autosearch-ai
-npx autosearch-ai --yes        # explicit one-shot install + init
-# OR
-autosearch init                # if you have the Python CLI on PATH
+npx autosearch-ai              # one-shot install + init
+# OR, if you already have the Python CLI on PATH:
+autosearch init
 ```
 
 `init` is an explicit step, not an npm postinstall hook. AutoSearch avoids
 running lifecycle scripts during npm install because automatic install-time
-execution is a known supply-chain risk.
+execution is a known supply-chain risk. Plain `npm install -g autosearch-ai`
+installs the wrapper but does not run `init` — use `npx autosearch-ai` for
+the one-shot flow.
 
 The explicit init step configures the MCP server. You should see:
 


### PR DESCRIPTION
## Summary

Three commits:

1. **`docs:`** unify install paths around three user personas:
   - Have Node? → `npx autosearch-ai`
   - Using Claude Code / Cursor / Zed? → paste install.md URL into the AI agent
   - Shell user on macOS / Linux? → `curl ... | bash`
2. **`fix(npm):`** remove `--yes` / `-y` flag from the npm wrapper entirely.
3. **`docs:`** add Uninstall section to install.md + cross-link from README.

## Why

- README.md (英文) used `--yes`, README.zh.md / 官网 (中文) didn't — same product gave two different first-run experiences.
- No major npm tool推 `--yes` in user-facing docs. Listing it trains users to无脑跳过 curl-bash 的 y/N confirmation — that defeats the wrapper's intentional supply-chain hardening.
- Plain `npm install -g autosearch-ai` is a half-step (wrapper installed but Python pkg + init not done), so listing it next to `npx autosearch-ai` muddied the message — dropped from quickstart.
- CI / non-interactive flows should bypass the wrapper entirely and use `pipx install autosearch && autosearch init` directly. The `confirm()` helper already returns `false` in non-TTY environments, so removing `--yes` gives CI / Docker / pipe contexts a clean "use pipx instead" abort message instead of silent install.
- Evaluators / mis-installs / AI agents reading install.md previously had no uninstall path. Now there's a 4-row decision table covering npx / curl / pipx / pip / npm-wrapper combinations, plus config + MCP cleanup.

## Files

- `README.md` / `README.zh.md` — three persona-tagged install paths, no `--yes`, one-line cross-link to Uninstall
- `docs/quickstart.mdx` — single `npx autosearch-ai` line, dropped `npm install -g` confusion
- `docs/install.md` — 4 install options, no `--yes`, CI escape hatch note removed, **new Uninstall decision table**
- `npm/bin/autosearch-ai.js` — `--yes` / `-y` flag removed; help text + abort message updated; top-level comment reflects "no escape hatch" design

## Test plan

- [x] `tests/smoke/test_npm_wrapper.py` — 3 tests pass after wrapper change
- [x] `node npm/bin/autosearch-ai.js --help` — clean output, no `--yes` documented
- [ ] Render preview of README.md / README.zh.md (GitHub PR diff)
- [ ] Render preview of docs/quickstart.mdx (Mintlify)
- [ ] Render preview of docs/install.md — Uninstall section renders correctly
- [ ] Verify `npx autosearch-ai` (no `--yes`) still triggers y/N prompt → install + init flow on a clean machine
- [ ] Verify non-TTY environments now get the "use pipx" abort message instead of silent install
- [ ] Spot-check uninstall one-liner on a uv-installed machine: `uv tool uninstall autosearch || pipx uninstall autosearch || pip uninstall -y autosearch`

## Out of scope

- Wrapper-internal `curl ... | bash` (macOS/Linux branch in `npm/bin/autosearch-ai.js:184`) — separate cleanup, propose switching to `pipx install autosearch` to align with the Windows branch.
- Stale `--yes` references in `docs/exec-plans/active/autosearch-0425-production-critical-fix-plan-v2.md` and `docs/million-user-product-readiness-plan.md` — historical planning docs; archival is a separate task.
- A native `autosearch uninstall` CLI command (would clean config + MCP entries automatically) — possible follow-up; current uninstall flow requires two manual steps.
- `docs/install.md` Docker / offline / corporate-proxy sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)