### PR TITLE
chore(public-repo): hygiene batch 2A — committer/husky/gitleaks tooling layer

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -53,12 +53,20 @@ regex = '''dangerously-skip-permissions'''
 tags = ["hygiene", "internal-flag"]
 keywords = ["dangerously"]
 
+  [[rules.allowlists]]
+  description = "Test fixtures may legitimately reference the flag for negative-test scenarios"
+  paths = ['''tests/e2b/.*\.yaml$''', '''tests/.*\.py$''']
+
 [[rules]]
 id = "handoff-file"
 description = "Reference to HANDOFF.md (internal session-handoff state)"
 regex = '''\bHANDOFF\.md\b'''
 tags = ["hygiene", "handoff"]
 keywords = ["HANDOFF"]
+
+  [[rules.allowlists]]
+  description = "Hygiene tooling files legitimately reference HANDOFF.md to enforce ignore rules"
+  paths = ['''^\.gitignore$''', '''^scripts/committer$''', '''^\.husky/pre-commit$''']
 
 [[rules]]
 id = "internal-plan-dir"
@@ -67,12 +75,28 @@ regex = '''docs/(plans|proposals|spikes|channel-hunt|exec-plans)/'''
 tags = ["hygiene", "internal-plan"]
 keywords = ["docs/plans", "docs/proposals", "docs/spikes", "docs/channel-hunt", "docs/exec-plans"]
 
+  [[rules.allowlists]]
+  description = "Hygiene tooling files reference internal-plan dirs to enforce ignore rules"
+  paths = ['''^\.gitignore$''', '''^scripts/committer$''', '''^\.husky/pre-commit$''']
+
+  [[rules.allowlists]]
+  description = "Release notes / migration docs may mention paths in historical context (batch 3 will rewrite migration doc)"
+  paths = ['''^CHANGELOG\.md$''', '''docs/migration/.*\.md$''', '''docs/testing/TEST_PLAN\.md$''', '''docs/delivery-status\.md$''']
+
 [[rules]]
 id = "runtime-experience-jsonl"
 description = "Runtime experience JSONL files should never be tracked (patterns-jsonl)"
 regex = '''experience/patterns\.jsonl'''
 tags = ["hygiene", "runtime-experience"]
 keywords = ["patterns.jsonl"]
+
+  [[rules.allowlists]]
+  description = "Skill docs / __init__ legitimately explain the patterns.jsonl mechanism as a system feature"
+  paths = ['''autosearch/skills/.*/SKILL\.md$''', '''autosearch/skills/.*/__init__\.py$''', '''autosearch/skills/router/references/.*\.md$''']
+
+  [[rules.allowlists]]
+  description = "Release notes / migration / bench docs reference patterns.jsonl in product context"
+  paths = ['''^CHANGELOG\.md$''', '''docs/migration/.*\.md$''', '''docs/bench/.*\.md$''']
 
 # ── Allowlist ────────────────────────────────────────────────────────────────
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -44,6 +44,36 @@ regex = '''\b(Armory|AIMD|atoms|kalami2?|alaya[_\-]os)\b'''
 tags = ["pii", "internal-codename"]
 keywords = ["Armory", "AIMD", "atoms", "kalami", "alaya"]
 
+# ── Public-repo-hygiene rules (per public-repo-hygiene-plan F010) ────────────
+
+[[rules]]
+id = "dangerous-permission-flag"
+description = "Use of `dangerously-skip-permissions` (Claude Code permission bypass)"
+regex = '''dangerously-skip-permissions'''
+tags = ["hygiene", "internal-flag"]
+keywords = ["dangerously"]
+
+[[rules]]
+id = "handoff-file"
+description = "Reference to HANDOFF.md (internal session-handoff state)"
+regex = '''\bHANDOFF\.md\b'''
+tags = ["hygiene", "handoff"]
+keywords = ["HANDOFF"]
+
+[[rules]]
+id = "internal-plan-dir"
+description = "Reference to internal plan / proposal / spike / channel-hunt / exec-plan directory paths"
+regex = '''docs/(plans|proposals|spikes|channel-hunt|exec-plans)/'''
+tags = ["hygiene", "internal-plan"]
+keywords = ["docs/plans", "docs/proposals", "docs/spikes", "docs/channel-hunt", "docs/exec-plans"]
+
+[[rules]]
+id = "runtime-experience-jsonl"
+description = "Runtime experience JSONL files should never be tracked (patterns-jsonl)"
+regex = '''experience/patterns\.jsonl'''
+tags = ["hygiene", "runtime-experience"]
+keywords = ["patterns.jsonl"]
+
 # ── Allowlist ────────────────────────────────────────────────────────────────
 
 [allowlist]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -41,9 +41,32 @@ if [ -n "$SCAN_FILES" ]; then
   fi
 fi
 
-# Secret detection
+# Public-repo hygiene path check — refuse internal-only paths even getting staged
+# (defense in depth — committer also blocks these, but a hook covers raw `git commit` too)
+HYGIENE_PATHS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(HANDOFF\.md$|docs/(plans|proposals|spikes|channel-hunt|exec-plans)/|reports/|.*\.private\.md$|.*\.handoff\.md$)' || true)
+if [ -n "$HYGIENE_PATHS" ]; then
+  echo "error: public-repo-hygiene blocked these paths from being committed:"
+  echo "$HYGIENE_PATHS"
+  echo "fix: these belong locally only — see docs/exec-plans/active/autosearch-0425-public-repo-hygiene-plan.md"
+  exit 1
+fi
+
+# Public-repo hygiene content check — flag dangerous flags / unsafe shortcuts
+# (Markdown docs included — these strings should never appear in published docs)
+HYGIENE_CONTENT_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.gitleaks\.toml$|\.husky/|\.github/workflows/|docs/exec-plans/)' || true)
+if [ -n "$HYGIENE_CONTENT_FILES" ]; then
+  HYGIENE_MATCHES=$(echo "$HYGIENE_CONTENT_FILES" | while IFS= read -r f; do grep -nEH 'dangerously-skip-permissions' "$f" 2>/dev/null; done || true)
+  if [ -n "$HYGIENE_MATCHES" ]; then
+    echo "error: 'dangerously-skip-permissions' found in staged files:"
+    echo "$HYGIENE_MATCHES"
+    echo "fix: remove the flag — it is an internal Claude Code shortcut, not for public docs"
+    exit 1
+  fi
+fi
+
+# Secret detection — Markdown is now in scope (only specific test fixtures + .example excluded)
 SECRET_PATTERNS='(API_KEY|SECRET_KEY|PRIVATE_KEY|AUTH_TOKEN|PASSWORD)\s*=\s*["\x27][^\s"'\'']+|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AIzaSy[a-zA-Z0-9_-]{33}|sk-ant-[a-zA-Z0-9_-]{40,}|sk-or-[a-zA-Z0-9_-]{20,}|tvly-[a-zA-Z0-9_-]{20,}|github_pat_[a-zA-Z0-9_]{22,}|exa-[a-zA-Z0-9_-]{20,}'
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.example$|\.test\.py$|tests/fixtures/|\.md$)' || true)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.example$|\.test\.py$|tests/fixtures/)' || true)
 if [ -n "$STAGED_FILES" ]; then
   MATCHES=$(echo "$STAGED_FILES" | while IFS= read -r f; do grep -nEH "$SECRET_PATTERNS" "$f" 2>/dev/null; done || true)
   if [ -n "$MATCHES" ]; then

--- a/scripts/committer
+++ b/scripts/committer
@@ -43,6 +43,19 @@ for file in "${FILES[@]}"; do
   [[ "$file" == *__pycache__* ]]  && die "refusing to stage '$file' — __pycache__ blocked"
   [[ "$file" == *.pyc ]]          && die "refusing to stage '$file' — .pyc files blocked"
   [[ "$(basename "$file")" == .env* ]] && die "refusing to stage '$file' — .env files blocked"
+
+  # Public-repo-hygiene paths (per public-repo-hygiene-plan F009)
+  [[ "$file" == "HANDOFF.md" ]]        && die "refusing to stage '$file' — internal handoff state blocked"
+  [[ "$file" == docs/plans/* ]]        && die "refusing to stage '$file' — internal plans blocked"
+  [[ "$file" == docs/proposals/* ]]    && die "refusing to stage '$file' — internal proposals blocked"
+  [[ "$file" == docs/spikes/* ]]       && die "refusing to stage '$file' — spike write-ups blocked"
+  [[ "$file" == docs/channel-hunt/* ]] && die "refusing to stage '$file' — channel reconnaissance logs blocked"
+  [[ "$file" == docs/exec-plans/* ]]   && die "refusing to stage '$file' — internal exec plans blocked"
+  [[ "$file" == reports/* ]]           && die "refusing to stage '$file' — local report artifacts blocked"
+  [[ "$(basename "$file")" == ".DS_Store" ]]   && die "refusing to stage '$file' — macOS metadata blocked"
+  [[ "$(basename "$file")" == *.private.md ]]  && die "refusing to stage '$file' — explicitly private docs blocked"
+  [[ "$(basename "$file")" == *.handoff.md ]]  && die "refusing to stage '$file' — handoff drafts blocked"
+
   if [[ ! -e "$file" ]] && ! git ls-files --error-unmatch "$file" &>/dev/null; then
     die "file not found: $file"
   fi


### PR DESCRIPTION
## Summary

Public-repo-hygiene plan **batch 2A** — the tooling layer. Adds three layers of defense so internal content (plans, handoff state, runtime experience, dangerous flags) can never re-enter the public repo silently.

This is the **second of 4 batches**. Batch 1 = #396 (HEAD cleanup + gitignore). Batch 2B = `public_repo_hygiene.py` script + tests + workflow (next). Batch 3 = doc rewrites (CLAUDE.md split, validation/bench/skill internal voice). Batch 4 = history exposure assessment + total verify.

## What's in this PR (4 commits, +69/-2 lines)

| Commit | Plan ref | Action |
|---|---|---|
| `chore(committer): block internal-doc / handoff / runtime-artifact paths` | F009 S1 | `scripts/committer` denies `HANDOFF.md`, `docs/plans/*`, `docs/proposals/*`, `docs/spikes/*`, `docs/channel-hunt/*`, `docs/exec-plans/*`, `reports/*`, `.DS_Store`, `*.private.md`, `*.handoff.md` |
| `chore(husky): scan markdown for secrets + add hygiene path/flag checks` | F009 S2 + S3 | `.husky/pre-commit` no longer excludes `.md` from secret scan; adds new path-block + content-block (`dangerously-skip-permissions`) |
| `chore(gitleaks): add hygiene rules for dangerous flag / handoff / internal plans / runtime jsonl` | F010 S2 | `.gitleaks.toml` adds 4 hygiene rules: `dangerous-permission-flag`, `handoff-file`, `internal-plan-dir`, `runtime-experience-jsonl` |
| `chore(gitleaks): add per-rule allowlists for hygiene rules to avoid noise on legitimate references` | F010 S2 follow-up | Per-rule allowlists for `.gitignore` / `scripts/committer` / `.husky/pre-commit` / `SKILL.md` / `CHANGELOG.md` / `docs/migration/*.md` so legitimate references don't trigger noise |

## Why now

After batch 1 (#396) removed internal docs and runtime experience from HEAD, we need the **hooks** and **CI scanner** to enforce that they don't come back:

- `scripts/committer` is the explicit commit gate — adding deny rules here is fast and obvious to whoever runs commands.
- `.husky/pre-commit` is the safety net for raw `git commit` — extends the scan to Markdown (was previously excluded entirely; that's how internal voice and dangerous flags got into docs in the first place).
- `.gitleaks.toml` is the CI fail-loud signal — fires on PR / push so anything that does sneak through committer + husky still gets caught before merge.

## Test plan

- [x] `tests/unit/` (fast subset): **602 passed** in 8.18s — no regression.
- [x] `scripts/committer --dry-run "test" HANDOFF.md` → `error: refusing to stage 'HANDOFF.md' — internal handoff state blocked` ✓
- [x] `scripts/committer --dry-run "test" docs/plans/foo.md` → `error: refusing to stage 'docs/plans/foo.md' — internal plans blocked` ✓
- [x] All 4 commits in this PR went through the new `.husky/pre-commit` (the hook ran on each commit).
- [ ] CI green on this PR (gitleaks workflow + ci).
- [ ] Verify gitleaks doesn't false-positive on existing tracked files like `.gitignore`, `SKILL.md`, `CHANGELOG.md` (allowlists added in commit 4).

## Out of scope (deferred)

- **F010 S3** (split gitleaks workflow PR-tree vs full-history) and **F010 S4** (new `public-hygiene.yml` workflow) → batch 2B alongside the validate script.
- **F011** (`scripts/validate/public_repo_hygiene.py` + tests + `pyproject` / `package.json` entrypoints) → batch 2B.
- **F003 S2/S3** (CLAUDE.md public/private split + `internal-docs.md`) → batch 3.
- **F004 / F006 / F007** (rewrite of validation / bench / million-user / upgrade-report / delivery-status / roadmap / 5 SKILL.md internal-voice files) → batch 3.

## Stacking note

Independent of #396 — this PR touches only `scripts/committer`, `.husky/pre-commit`, `.gitleaks.toml`. Files don't overlap with batch 1. Both can merge in either order.

After batch 1 + 2A merge, gitleaks scan on main may surface a few legitimate-reference cases not covered by the per-rule allowlists. Those will be addressed as F006 cleanup in batch 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)