### PR TITLE
chore(public-repo): hygiene batch 3C — drop 'boss' wording from skill READMEs + add public-repo-policy.md

### DIFF
--- a/autosearch/skills/meta/experience-compact/SKILL.md
+++ b/autosearch/skills/meta/experience-compact/SKILL.md
@@ -86,7 +86,7 @@ Archives are permanent — never delete. They serve as the lineage trail for AVO
 This skill **writes** `experience.md`. That's the promotion layer. It does **not**:
 
 - Modify the skill's `SKILL.md` body (that's `auto-evolve`'s domain, which must commit via `scripts/committer` and be reversible via `git revert`).
-- Modify `judge.py` or `PROTOCOL.md` (boss rule, hard constraint).
+- Modify `judge.py` or `PROTOCOL.md` (project-level fixed contracts; AVO must not change its own evaluation function).
 - Delete or rewrite `patterns.jsonl` (append-only; only rotation is allowed).
 
 ## Invocation Pattern

--- a/autosearch/skills/meta/model-routing/SKILL.md
+++ b/autosearch/skills/meta/model-routing/SKILL.md
@@ -14,7 +14,7 @@ experience_digest: experience.md
 
 # Model Tier Routing — Advisory
 
-**Principle (boss's words)**: "Most steps use the runtime's cheapest model; only the critical 1-2 steps use the best model."
+**Routing principle**: most steps use the runtime's cheapest model; only the critical 1–2 steps use the best model.
 
 Autosearch stamps every leaf skill with a `model_tier` suggestion. This skill tells the runtime AI what the three tiers mean, which skills default to which tier, and when to escalate or de-escalate.
 

--- a/autosearch/skills/router/references/groups/channels-chinese-ugc.md
+++ b/autosearch/skills/router/references/groups/channels-chinese-ugc.md
@@ -29,6 +29,6 @@ Opinions, experiences, product reviews, and discussions from Chinese social plat
 
 ## Routing notes
 
-- Chinese-language tasks should keep **at least 2 channels from this group**, regardless of historical yield (boss rule).
+- Chinese-language tasks should keep **at least 2 channels from this group**, regardless of historical yield. Native-language coverage is a non-negotiable contract for Chinese tasks; routing must not shrink it on win-rate alone.
 - For hard anti-bot platforms (Xiaohongshu / Douyin / Zhihu), TikHub is the paid fallback; `mcporter` gives the free alternative if user has no TikHub key.
 - Podcast-style queries should also check `channels-video-audio` for `search-xiaoyuzhou` + transcription skills.

--- a/autosearch/skills/router/references/groups/workflow-quality.md
+++ b/autosearch/skills/router/references/groups/workflow-quality.md
@@ -29,4 +29,4 @@ After channels return results: normalize, dedupe, rerank by relevance, score, an
 - `normalize-results` → `extract-dates` → `rerank-evidence` is the standard pipeline order after raw channel output.
 - `anti-cheat` should run before any scoring that affects routing, to prevent self-reinforcing bias.
 - Rubrics (`generate-rubrics` + `check-rubrics`) are optional — use only when task has clear must-have criteria, not for every session.
-- Do not invent N-dim × 0/3/5 rubrics — boss feedback. Use pairwise A/B preference for judgment; rubrics only for binary must-have checks.
+- Do not invent N-dimensional × 0/3/5 numeric rubrics. Use pairwise A/B preference for judgment; rubrics only for binary must-have checks.

--- a/autosearch/skills/router/references/groups/workflow-synthesis.md
+++ b/autosearch/skills/router/references/groups/workflow-synthesis.md
@@ -26,5 +26,5 @@ Turn evidence into knowledge and a delivered report. Highest-value, highest-tier
 ## Routing notes
 
 - Autosearch v2 **does not own the final LLM synthesis pass** — the runtime AI synthesizes using the transcripts, snippets, and structured context autosearch provides. These skills exist to prepare material, not replace Claude's judgment.
-- `synthesize-knowledge` and `evaluate-delivery` are the Best-tier "key 1-2 steps" the boss called out — they shape the whole deliverable, so use the best model.
+- `synthesize-knowledge` and `evaluate-delivery` are the Best-tier "key 1–2 steps" — they shape the whole deliverable, so they should use the best model available.
 - `knowledge-map` is the cross-session memory layer — load before a session to see what's already known on the topic, save at session end.

--- a/autosearch/skills/tools/fetch-playwright/SKILL.md
+++ b/autosearch/skills/tools/fetch-playwright/SKILL.md
@@ -24,7 +24,7 @@ This skill is **documentation-only**. The runtime AI calls `playwright-mcp` tool
 
 ## Install
 
-Add to your MCP client config (Claude Code: `~/.claude/settings.json` or project `.mcp.json`; Cursor: `~/.cursor/mcp.json`; Zed: project `.zed/mcp.json`):
+Register with your MCP client. For Claude Code, prefer `claude mcp add` (writes to `~/.claude.json`); for project-scoped config use `<project>/.mcp.json`. Cursor reads `~/.cursor/mcp.json`; Zed reads `<project>/.zed/mcp.json`. Schema for any of them:
 
 ```json
 {

--- a/autosearch/skills/tools/mcporter/SKILL.md
+++ b/autosearch/skills/tools/mcporter/SKILL.md
@@ -24,7 +24,7 @@ This skill is **documentation-only**. The runtime AI invokes MCP tools directly 
 
 ## Install
 
-Add to your MCP client config (Claude Code `~/.claude/settings.json` or project `.mcp.json`; Cursor `~/.cursor/mcp.json`; Zed project `.zed/mcp.json`):
+Register with your MCP client. For Claude Code, prefer `claude mcp add` (writes to `~/.claude.json`); for project-scoped config use `<project>/.mcp.json`. Cursor reads `~/.cursor/mcp.json`; Zed reads `<project>/.zed/mcp.json`. Schema for any of them:
 
 ```json
 {

--- a/docs/public-repo-policy.md
+++ b/docs/public-repo-policy.md
@@ -1,0 +1,98 @@
+# Public Repository Policy
+
+> Authoritative list of what may be committed to this repository, what must
+> never be committed, and how to handle content that is publishable only
+> after redaction. The detailed enforcement layers (gitignore, commit
+> hooks, CI workflows) live in [`docs/internal-docs.md`](internal-docs.md);
+> this page states the *rules* those layers enforce.
+
+## Rule 1 — Always public
+
+Commit freely:
+
+- Source code under `autosearch/` and `scripts/` (excluding subpaths
+  marked private in `.gitignore`).
+- Tests under `tests/`.
+- Public documentation under `docs/` (install / channels / quickstart /
+  introduction / migration / changelog / mcp-clients / security /
+  internal-docs / public-repo-policy / testing / roadmap /
+  delivery-status / mcp-channels-playbook / local-nightly).
+- Top-level project files (`README.md`, `README.zh.md`, `LICENSE`,
+  `SECURITY.md`, `CHANGELOG.md`, `pyproject.toml`, `package.json`,
+  `commitlint.config.cjs`, `.gitignore`, `.gitleaks.toml`).
+- CI workflows under `.github/workflows/` and hooks under `.husky/`.
+- Channel skill bundles under `autosearch/skills/`.
+
+## Rule 2 — Never commit
+
+**Never commit** any of the following to this repository, regardless of
+intent:
+
+- Real secrets, API keys, tokens, cookies, or session credentials.
+  Treat anything that looks like a credential as a credential.
+- Internal exec plans (`docs/exec-plans/`), architectural drafts
+  (`docs/plans/`), proposals (`docs/proposals/`), spike write-ups
+  (`docs/spikes/`), or channel reconnaissance logs
+  (`docs/channel-hunt/`).
+- Session handoff state (`HANDOFF.md`) or any `*.handoff.md` /
+  `*.private.md` draft.
+- Runtime experience JSONL files (`experience/`, `**/patterns.jsonl`).
+- Per-run reports, benchmarks, or logs (`reports/`).
+- macOS metadata (`.DS_Store`).
+- Maintainer-private file paths in any committed content
+  (e.g. `~/.claude/...` paths that name a single contributor's setup,
+  `~/.config/ai-secrets.env`).
+- Internal-project codenames belonging to other private projects.
+- Personal home-directory paths matching `/Users/<name>` or
+  `/home/<name>` outside of clearly placeholder values.
+- Internal-voice references like "boss" / "老板" / "未来老板" or other
+  approval-flow language naming a specific maintainer.
+- The `dangerously-skip-permissions` flag in any user-facing
+  documentation. (It exists in test fixtures only.)
+
+These rules are enforced by `.gitignore`, `scripts/committer`,
+`.husky/pre-commit`, `.gitleaks.toml`, and the
+`.github/workflows/public-hygiene.yml` and gitleaks workflows. If any
+gate fires on a legitimate file, add a per-rule allowlist; do not
+disable the rule itself.
+
+## Rule 3 — Publishable only after redaction
+
+Some content is publishable in summary form but **must be redacted**
+first:
+
+- Validation / benchmark / E2E test reports — strip any maintainer
+  paths, secrets references, internal failure narratives, and
+  contributor-private setup details. Publish only summary metrics and
+  reproducible test recipes (typically as a docs page, not a raw run
+  log).
+- Experiment write-ups — keep the *finding* (what worked, what didn't,
+  why), drop bypass/workaround details that read as adversarial
+  guidance against third-party platforms, and drop dated rate-limit
+  heuristics that misrepresent stable product capability.
+- Migration guides — if they previously linked to internal proposal
+  docs, the proposals' factual content must be rewritten inline
+  (citing only public sources), and the internal links must be
+  removed.
+
+When in doubt, ask: would an external reader find this useful and
+representative of stable product behavior? If no on either count, do
+not publish.
+
+## Rule 4 — When something slips through
+
+If an internal-only artifact does land in `main`:
+
+1. Open a hygiene PR that removes the file from HEAD and confirms the
+   gate that should have caught it. If the gate has a gap, add the
+   missing rule (`scripts/committer` deny path, `.gitleaks.toml`
+   pattern, or `scripts/validate/public_repo_hygiene.py` rule).
+2. Decide whether history rewrite is required. The bar is real
+   secrets, real PII, or regulated data — internal narrative alone
+   does not justify the disruption of a `git filter-repo`.
+3. Document the incident under "Lessons Learned" in `CLAUDE.md` so the
+   gate addition is preserved across rewrites.
+
+The triage matrix lives in
+`docs/security/history-exposure-assessment.md` (added in a later
+hygiene pass).


### PR DESCRIPTION
## Summary

Public-repo-hygiene plan **batch 3C** — content rewrites round 3 (F007 + F001). 5 commits:

| Commit | Plan ref | Action |
|---|---|---|
| `docs(skills): drop 'boss rule' wording from experience-compact` | F007 S1 | "boss rule, hard constraint" → "project-level fixed contracts; AVO must not change its own evaluation function" |
| `docs(skills): rephrase model-routing principle as neutral routing rule` | F007 S2 | "Principle (boss's words)" → "Routing principle" |
| `docs(router-groups): rephrase 3 group READMEs to drop 'boss' wording` | F007 S3 + S4 + S5 | channels-chinese-ugc / workflow-quality / workflow-synthesis — convert "(boss rule)" / "boss feedback" / "boss called out" into neutral product rationale. |
| `docs(skills): align fetch-playwright + mcporter MCP config paths with mcp-clients.md` | F007 S6 + S7 | Replace `~/.claude/settings.json` (outdated) with the canonical `claude mcp add` flow → `~/.claude.json`, matching what `docs/mcp-clients.md` already documents. |
| `docs(public-repo-policy): add canonical public/private/redaction rules document` | F001 S1 | New `docs/public-repo-policy.md` — 4 rules (Always public / Never commit / Publishable after redaction / When something slips through). Companion to `docs/internal-docs.md` from batch 2C; this one states the rules, that one explains the enforcement. |

## Why now

After 2A (commit-time guards), 2B (CI hygiene script), 2C (gitleaks split + internal-docs explainer), 3A (CLAUDE.md cleanup + delete stale internal docs), 3B (rewrite 5 user-facing docs), the only remaining "internal voice" surface is the `autosearch/skills/` tree — `boss` references inside skill READMEs that runtime AIs read at runtime and that ship as part of the package. Cleaning them up is the last piece of F007.

`docs/public-repo-policy.md` (F001 S1) makes the rules explicit so contributors and AI agents can cite them. `README.md` / `README.zh.md` were already clean of internal-doc references (F001 S2 / S3 verify pre-passed) so no README changes were needed.

## What's left after this batch

- **F012**: history-exposure assessment doc (`docs/security/history-exposure-assessment.md`).
- **F013**: total verify run — git-grep sweep for residual leaks across the published tree, all hygiene gates green.
- Optional: `docs/install.md` Docker / offline / corporate-proxy sections; `pyproject.toml` console-script entry for `autosearch-hygiene`.

## Test plan

- [x] `tests/unit/` (fast subset): **602 passed** in 7.72s.
- [x] `grep -nE "老板|boss" autosearch/skills/{meta/{experience-compact,model-routing}/SKILL.md,router/references/groups/{channels-chinese-ugc,workflow-quality,workflow-synthesis}.md}` → no matches (F007 S1–S5 verifies pass).
- [x] `test -f docs/public-repo-policy.md && grep -n "Never commit" docs/public-repo-policy.md` → file exists with the required rule heading (F001 S1 verify passes).
- [x] `grep -nE "docs/(plans|proposals|exec-plans)|HANDOFF|CLAUDE" README.md README.zh.md` → no matches (F001 S2 / S3 verifies pass on existing files).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)