### PR TITLE
chore(public-repo): hygiene batch 2B — public_repo_hygiene.py + tests + npm/CI entrypoints

### DIFF
--- a/.github/workflows/public-hygiene.yml
+++ b/.github/workflows/public-hygiene.yml
@@ -1,0 +1,29 @@
+name: Public Repo Hygiene
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    name: hygiene paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Run path-level hygiene check
+        # `--paths-only` until batch 3 finishes rewriting docs that still
+        # carry internal voice. Once the doc rewrites land, drop the flag
+        # so content rules also gate.
+        run: python scripts/validate/public_repo_hygiene.py --paths-only

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "husky": "^9.1.7"
   },
   "scripts": {
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "public:hygiene": "python3 scripts/validate/public_repo_hygiene.py"
   }
 }

--- a/scripts/validate/public_repo_hygiene.py
+++ b/scripts/validate/public_repo_hygiene.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Verify public-repo hygiene invariants on git-tracked files.
+
+Per public-repo-hygiene-plan F011. Complements gitleaks (which scans
+content for secrets / codenames) by enforcing path-level rules:
+files that should never be tracked at all.
+
+Reports `path:line` and rule ID. Never prints the matched value.
+Exit 0 on clean, 1 on any violation.
+
+Usage:
+    python scripts/validate/public_repo_hygiene.py [--tracked] [--paths-only]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    description: str
+    pattern: re.Pattern[str]
+    allowlist_paths: tuple[re.Pattern[str], ...] = field(default_factory=tuple)
+
+
+# Files that must never be tracked. Matched against the file path.
+PATH_RULES: tuple[Rule, ...] = (
+    Rule(
+        id="tracked-handoff",
+        description="HANDOFF.md must not be tracked (internal session-handoff state)",
+        pattern=re.compile(r"^HANDOFF\.md$"),
+    ),
+    Rule(
+        id="tracked-internal-dir",
+        description="docs/{plans,proposals,spikes,channel-hunt,exec-plans}/ must not be tracked",
+        pattern=re.compile(r"^docs/(plans|proposals|spikes|channel-hunt|exec-plans)/"),
+    ),
+    Rule(
+        id="tracked-experience-jsonl",
+        description="experience/**/*.jsonl must not be tracked (live runtime patterns)",
+        pattern=re.compile(r"experience/.*\.jsonl$"),
+    ),
+    Rule(
+        id="tracked-private-md",
+        description="*.private.md and *.handoff.md must not be tracked",
+        pattern=re.compile(r"\.(private|handoff)\.md$"),
+    ),
+    Rule(
+        id="tracked-reports",
+        description="reports/ must not be tracked (E2B per-run artifacts)",
+        pattern=re.compile(r"^reports/"),
+    ),
+    Rule(
+        id="tracked-ds-store",
+        description=".DS_Store must not be tracked (macOS metadata)",
+        pattern=re.compile(r"(^|/)\.DS_Store$"),
+    ),
+)
+
+
+# Strings whose presence in tracked files indicates a hygiene leak.
+CONTENT_RULES: tuple[Rule, ...] = (
+    Rule(
+        id="dangerous-permission-flag",
+        description=(
+            "`dangerously-skip-permissions` must not appear in published files "
+            "(internal Claude Code shortcut, not for public docs)"
+        ),
+        pattern=re.compile(r"dangerously-skip-permissions"),
+        allowlist_paths=(
+            re.compile(r"^tests/.*\.(py|yaml|yml)$"),
+            re.compile(r"^\.gitleaks\.toml$"),
+            re.compile(r"^\.husky/"),
+            re.compile(r"^\.github/workflows/"),
+            re.compile(r"^scripts/validate/public_repo_hygiene\.py$"),
+        ),
+    ),
+)
+
+
+def list_tracked_files() -> list[str]:
+    """Return paths of every git-tracked file in the repo."""
+    out = subprocess.run(  # noqa: S603 — known git binary
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def check_path_rules(files: list[str]) -> list[tuple[str, int, str]]:
+    """Find tracked files that match any disallowed-path rule."""
+    return [
+        (path, 0, rule.id) for rule in PATH_RULES for path in files if rule.pattern.search(path)
+    ]
+
+
+def check_content_rules(files: list[str]) -> list[tuple[str, int, str]]:
+    """Find lines in tracked files that match any disallowed-content rule."""
+    violations: list[tuple[str, int, str]] = []
+    for path in files:
+        full = REPO_ROOT / path
+        if not full.is_file():
+            continue
+        try:
+            content = full.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for rule in CONTENT_RULES:
+            if any(p.match(path) for p in rule.allowlist_paths):
+                continue
+            for line_no, line in enumerate(content.splitlines(), start=1):
+                if rule.pattern.search(line):
+                    violations.append((path, line_no, rule.id))
+    return violations
+
+
+def report(violations: list[tuple[str, int, str]]) -> None:
+    rule_index = {r.id: r for r in (*PATH_RULES, *CONTENT_RULES)}
+    by_rule: dict[str, list[tuple[str, int]]] = {}
+    for path, line_no, rule_id in violations:
+        by_rule.setdefault(rule_id, []).append((path, line_no))
+
+    for rule_id in sorted(by_rule):
+        rule = rule_index[rule_id]
+        print(f"\n[{rule_id}] {rule.description}")
+        for path, line_no in by_rule[rule_id]:
+            print(f"  {path}:{line_no}" if line_no else f"  {path}")
+
+    file_count = len({v[0] for v in violations})
+    print(f"\n{len(violations)} violation(s) across {file_count} file(s).")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--tracked",
+        action="store_true",
+        help="Scan git-tracked files (default behavior; flag is for explicit clarity)",
+    )
+    parser.add_argument(
+        "--paths-only",
+        action="store_true",
+        help="Run only path-level rules; skip content scan",
+    )
+    args = parser.parse_args(argv)
+    _ = args.tracked  # tracked is the only mode for now
+
+    files = list_tracked_files()
+    violations = check_path_rules(files)
+    if not args.paths_only:
+        violations += check_content_rules(files)
+
+    if not violations:
+        print(f"OK: {len(files)} tracked files clean — no hygiene violations.")
+        return 0
+
+    report(violations)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_public_repo_hygiene.py
+++ b/tests/unit/test_public_repo_hygiene.py
@@ -1,0 +1,158 @@
+"""Tests for scripts/validate/public_repo_hygiene.py.
+
+Per public-repo-hygiene-plan F011 S2 — covers path rules, content rules,
+and allowlists. The script itself is imported via sys.path because
+`scripts/validate/` is not a Python package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "validate"))
+
+import public_repo_hygiene as hyg  # noqa: E402
+
+
+# ---------- Path rules ----------
+
+
+class TestPathRules:
+    def test_blocks_handoff_md(self) -> None:
+        violations = hyg.check_path_rules(["HANDOFF.md"])
+        assert violations == [("HANDOFF.md", 0, "tracked-handoff")]
+
+    def test_blocks_internal_plan_dirs(self) -> None:
+        files = [
+            "docs/plans/foo.md",
+            "docs/proposals/bar.md",
+            "docs/spikes/baz.md",
+            "docs/channel-hunt/qux.md",
+            "docs/exec-plans/zap.md",
+        ]
+        violations = hyg.check_path_rules(files)
+        assert len(violations) == 5
+        assert all(v[2] == "tracked-internal-dir" for v in violations)
+
+    def test_blocks_experience_jsonl(self) -> None:
+        violations = hyg.check_path_rules(["autosearch/skills/foo/experience/patterns.jsonl"])
+        assert violations == [
+            (
+                "autosearch/skills/foo/experience/patterns.jsonl",
+                0,
+                "tracked-experience-jsonl",
+            )
+        ]
+
+    def test_blocks_private_and_handoff_md(self) -> None:
+        violations = hyg.check_path_rules(["draft.private.md", "wip.handoff.md"])
+        ids = [v[2] for v in violations]
+        assert ids.count("tracked-private-md") == 2
+
+    def test_blocks_reports_dir(self) -> None:
+        violations = hyg.check_path_rules(["reports/run-1.txt"])
+        assert ("reports/run-1.txt", 0, "tracked-reports") in [
+            (v[0], v[1], v[2]) for v in violations
+        ]
+
+    def test_blocks_ds_store_at_root_and_subdir(self) -> None:
+        violations = hyg.check_path_rules([".DS_Store", "subdir/.DS_Store"])
+        ds_violations = [v for v in violations if v[2] == "tracked-ds-store"]
+        assert len(ds_violations) == 2
+
+    def test_clean_public_paths_pass(self) -> None:
+        files = [
+            "README.md",
+            "README.zh.md",
+            "autosearch/cli/main.py",
+            "tests/unit/test_foo.py",
+            "docs/install.md",
+            "docs/quickstart.mdx",
+            "scripts/install.sh",
+            ".gitignore",
+        ]
+        assert hyg.check_path_rules(files) == []
+
+
+# ---------- Content rules ----------
+
+
+class TestContentRules:
+    def test_detects_dangerous_flag(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        bad = tmp_path / "docs" / "forbidden.md"
+        bad.parent.mkdir(parents=True)
+        bad.write_text("Run with --dangerously-skip-permissions to skip.\n")
+        monkeypatch.setattr(hyg, "REPO_ROOT", tmp_path)
+        violations = hyg.check_content_rules(["docs/forbidden.md"])
+        assert len(violations) == 1
+        path, line_no, rule_id = violations[0]
+        assert path == "docs/forbidden.md"
+        assert line_no == 1
+        assert rule_id == "dangerous-permission-flag"
+
+    def test_allowlists_test_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        path = tmp_path / "tests" / "unit" / "test_foo.py"
+        path.parent.mkdir(parents=True)
+        path.write_text("# Negative test of --dangerously-skip-permissions usage\n")
+        monkeypatch.setattr(hyg, "REPO_ROOT", tmp_path)
+        assert hyg.check_content_rules(["tests/unit/test_foo.py"]) == []
+
+    def test_allowlists_workflow_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / ".github" / "workflows" / "hygiene.yml"
+        path.parent.mkdir(parents=True)
+        path.write_text("description: dangerously-skip-permissions check\n")
+        monkeypatch.setattr(hyg, "REPO_ROOT", tmp_path)
+        assert hyg.check_content_rules([".github/workflows/hygiene.yml"]) == []
+
+    def test_allowlists_husky_hook(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        path = tmp_path / ".husky" / "pre-commit"
+        path.parent.mkdir(parents=True)
+        path.write_text("grep dangerously-skip-permissions\n")
+        monkeypatch.setattr(hyg, "REPO_ROOT", tmp_path)
+        assert hyg.check_content_rules([".husky/pre-commit"]) == []
+
+    def test_allowlists_gitleaks_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / ".gitleaks.toml"
+        path.write_text("regex = '''dangerously-skip-permissions'''\n")
+        monkeypatch.setattr(hyg, "REPO_ROOT", tmp_path)
+        assert hyg.check_content_rules([".gitleaks.toml"]) == []
+
+    def test_clean_public_doc_passes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        path = tmp_path / "README.md"
+        path.write_text("# Hello\n\nNothing internal here.\n")
+        monkeypatch.setattr(hyg, "REPO_ROOT", tmp_path)
+        assert hyg.check_content_rules(["README.md"]) == []
+
+
+# ---------- CLI entrypoint ----------
+
+
+class TestEntrypoint:
+    def test_help_exits_cleanly(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            hyg.main(["--help"])
+        assert exc_info.value.code == 0
+
+    def test_paths_only_skips_content_rules(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stage one bad-content file (not on path-rule blocklist).
+        path = tmp_path / "docs" / "bad.md"
+        path.parent.mkdir(parents=True)
+        path.write_text("dangerously-skip-permissions\n")
+        monkeypatch.setattr(hyg, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(hyg, "list_tracked_files", lambda: ["docs/bad.md"])
+
+        # With --paths-only, the content violation is skipped → exit 0.
+        assert hyg.main(["--paths-only"]) == 0
+
+        # Without --paths-only, the content violation triggers exit 1.
+        assert hyg.main([]) == 1


### PR DESCRIPTION
## Summary

Public-repo-hygiene plan **batch 2B** — the verification layer. Adds a Python script that enforces path-level hygiene invariants on git-tracked files, with tests and CI wiring.

This is the **third of 4 batches**. Batch 1 = #396 (HEAD cleanup + gitignore). Batch 2A = #397 (committer/husky/gitleaks tooling). Batch 3 = doc rewrites. Batch 4 = history exposure assessment + total verify.

## What's in this PR (4 commits, 365 added lines)

| Commit | Plan ref | Action |
|---|---|---|
| `feat(scripts): add public_repo_hygiene.py for path-level hygiene verification` | F011 S1 | Pure-stdlib Python script. Path rules (HANDOFF.md / docs/{plans,proposals,spikes,channel-hunt,exec-plans}/ / experience/*.jsonl / *.private.md / *.handoff.md / reports/ / .DS_Store). Content rule for `dangerously-skip-permissions` with allowlists. `--tracked` (default) and `--paths-only` flags. Reports `path:line` and rule ID; never prints matched values. |
| `test(scripts): cover public_repo_hygiene path/content rules and allowlists` | F011 S2 | 15 unit tests covering each path rule, dangerous-flag detection, all 4 allowlist categories (tests/, .github/workflows/, .husky/, .gitleaks.toml), clean-content pass-through, `--help` and `--paths-only` modes. |
| `chore(npm): add public:hygiene script that runs the hygiene check` | F011 S4 | `npm run public:hygiene` invokes the Python script. Verified `npm run public:hygiene -- --help` produces clean output. |
| `ci: add public-hygiene workflow that runs path-level hygiene check on PRs and main` | F010 S4 | New `.github/workflows/public-hygiene.yml`. Runs on PRs + push to main. Uses `--paths-only` until batch 3 finishes — content rules become CI-blocking once doc rewrites land. |

## Why now

Batch 2A added committer / husky / gitleaks rules — those catch leaks **at commit time**. Batch 2B adds a **verification step** that runs in CI on every PR + push:

- Catches anything that bypasses the local hooks (e.g., commits made on a fork / cloud editor without husky).
- Provides a single command (`npm run public:hygiene`) that contributors can run before pushing.
- Has unit tests that codify the rules — if anyone "improves" the script and breaks an invariant, tests fail.

The script complements gitleaks, not duplicates it: gitleaks scans **content** for secrets / codenames; this script enforces **path-level** invariants ("HANDOFF.md must not be tracked at all") that gitleaks cannot express directly.

## Test plan

- [x] `tests/unit/test_public_repo_hygiene.py`: **15 passed** in 0.10s.
- [x] Full unit suite: **617 passed** in 7.45s (+15 from new tests, no regressions).
- [x] `npm run public:hygiene -- --help` → clean output.
- [x] `python scripts/validate/public_repo_hygiene.py --paths-only` on current main → 19 violations from files batch-1 (#396) removes; **post-merge of batch 1 → 0 violations** (script will pass CI then).
- [ ] CI green on this PR (the new workflow runs against this PR's tree, which doesn't include batch 1 changes — it will report the same 19 violations until batch 1 merges; after that, all path-level checks pass).

## CI behavior note

The new `Public Repo Hygiene` workflow will **fail on this PR's tree** because batch 1 (#396) hasn't merged yet — `docs/plans/`, `docs/proposals/`, `docs/spikes/`, `docs/channel-hunt/` are still tracked here. This is expected; the workflow exists to catch exactly this state. The PR itself does not regress hygiene; it adds the gate.

Recommended merge order: **#396 → #397 → #398**. After #396, the workflow turns green for #397 / #398.

## Out of scope (deferred)

- **F010 S3** (split `gitleaks.yml` PR-tree vs full-history scan) — separate workflow tweak, batch 2C.
- **F011 S3** (`pyproject.toml` console-script entry) — adding `autosearch-hygiene` requires turning `scripts/` into a Python package; not strictly necessary since the script runs via `python scripts/validate/...` today. Skipped to keep the PR scoped; can add later as `autosearch.tooling.hygiene:main` if needed.
- **F003 S2/S3** + **F004 / F006 / F007** + **F001** → batch 3 (doc rewrites; this is where the script's content rules become useful CI gates).
- **F012 / F013** → batch 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)