### PR TITLE
chore(public-repo): hygiene batch 2C — split gitleaks + public/private docs note

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,7 +10,27 @@ permissions:
   pull-requests: write
 
 jobs:
-  scan:
+  # Per public-repo-hygiene-plan F010 S3 — PR runs are scoped to the PR's
+  # own commits (gitleaks-action default behavior on `pull_request` events),
+  # so PR failures are about *this PR's* changes, not historical artifacts.
+  pr-diff-scan:
+    if: github.event_name == 'pull_request'
+    name: PR diff scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Per public-repo-hygiene-plan F010 S3 — pushes to main scan the new
+  # commits introduced by the push (gitleaks-action default on `push`).
+  # This separates "did this push add a leak" from "is the PR diff clean".
+  main-push-scan:
+    if: github.event_name == 'push'
+    name: Main push scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/docs/internal-docs.md
+++ b/docs/internal-docs.md
@@ -1,0 +1,75 @@
+# Internal Records and the Public Repository
+
+> What this is: a brief contributor-facing note explaining what kinds of
+> working files are deliberately kept **out** of the public repository,
+> and how that is enforced.
+
+## What stays public
+
+The public repository on GitHub holds material that is useful to anyone
+running, integrating, or contributing to AutoSearch:
+
+- Source code under `autosearch/` and `scripts/`
+- User documentation under `docs/` (install / channels / quickstart /
+  MCP-clients / migration / changelog / security)
+- Tests under `tests/`
+- Release artifacts (`CHANGELOG.md`, `pyproject.toml`, `package.json`,
+  release workflow)
+- Channel skill bundles under `autosearch/skills/`
+
+## What stays out of the public repository
+
+Some working files have value during development but no value as
+published reference material — they are kept in the contributor's local
+working tree (or in private knowledge bases) and never tracked in git:
+
+| Category | Where it lives locally | Why it is not published |
+|---|---|---|
+| Internal exec plans | `docs/exec-plans/` | Working drafts and status logs; readers without the surrounding context will be misled. |
+| Architectural drafts and pre-implementation proposals | `docs/plans/`, `docs/proposals/` | Pre-decision sketches; final results land in real docs once shipped. |
+| One-shot experiment write-ups | `docs/spikes/` | Transient harnesses whose conclusions are already encoded in product behavior. |
+| Channel reconnaissance logs | `docs/channel-hunt/` | Rate-limit heuristics and anti-bot notes that misrepresent stable product capability. |
+| Session handoff state | `HANDOFF.md` | Per-session continuity notes; not user-facing. |
+| Runtime experience JSONL | `experience/`, `**/patterns.jsonl` | Live query patterns accumulated during use; user-private by design. |
+| Per-run E2B reports | `reports/` | Local bench artifacts, transient. |
+| Drafts | `*.private.md`, `*.handoff.md` | Explicitly marked drafts; never publish-ready. |
+
+If a working file becomes publish-worthy, the right move is to
+**rewrite it** into a stable doc under `docs/` (or into a `SKILL.md` for
+channel-shaped content) — not to copy or rename the working file.
+
+## How it is enforced
+
+Three layers stop internal records from re-entering the public repository:
+
+1. **`.gitignore`** — every category above is ignored at the repo root.
+   New files in those paths are never tracked unless someone explicitly
+   bypasses the ignore rule.
+
+2. **`scripts/committer` + `.husky/pre-commit`** — local commit gates.
+   `committer` refuses to stage internal-doc paths; the `pre-commit`
+   hook rejects any commit whose staged paths or content match
+   hygiene rules (e.g., `dangerously-skip-permissions`, `HANDOFF.md`).
+
+3. **CI (`gitleaks` + `public-hygiene` workflows)** — server-side gates.
+   `gitleaks` scans for secrets and codenames on every PR and main
+   push. `public-hygiene` (see `.github/workflows/public-hygiene.yml`)
+   runs `scripts/validate/public_repo_hygiene.py` and fails the build
+   if any of the above categories appear in the tracked tree.
+
+If any of these gates fires unexpectedly on a legitimate file, the fix
+is to add an allowlist entry in the matching config — never to disable
+the rule itself.
+
+## Why this matters
+
+Internal-only material is useful, but in the public repository it costs
+more than it earns:
+
+- Stale plans look like roadmap and mislead users about what to expect.
+- Failed-experiment write-ups misrepresent stable product capability.
+- Channel reconnaissance notes can read as adversarial guidance.
+- Runtime patterns are user-private; tracking them violates that.
+
+The split keeps the public repository focused on what an external
+reader can actually consume, run, or build on.


### PR DESCRIPTION
## Summary

Public-repo-hygiene plan **batch 2C** — small follow-up to 2A/2B. Two commits:

| Commit | Plan ref | Action |
|---|---|---|
| `ci(gitleaks): split into PR-diff-scan and main-push-scan jobs` | F010 S3 | Splits the single `scan` job into two named jobs gated on `github.event_name`. Behavior unchanged (gitleaks-action already does the right thing per event), but intent is now explicit and PR failures are unambiguously about PR commits. |
| `docs: add internal-docs.md explaining public/private split + enforcement layers` | F003 S3 | New `docs/internal-docs.md` — contributor-facing doc that lists what stays out of the public repo and how the 3-layer enforcement works (`.gitignore` → committer/husky → CI). Pure structural doc; contains zero internal content itself. |

## Why now

After 2A (commit-time guards) and 2B (CI verifier + script), contributors need a single doc explaining **what** the rules are blocking and **why**. `docs/internal-docs.md` is that doc — short, public-friendly, no leakage of actual internal material.

The gitleaks split is structural cleanup on the workflow file: the original single job worked correctly (gitleaks-action defaults to PR-commit scan on `pull_request` and push-commit scan on `push`), but having two named jobs with `if:` guards makes the intent explicit and matches plan F010 S3's "PR scan vs history scan separated" wording.

## What's NOT in this PR

- **F011 S3** (`pyproject.toml` console-script entry for `autosearch-hygiene`) — skipped. Requires turning `scripts/` into a Python package; not strictly necessary since the script runs via `python scripts/validate/...` and `npm run public:hygiene`. Can revisit if a maintainer asks for it.
- **F003 S2** (rewrite `CLAUDE.md` as public contributor guide) — content rewrite, deferred to batch 3 alongside the other doc rewrites (F004 / F006 / F007).
- **F004 / F006 / F007 / F001 / F012 / F013** — batches 3 + 4.

## Test plan

- [x] `tests/unit/` (fast subset): **602 passed** in 7.26s — no regression.
- [x] `docs/internal-docs.md` created; `grep -n "public repository" docs/internal-docs.md` returns 6 hits.
- [ ] CI green on this PR (gitleaks workflow now runs `pr-diff-scan` job; should be equivalent to before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)