### PR TITLE
chore(public-repo): hygiene batch 3B — rewrite 5 user-facing docs to drop internal voice

### DIFF
--- a/docs/delivery-status.md
+++ b/docs/delivery-status.md
@@ -5,7 +5,7 @@ description: "Module-by-module status of the v2 rewrite"
 
 # v2 Delivery Status
 
-Snapshot of which modules from `plan v2.3 § 13.5` have landed. All shipped modules have unit or integration tests and a 1:1 source comment on each file.
+Snapshot of which v2 modules have landed. All shipped modules have unit or integration tests and a 1:1 source comment on each file.
 
 ## Pipeline (M0–M8)
 
@@ -49,7 +49,7 @@ Snapshot of which modules from `plan v2.3 § 13.5` have landed. All shipped modu
 
 Deferred — real adapters will land after the channel layer unpauses. `DemoChannel` ships today as a placeholder implementing the `Channel` Protocol so the pipeline runs end-to-end.
 
-Planned roadmap (plan § 5):
+Planned roadmap:
 
 - Overseas P0 (12–15): arxiv / DDGS / GitHub repos+issues / Reddit / HackerNews / StackOverflow / YouTube / ProductHunt / Semantic Scholar / HuggingFace / npm / PyPI
 - Chinese P0 (6): 小红书 / B 站 / 微信公众号 / 知乎 / 抖音 / 微博
@@ -57,9 +57,8 @@ Planned roadmap (plan § 5):
 
 ## Known Deferred Items
 
-- `autosearch init` dependency orchestrator (plan § 4.5) — channel-dep-heavy, deferred until channel layer unpauses
-- Per-source HTML cleaners for specific Chinese sites — deferred (channel layer owns the fetch path)
-- Plan v2.3 itself — spike 2 findings suggested the plan initially tested the wrong fetch paths (HTML direct scrape for zhihu/csdn/juejin where the plan always intended API + cookie per § 5 中文 P0). No structural plan revision needed; the spike retrospectively validated plan § 5's path choices.
+- `autosearch init` dependency orchestrator — channel-dep-heavy, deferred until channel layer unpauses.
+- Per-source HTML cleaners for specific Chinese sites — deferred (channel layer owns the fetch path).
 
 ## Test Coverage
 
@@ -71,6 +70,6 @@ Planned roadmap (plan § 5):
 
 ## Related Docs
 
-- Plan: `~/.claude/plans/autosearch-v2-dev.md` (v2.3)
-- Research mapping: `~/.claude/plans/research/module-map-*.md`
-- Spike results: `docs/spikes/`
+- Test pyramid: [`docs/testing/TEST_PLAN.md`](testing/TEST_PLAN.md)
+- Channel matrix: [`docs/channels.mdx`](channels.mdx)
+- Migration guide: [`docs/migration/legacy-research-to-tool-supplier.md`](migration/legacy-research-to-tool-supplier.md)

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -26,7 +26,7 @@ autosearch init
 
 </CodeGroup>
 
-`init` auto-detects your LLM providers and writes the MCP server config to `~/.claude/mcp.json` and `~/.cursor/mcp.json` automatically.
+`init` auto-detects your LLM providers and registers AutoSearch with your MCP-capable AI clients automatically. For Claude Code that uses `claude mcp add` (writing to `~/.claude.json`); for Cursor / Zed it writes to the per-client MCP config file.
 
 ## What you get
 

--- a/docs/local-nightly.md
+++ b/docs/local-nightly.md
@@ -5,7 +5,7 @@ description: "Schedule the F101 baseline regression on your own machine via macO
 
 # Local Nightly Runner
 
-`scripts/nightly-local.sh` drives the same F101 baseline regression that `.github/workflows/e2b-nightly.yml` runs, but locally — without uploading any keys to GitHub Actions secrets. It reads your LLM / E2B keys directly from `~/.config/ai-secrets.env`.
+`scripts/nightly-local.sh` drives the same F101 baseline regression that `.github/workflows/e2b-nightly.yml` runs, but locally — without uploading any keys to GitHub Actions secrets. It reads your LLM / E2B keys from a local secrets file (default `${XDG_CONFIG_HOME:-$HOME/.config}/autosearch/secrets.env`; override via the `AUTOSEARCH_SECRETS_FILE` env var).
 
 Use this when you want Gate 13 observation-period evidence (3 consecutive nightly greens) but don't want a GitHub Actions footprint.
 
@@ -21,8 +21,8 @@ Override defaults via env vars:
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `AUTOSEARCH_PARALLEL` | `15` | Sandbox pool size (cap is 15 per `~/.config/ai-secrets.env` quota) |
-| `AUTOSEARCH_SECRETS_FILE` | `~/.config/ai-secrets.env` | Where the orchestrator reads API keys |
+| `AUTOSEARCH_PARALLEL` | `15` | Sandbox pool size; cap depends on your E2B account tier |
+| `AUTOSEARCH_SECRETS_FILE` | `$XDG_CONFIG_HOME/autosearch/secrets.env` (typically `~/.config/autosearch/secrets.env`) | Where the orchestrator reads API keys |
 
 ## macOS launchd (daily schedule)
 
@@ -119,11 +119,11 @@ systemctl --user list-timers autosearch-nightly.timer
 
 | Concern | Local (launchd / systemd) | GitHub Actions (`e2b-nightly.yml`) |
 |---|---|---|
-| Secret sync | Reads `~/.config/ai-secrets.env` in place | Requires `gh secret set` for each key |
+| Secret sync | Reads your local secrets file in place | Requires `gh secret set` for each key |
 | Keeps running if your machine is off | No — scheduler fires only when the machine is on | Yes — runs on GitHub's runners |
 | Failure notification | stderr log file | Auto-opens a GitHub issue via `peter-evans/create-issue-from-file` |
-| Cost | Just E2B sandbox minutes + LLM calls | Same + GH Actions minutes (free within quota) |
-| Good fit | Solo maintainer, always-on workstation | Team, intermittent developer availability |
+| Cost | E2B sandbox minutes + LLM calls only | Same plus GitHub Actions minutes (free within the public-repo allotment) |
+| Good fit | Always-on workstation | Intermittent developer availability |
 
 They're not mutually exclusive — you can run both.
 
@@ -131,8 +131,8 @@ They're not mutually exclusive — you can run both.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `error: no orchestrator venv found` | `scripts/e2b/` venv never created and shared `~/.claude/scripts/e2b/.venv` is missing | `uv venv scripts/e2b/.venv --python 3.12 && uv pip install --python scripts/e2b/.venv/bin/python e2b e2b-code-interpreter rich pyyaml` |
-| `error: secrets file not readable` | `~/.config/ai-secrets.env` missing or wrong perms | Create the file with `chmod 600`; populate with `E2B_API_KEY=...`, `ANTHROPIC_API_KEY=...` lines |
+| `error: no orchestrator venv found` | `scripts/e2b/.venv` was never created | `uv venv scripts/e2b/.venv --python 3.12 && uv pip install --python scripts/e2b/.venv/bin/python e2b e2b-code-interpreter rich pyyaml` |
+| `error: secrets file not readable` | The secrets file referenced by `AUTOSEARCH_SECRETS_FILE` is missing or has wrong perms | Create the file with `chmod 600`; populate with lines like `E2B_API_KEY=...`, `ANTHROPIC_API_KEY=...` |
 | Script exits 2 with `error: no orchestrator venv found` when launchd fires | `PATH` inside launchd is minimal, so `uv` / `python` from `~/.local/bin` or `/opt/homebrew/bin` is out of reach | Keep the `EnvironmentVariables.PATH` stanza above; adjust for your own `uv` install location if needed |
 | No reports produced, no error | Scheduler fired while machine asleep | launchd uses `StartCalendarInterval`; wake-on-LAN or `caffeinate` around the hour if you suspend the machine at night |
 

--- a/docs/mcp-channels-playbook.md
+++ b/docs/mcp-channels-playbook.md
@@ -12,7 +12,7 @@
 
 1. **无 cookie 免费可用**：搜狗微信、open-websearch（4 引擎）、Paper Search MCP（21 学术源）、PullPush（Reddit 历史）、RSS 直读、Jina Reader（部分站）、以及 13 个官方 API。
 2. **硬骨头 8 个中付费打通 5 个**（TikHub）：小红书、微博、知乎、Twitter/X、抖音。剩 3 个（微博上游 flaky、Instagram/LinkedIn 参数未调通）本轮未完全解决。
-3. **最终架构**：AutoSearch 走 BYOK（用户自配 TikHub key），`requires: [env:TIKHUB_API_KEY]` 声明依赖，未来可无缝切换到 hosted proxy 做商业化。
+3. **最终架构**：AutoSearch 走 BYOK（用户自配 TikHub key），`requires: [env:TIKHUB_API_KEY]` 声明依赖。Base URL 从 env var 读，便于在不同环境之间切换。
 
 **成本锚点**：TikHub 实测平均 **$0.0036/请求**。1000 次研究级调用 ≈ $3.6/月。
 
@@ -141,7 +141,7 @@ Threads · TikHub Utilities · 其他
 
 ### 🚨 安全注意：Key 会在错误响应里被回显
 
-**TikHub 的 400 / 403 / 422 响应体会原样回显完整 `Authorization` header（含 Bearer token）**。接入必须：
+**TikHub 的 400 / 403 / 422 响应体会原样回显完整请求头（含认证信息）**。接入必须：
 
 ```python
 # BAD — 直接打印 response body 会泄露 key
@@ -218,11 +218,11 @@ tests/channels/zhihu/test_via_tikhub.py  # method 单测
 base_url = os.getenv("TIKHUB_BASE_URL", "https://api.tikhub.io")
 ```
 
-未来老板上 hosted proxy 做商业化时，用户只需改两个 env var，零代码改动：
+这样如果以后需要换上游（比如自托管代理或镜像），用户只需改两个 env var，零代码改动：
 
 ```bash
-export TIKHUB_BASE_URL=https://api.autosearch.com/tikhub
-export TIKHUB_API_KEY=<AutoSearch 平台发的 token>
+export TIKHUB_BASE_URL=https://your-proxy.example.com/tikhub
+export TIKHUB_API_KEY=<your-proxy-token>
 ```
 
 ### 待接入的 5 个 channel（按优先级）

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,112 +1,66 @@
 ---
-title: "v2 Post-Test-Plan Roadmap"
-description: "What's worth doing after TEST_PLAN waves land, with channel layer paused"
+title: "Roadmap"
+description: "What's shipped, what's planned, what's deferred"
 ---
 
-# v2 Roadmap — Post Test Plan
+# AutoSearch Roadmap
 
-> Owner: vimala. Status: draft, waiting approval.
-> Prior plans: `~/.claude/plans/autosearch-v2-dev.md` (v2.3), `docs/testing/TEST_PLAN.md` (waves 1-5 merged).
+## Shipped
 
-## 1. Ground state
+The v2 tool-supplier architecture is live. Stable surfaces today:
 
-After the test plan, `main` has:
+- **MCP server** (`autosearch-mcp` stdio): `list_skills`, `run_clarify`,
+  `run_channel`, `decompose-task`, `delegate-subtask`, `consolidate-research`,
+  `citation-export`, plus per-channel skill bundles.
+- **CLI** (`autosearch`): `init`, `doctor`, `mcp`, `mcp-check`, `configure`,
+  `login`. The CLI is the wrapper around the MCP tools — host AIs (Claude
+  Code, Cursor, Zed) drive the synthesis.
+- **Channels**: 40 sources spanning academic preprints, web search,
+  developer platforms, news, video, and Chinese social media. See
+  [`docs/channels.mdx`](channels.mdx).
+- **Distribution**: `pipx install autosearch`, `npx autosearch-ai`, and the
+  `curl ... | bash` install script. See [`docs/install.md`](install.md).
 
-- Pipeline M0–M8 + orchestrator wired to Cost + Session primitives
-- 4 user surfaces: CLI (`query / mcp / serve`), FastAPI `/search` SSE, OpenAI-compat `/v1/chat/completions`, MCP `autosearch-mcp` stdio, Claude Code `/autosearch` slash
-- 104 tests across 4 tiers (default / smoke / real_llm nightly / perf on-demand)
-- `DemoChannel` placeholder; real channel adapters deferred per boss
+Module-level status of the v2 pipeline lives in
+[`docs/delivery-status.md`](delivery-status.md). The legacy `research()`
+MCP tool is in deprecation; the migration guide is at
+[`docs/migration/legacy-research-to-tool-supplier.md`](migration/legacy-research-to-tool-supplier.md).
 
-What's missing to call v2 "real"? One blocker plus several polish items. This plan lists everything except the blocker (channel layer, paused).
+## Planned (next)
 
-## 2. Explicit exclusions
+- **Channel reliability**: typed failure status everywhere (no more
+  `failure-as-empty`), per-channel published_at metadata, citation
+  canonicalization. Most of this is already in `v2026.04.25.x`.
+- **Doctor / MCP health parity**: `autosearch doctor` and `mcp-check`
+  must show the same channel availability that `run_channel` actually
+  experiences at runtime.
+- **First-use smoke test**: a `pipx install` → first query → evidence
+  output flow that runs end-to-end without manual configuration.
 
-The items below are **not** on this roadmap:
+## Considered (waiting for signal)
 
-- **Channel layer adapters** (海外 P0 + 中文 P0) — paused by boss. Resumes separately when unpaused; plan § 5 + § 12 already detail scope.
-- **`autosearch init` channel-dep installer** (npm mcporter / xhs-cli / rdt-cli / cookie harvester / MCP service boot) — requires channel layer unpaused.
-- **Plan v2.3 revision** — delivery-status.md already documents actual shipped state; plan itself doesn't need editing (spike 2 confirmed plan § 5's API + cookie paths rather than refuting them).
-- **Mutation testing, CHANGELOG.md, CONTRIBUTING.md** — not worth doing until there's an external contributor base or a tagged release.
+- **Token-by-token streaming** for the OpenAI-compat endpoint. Today's
+  stream emits one role + one content chunk + `[DONE]`. True streaming
+  needs `ReportSynthesizer` to become an async generator. Deferred until
+  there's a real user workflow that requires it.
+- **Session store TTL / GC**. `SessionStore` rows accumulate
+  indefinitely. Will add `prune(older_than)` once disk usage is visibly
+  a problem.
+- **Public-endpoint rate limiting**. `/v1/chat/completions` and `/search`
+  have no throttle today. Matters only if AutoSearch is ever deployed as
+  a public-facing service rather than a personal MCP server.
 
-## 3. Ranked follow-ups
+## Out of scope
 
-> **Status (2026-04-18):** R1 ✅, R2 ✅ (workflow shipped; first `v*` tag still boss action), R3 ✅, R4 ✅, R5 ✅. R6–R8 remain deferred.
+- Mutation testing.
+- A `CONTRIBUTING.md` template — the existing `CLAUDE.md` covers
+  contributor rules until there's an external contributor base.
+- A "real-time research" mode — AutoSearch is a tool supplier, not an
+  agent runtime.
 
-### P0 — real bug, fast
+## Versioning
 
-**R1. Pipeline channel-error event emission** ✅ shipped — ~30 min
-  - **Gap**: `Pipeline._TrackingIterationController._search` swallows `Channel.search()` exceptions via `try/except` + `structlog` log only. No `on_event({type:"error"})` emitted. Downstream consumers (CLI `--stream`, SSE `/search`, real users) see nothing when a channel breaks.
-  - **Discovery**: W3 `test_pipeline_channel_error.py` had to downgrade its assertion to match current swallow-and-log behavior.
-  - **Fix**: emit a structured error event from the catch block with `{channel: name, phase: "search", message: str(exc)}`. Keep the swallow (don't crash the pipeline) but surface visibility. Upgrade W3 test to assert the event is emitted.
-  - **Why P0**: it's a real correctness gap our own test plan found; leaving it means our "error handling" claim is a lie.
-
-### P1 — make `pipx install autosearch` actually usable
-
-**R2. First v2 alpha release** 🟡 workflow shipped, tag pending boss action — ~1 h
-  - `pyproject.toml` already has `version = "0.0.1a1"` but there's no git tag, no GitHub Release, no PyPI artifact.
-  - Deliver: `.github/workflows/release.yml` that triggers on `v*` tag → `python -m build` → `twine upload` to PyPI + creates GitHub Release with notes derived from commits since last tag.
-  - Boss action: push a `v0.0.1a1` tag once the workflow lands.
-  - **Why P1**: README's Quick Start says `pipx install autosearch`. Until this ships, that's a dead promise.
-
-**R3. `autosearch init` minimal version (channel-agnostic parts only)** ✅ shipped — ~half day
-  - Scope (excludes channel-dep installers):
-    - Detect Python 3.12+ (error with message if older)
-    - Probe each LLM provider: check env var set OR `claude` binary on PATH; print a summary table of which providers are available
-    - Create `~/.autosearch/config.yaml` with detected defaults (provider priority, log level, optional DB path for `SessionStore`)
-    - Print next-step hint: "Run `autosearch query "your question"` to test"
-  - Explicitly NOT in scope for this slice:
-    - `npm install -g mcporter xhs-cli rdt-cli`
-    - `pip install douyin-mcp-server mcp-server-weibo`
-    - `rookiepy` cookie extraction
-    - Booting any MCP service
-  - **Why P1**: closes the `pipx install` → first-query loop. Channel-dep install gets added on top later when channel layer unpauses.
-
-### P2 — polish / completeness
-
-**R4. OpenAI-compat metadata (visitedURLs / reasoning_content)** ✅ shipped — ~1-2 h
-  - node-deepresearch `src/app.ts:L387-L824` exposes `visitedURLs`, `readURLs`, `reasoning_content` (Claude-style) in the response. Our simplified port dropped them.
-  - Fill them from `PipelineResult` (evidences → URLs; pipeline's `on_event` gap reflection → `reasoning_content` block).
-  - Keep backwards-compatible — new fields optional in response schema.
-
-**R5. LLMClient provider fallback chain** ✅ shipped — ~1 d
-  - Today: `LLMClient` auto-detects the first available provider at init and sticks with it. If that provider's API is down mid-call, no recovery.
-  - Add: ordered provider preference (config-driven), per-call fallback when primary raises `httpx.HTTPError` or times out, surface `fallback_count` in metrics.
-  - Add cost-tracker notes when fallback used (different model → different token cost).
-
-### P3 — nice-to-haves, defer
-
-**R6. Real token-by-token streaming** — ~1-2 d (architectural)
-  - Current `/v1/chat/completions` stream emits one role chunk + one content chunk + `[DONE]`. Spec-valid.
-  - True streaming needs `ReportSynthesizer.synthesize` to become an async generator yielding section chunks, and `Pipeline.run` to thread that through. Non-trivial refactor.
-  - Defer until there's a user signal that chunked stream matters for real workflows.
-
-**R7. Session store garbage collection / TTL** — ~2-3 h
-  - `SessionStore` rows accumulate indefinitely. Add a `prune(older_than: timedelta)` method + optional background task.
-  - Defer until disk usage is a visible problem.
-
-**R8. Public-endpoint rate limiting** — ~2-3 h
-  - `/v1/chat/completions` + `/search` currently have no throttle. Fine for personal / localhost use. Matters if ever deployed publicly.
-  - Defer; not a v0.1-alpha concern.
-
-## 4. Proposed wave order
-
-| Wave | Items | Cost | Gate | Status |
-|---|---|---|---|---|
-| **R1** | Pipeline error-event emission + test upgrade | ~30 min | single PR | ✅ merged |
-| **R2** | Release workflow + first alpha tag | ~1 h | single PR + boss pushes tag | 🟡 workflow merged, tag pending |
-| **R3** | `autosearch init` minimal | ~half day | single PR (one Codex wave) | ✅ merged |
-| **R4** | OpenAI-compat metadata | ~1-2 h | single PR (small Codex wave) | ✅ merged |
-| **R5** | LLMClient fallback chain | ~1 day | single PR (one Codex wave + new tests) | ✅ merged |
-| **R6–R8** | deferred until signal | — | — | defer |
-
-R1–R5 have all landed on main. Remaining gating action: boss pushes a `v0.0.1a1` tag to trigger the release workflow. R6/R7/R8 continue to wait for a user signal.
-
-## 5. When channel layer unpauses
-
-At that point this roadmap interleaves with plan § 5 / § 12 (real channel impls) + `autosearch init` channel-dep layer. R3's minimal init gets extended, not rewritten.
-
-## 6. Decision needed
-
-- Confirm R1 → R2 → R3 sequencing
-- Confirm R4/R5 as "land opportunistically" (no strict order)
-- Confirm R6/R7/R8 stay deferred
+CalVer (`YYYY.MM.DD.N`) — daily release sequence. The release workflow
+publishes both PyPI and npm artifacts. Source-of-truth version lives in
+`pyproject.toml`; `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
+and `npm/package.json` are kept in sync by `scripts/bump-version.sh`.


### PR DESCRIPTION
## Summary

Public-repo-hygiene plan **batch 3B** — content rewrites round 2 (F006). 5 commits, one per doc:

| Commit | Plan ref | Action |
|---|---|---|
| `docs(delivery-status): drop internal plan paths + stale section refs` | F006 S1 | Removes `~/.claude/plans/...` references; trims "Related Docs" to live links (test plan / channels / migration); drops "plan v2.3 § 13.5" / "spike 2 findings" internal-narrative bits. |
| `docs(roadmap): rewrite as public-facing roadmap (drop internal narrative)` | F006 S2 | Full rewrite — 113 lines → 63 lines. Drops "Owner: vimala", "boss action", "paused by boss", `v0.0.1a1`, `~/.claude/plans/`. New structure: Shipped / Planned / Considered / Out of scope / Versioning. |
| `docs(introduction): correct Claude Code MCP config path` | F006 S3 | `~/.claude/mcp.json` → `~/.claude.json` (matches what `claude mcp add` actually writes today). |
| `docs(local-nightly): drop maintainer-specific paths and quota wording` | F006 S4 | Replaces hardcoded `~/.config/ai-secrets.env` with `${XDG_CONFIG_HOME:-~/.config}/autosearch/secrets.env` + `AUTOSEARCH_SECRETS_FILE` override. Drops `~/.claude/scripts/e2b/.venv` reference (was incorrect anyway). Reframes "Solo maintainer" → generic. |
| `docs(mcp-channels-playbook): scrub commercial-strategy / hosted-proxy / boss references` | F006 S5 | Drops "未来老板上 hosted proxy 做商业化" wording. Reframes proxy URL as generic env-var override. Removes literal "Authorization: Bearer token" mention from the security note (kept the security warning — just no longer name the header). |

## Why each change

These five docs are publishable in spirit (real install / config / channel info) but were carrying maintainer-private context: internal plan paths, named approval gates ("boss action"), unannounced commercial-strategy hints (hosted proxy / 商业化), and PII-flavored references (`~/.config/ai-secrets.env`). Removing those does not reduce information for the public reader — it removes information they had no business reading.

## Test plan

- [x] `tests/unit/` (fast subset): **602 passed** in 7.57s — no regression.
- [x] `grep -nE "老板|boss|/Users/|~/.claude|paused by|v0\.0\.1a1" docs/{delivery-status,roadmap,introduction.mdx,local-nightly,mcp-channels-playbook}.md` (where applicable) → no matches per F006 S1–S5 verify commands.
- [ ] CI green on this PR.
- [ ] Render preview of `docs/roadmap.md` and `docs/introduction.mdx` (Mintlify) — content rewrites should still render correctly.

## Out of scope (deferred)

- **F007** — internal voice in 5 SKILL.md / router-group files (`autosearch/skills/meta/experience-compact/SKILL.md`, `autosearch/skills/meta/model-routing/SKILL.md`, `autosearch/skills/router/references/groups/{channels-chinese-ugc,workflow-quality,workflow-synthesis}.md`) plus the 2 fetch-playwright / mcporter MCP-config-path docs.
- **F001** — write `docs/public-repo-policy.md` and update README docs entrypoints.
- **F012 / F013** — history exposure assessment + final verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)