### PR TITLE
chore(public-repo): hygiene batch 4 — history-exposure assessment + verification procedure

### DIFF
--- a/docs/security/history-exposure-assessment.md
+++ b/docs/security/history-exposure-assessment.md
@@ -1,0 +1,112 @@
+# History Exposure Assessment
+
+> Last assessed: 2026-04-25 (end of public-repo-hygiene plan execution).
+> Reassessment cadence: whenever a hygiene gate fires on `main`, or when
+> any new evidence of PII / secret leakage surfaces.
+
+## Purpose
+
+Public git history of this repository is permanent unless rewritten with
+`git filter-repo` (or equivalent) and force-pushed. History rewrite is
+disruptive — it breaks every clone, fork, open PR, and tag reference.
+This document classifies *what* leaked into history, *how severe* each
+leak is, and *whether* a history rewrite is justified.
+
+## Severity tiers
+
+- **P0** — real secret / credential / PII / regulated data in any commit
+  that has been pushed to a public branch. Always justifies a history
+  rewrite **after** the credential has been rotated.
+- **P1** — unredacted personal contributor identity (real name,
+  non-public email, internal hostname) in commit metadata or file
+  content. History rewrite is the right answer if the metadata is
+  stable; rotate the affected accounts first.
+- **P2** — internal-only narrative content (process notes, architectural
+  drafts, plan numbering, internal codenames, "boss" voice, etc.) with
+  no real-world security cost. HEAD removal is sufficient; history
+  rewrite is **not** justified by the disruption-to-readers tradeoff.
+
+Anything that does not fit P0/P1/P2 is **not a leak** — close the
+finding without action.
+
+## Current assessment
+
+As of 2026-04-25, after running the hygiene plan (batches 1–3) and
+this assessment exercise:
+
+| Tier | Finding | Action taken |
+|---|---|---|
+| **P0** | None found. Repo-wide grep for the standard credential patterns (`sk-...{20,}`, `sk-ant-...{20,}`, `ghp_...{36}`, `AIzaSy...{33}`, `Bearer ...{20,}`, etc.) returns only test placeholders and clearly-fake example values. **No real secret has been confirmed in tracked content.** | None required. Continue running gitleaks on every PR + push. |
+| **P1** | A prior incident leaked a contributor's real name and a non-public hostname into ~56 commits in 2026-04-04. That history was rewritten at the time and the affected accounts were rotated. The lesson became a hard pre-commit gate (author email must be the noreply address; author name must be the public pseudonym; `.gitleaks.toml` patterns reject literal hostname strings). | Closed in 2026-04-04. The pre-commit hook and gitleaks rule prevent recurrence. |
+| **P2** | Internal exec plans, architectural drafts, channel reconnaissance logs, session handoff state, "boss" voice in skill READMEs, and dated validation / bench reports were all present in HEAD as of 2026-04-25. None contained real secrets — the cost was misleading public readers, not credential exposure. | Removed from HEAD across hygiene-plan batches 1–3. Enforcement layers (`.gitignore`, `scripts/committer`, `.husky/pre-commit`, `.gitleaks.toml`, `public_repo_hygiene.py`, `.github/workflows/public-hygiene.yml`) prevent reentry. **No history rewrite performed for this tier.** |
+
+## Why no history rewrite for the P2 tier
+
+Three reasons:
+
+1. **No real secret was leaked.** The content is internal narrative —
+   plans, proposals, postmortems. Reading old commits exposes process,
+   not credentials. There is no rotation work that an attacker could
+   skip by reading history.
+2. **History rewrite has high collateral cost.** Every fork, clone,
+   open PR, and tag reference breaks. CI workflows that pin SHAs
+   become invalid. External contributors are left with "your branch
+   has diverged" errors and no clean recovery. For P2 content this
+   cost dominates.
+3. **HEAD removal is the correct floor.** External readers land on
+   `main` first; the GitHub UI surfaces the current tree. Old commits
+   are visible but require deliberate spelunking. The disclosure
+   surface that matters is HEAD, and HEAD is now clean.
+
+## When a history rewrite **is** justified
+
+History rewrite is the right call when **any** of the following is true:
+
+1. A real secret has been confirmed in any pushed commit. Rotate the
+   credential first, then rewrite.
+2. Personally identifying information (legal name, real email,
+   private hostname) of a contributor or any user has been
+   committed and is not retractable through normal means.
+3. Regulated data (PHI, PII subject to GDPR / HIPAA / similar) has
+   entered any commit, regardless of whether it is currently in HEAD.
+4. A contributor or external party with legal standing requests
+   removal of their content under a takedown policy and the request
+   meets the project's stated policy.
+
+If none of these apply, **do not** run `git filter-repo` and **do not**
+force-push to `main`. Open a follow-up hygiene plan instead.
+
+## Procedure if a P0 / P1 finding surfaces later
+
+1. **Rotate first, rewrite second.** Whatever credential / identity is
+   exposed must be invalidated upstream before history is touched.
+2. **Snapshot.** Tag the current `main` HEAD with a dated tag
+   (`pre-rewrite-YYYY-MM-DD`) and push it to a private mirror.
+3. **Plan the rewrite as its own document.** A separate exec-plan
+   listing the affected SHAs, the redaction strategy, the
+   force-push timeline, and the contributor communication plan.
+4. **Coordinate with all open-PR authors.** They will need to rebase
+   or recreate their branches against the new history.
+5. **Execute `git filter-repo`** with the planned redaction. Verify
+   the rewritten history no longer contains the leak.
+6. **Force-push** to `main` and to all live release branches. Update
+   tags. Notify forks via the project's normal channels.
+7. **Document the incident** in `CLAUDE.md`'s Lessons Learned and
+   update the gate that should have caught it.
+
+This document does **not** itself execute a `git filter-repo`; that
+command runs only inside a dedicated rewrite plan after Steps 1–4 of
+the procedure above.
+
+## Reassessment triggers
+
+Re-evaluate this document when:
+
+- A hygiene gate fires on `main` (committer block, gitleaks fail,
+  public-hygiene workflow fail).
+- An external party reports a finding through `SECURITY.md`'s
+  disclosure channel.
+- A contributor's identity or credential changes (rotation,
+  account migration).
+- Any new content category enters the public repository that did
+  not exist at the time of the previous assessment.

--- a/docs/security/hygiene-verify.md
+++ b/docs/security/hygiene-verify.md
@@ -1,0 +1,148 @@
+# Public-Repo Hygiene — Verification Procedure
+
+> Companion to `history-exposure-assessment.md`. This page lists the
+> commands that prove the hygiene gates are intact and the published
+> tree is clean. Run these on `main` after every hygiene-related PR
+> merges, and as part of the release-gate pre-flight.
+
+## Prerequisites
+
+- A current clone of `main` (no in-flight branches mixed in).
+- Repo-local virtualenv at `.venv/` for the pytest run.
+- `git` (built-in) and `npm` (for the `public:hygiene` script alias).
+- Standard Unix `grep`. No external dependencies are required.
+
+## Verification commands
+
+Run all six. Each line ends `→ exit 0` on a clean repo. A non-zero
+exit means the corresponding hygiene gate fired and must be addressed
+before the next release.
+
+### V1 — High-risk path absence
+
+```bash
+git ls-files \
+    docs/plans docs/proposals docs/spikes docs/channel-hunt \
+    HANDOFF.md \
+    autosearch/skills/channels/xiaohongshu/experience/patterns.jsonl \
+    autosearch/skills/meta/channel-selection/experience/patterns.jsonl \
+    tests/eval/spike_2_results.json tests/eval/spike_2_urls.yaml \
+  | tee /tmp/autosearch-public-leftovers.txt
+test ! -s /tmp/autosearch-public-leftovers.txt
+```
+
+Confirms no internal directory or runtime-experience artifact is in the
+tracked tree.
+
+### V2 — Internal-voice / private-path grep
+
+```bash
+git grep -n -I -E \
+    "老板|\\bboss\\b|dangerously-skip-permissions|~/.claude|~/.config/ai-secrets|/Users/|force-with-lease|reflog" \
+    -- README.md README.zh.md docs autosearch/skills CLAUDE.md \
+       .github .husky scripts \
+  && exit 1 || exit 0
+```
+
+Catches "老板" / "boss" / dangerous flags / maintainer-private paths
+that may have re-entered published files. The `\bboss\b` word boundary
+prevents legitimate substring hits like `in_boss_key` (an upstream
+Bilibili API field name) from triggering a false positive — see the
+"Known false positives" section below.
+
+### V3 — Credential pattern scan
+
+```bash
+git grep -n -I -E \
+    "sk-[A-Za-z0-9_-]{20,}|sk-ant-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|Bearer [A-Za-z0-9._~-]{20,}" \
+    -- .
+```
+
+Standard credential shapes. Exit 0 with "no matches" is the pass
+condition. Any hit must be triaged: real → P0 (rotate first, see
+`history-exposure-assessment.md`); fake / placeholder → add an
+allowlist entry to `.gitleaks.toml`.
+
+### V4 — Tracked-tree hygiene script
+
+```bash
+python scripts/validate/public_repo_hygiene.py --tracked
+# or
+npm run public:hygiene
+```
+
+Runs the path-rule + dangerous-flag content-rule check on all
+git-tracked files. Exit 0 on clean. The CI workflow
+`.github/workflows/public-hygiene.yml` runs the `--paths-only` form on
+every PR and push to main; this command is the maintainer's local
+equivalent (with content rules included).
+
+### V5 — Test suite
+
+```bash
+.venv/bin/python -m pytest tests/unit/ -x -q -m "not real_llm and not slow and not network"
+```
+
+The fast-tier subset that runs in ≤ 10 seconds and confirms no doc
+edit or hygiene change broke the product. Full suite runs in CI.
+
+### V6 — Working-tree drift check
+
+```bash
+git status --short --ignored | grep -E "docs/.DS_Store|reports/|\\.env|docs/exec-plans" || true
+```
+
+Warns about local files that are correctly ignored but whose presence
+indicates the developer might be about to stage one of them by
+accident. This command is informational — exit code is always 0; the
+output is the signal.
+
+## Pass criteria
+
+A run is **green** when:
+
+1. V1 — `/tmp/autosearch-public-leftovers.txt` is empty.
+2. V2 — exit 0 (no matches, modulo known false positives below).
+3. V3 — no output (no credential shapes anywhere in the tree).
+4. V4 — `OK: N tracked files clean — no hygiene violations.`
+5. V5 — `N passed` from pytest, no failures.
+6. V6 — empty output, or only the maintainer-known transient files.
+
+If any of V1 / V2 / V3 / V4 / V5 fails, the corresponding hygiene gate
+fired and the leak must be addressed before the next release. Do not
+ship around it.
+
+## Known false positives
+
+| Match | File | Reason | Action |
+|---|---|---|---|
+| `boss` substring inside `in_boss_key` / `InBossKey` | `autosearch/skills/tools/video-to-text-bcut/transcribe.py` | These are upstream Bilibili B-Cut API field names; the literal strings come from the third-party API contract and cannot be renamed locally. | The V2 grep above uses `\bboss\b` (word boundary) to skip this; if you copy the older non-boundary form of the grep from prior plan revisions, expect false positives here. |
+| `~/.local/` paths | various `SKILL.md` files, `tests/e2b/matrix.yaml` | Linux XDG Base-Dir convention; not a Tailscale `.local` domain reference. | `.gitleaks.toml` already has a per-rule allowlist for these paths; no action needed. |
+
+## When verification fails
+
+- **V1 or V4 fails**: a path-level rule fired. Either remove the file
+  from HEAD or, if it is a legitimate addition, extend the
+  `scripts/validate/public_repo_hygiene.py` allowlist (rare).
+- **V2 fails on a real leak**: rewrite or remove the offending
+  content. Then add a regex / allowlist entry that would have
+  blocked it earlier (committer / husky / gitleaks /
+  public_repo_hygiene script — pick the layer that should have
+  caught it).
+- **V3 fails on a real credential**: rotate the credential first, then
+  follow `history-exposure-assessment.md` Procedure (steps 1–7).
+- **V5 fails**: the doc / hygiene change broke the product. Fix
+  forward, do not bypass the hygiene gate.
+
+## Reassessment cadence
+
+Run all six verifications:
+
+- After every PR that modifies any of the hygiene config files
+  (`.gitignore`, `.gitleaks.toml`, `.husky/pre-commit`,
+  `scripts/committer`, `scripts/validate/public_repo_hygiene.py`,
+  `.github/workflows/public-hygiene.yml`,
+  `.github/workflows/gitleaks.yml`).
+- Before every release tag is pushed.
+- When any external party reports a finding through the channel in
+  `SECURITY.md`.


### PR DESCRIPTION
## Summary

Public-repo-hygiene plan **batch 4** (final). Two security-folder additions that close out the plan:

| Commit | Plan ref | Action |
|---|---|---|
| `docs(security): add history-exposure-assessment.md (P0/P1/P2 tiers + rewrite procedure)` | F012 (S1–S4) | New `docs/security/history-exposure-assessment.md`. Defines P0/P1/P2 leak tiers with current findings (P0: none; P1: 2026-04-04 incident, closed; P2: cleaned in batches 1–3, no rewrite). Documents the trigger conditions for `git filter-repo` and the 7-step rewrite procedure. |
| `docs(security): add hygiene-verify.md (6-step verification procedure for the published tree)` | F013 (S1–S6) | New `docs/security/hygiene-verify.md`. Lists six commands (V1–V6) that prove the hygiene gates are intact: tracked-path absence, internal-voice grep (with `\bboss\b` boundary fix), credential pattern scan, `public_repo_hygiene.py` script, fast unit-test suite, working-tree drift check. |

## Why now

After batches 1–3 removed the leaked content and added the enforcement layers, the hygiene plan was missing two things:

1. **A written security policy** for what to do if a leak resurfaces (`history-exposure-assessment.md`). Without a documented procedure, an actual P0 finding would force ad-hoc decision-making under time pressure.
2. **A repeatable verification recipe** that a maintainer can run on any clean checkout to confirm the gates are working (`hygiene-verify.md`). Without this, "the hygiene plan is done" is an unverifiable claim.

Both docs are pure documentation — no code changes, no enforcement layer changes. The enforcement layers themselves were added in batches 1–3.

## Notable refinement vs the original plan

The original `autosearch-0425-public-repo-hygiene-plan.md` F013 S2 verify command used a bare `boss` regex without word boundaries. That false-positives on legitimate upstream API field names (e.g. `in_boss_key` / `InBossKey` in `autosearch/skills/tools/video-to-text-bcut/transcribe.py` — Bilibili B-Cut API contract). The verification doc here uses `\bboss\b` (word-boundary form) and explicitly lists this false-positive case in a "Known false positives" table, so the next maintainer to run V2 won't waste cycles chasing it.

## Plan completion summary

This PR completes the public-repo-hygiene plan. Status of all 13 features:

| Feature | Status | PR |
|---|---|---|
| F001 entry-list policy | ✅ shipped (just `docs/public-repo-policy.md`; README entry-points were already clean) | #402 |
| F002 remove plans / proposals | ✅ shipped | #396 |
| F002B remove spikes / channel-hunt | ✅ shipped | #396 |
| F003 untrack HANDOFF + rewrite CLAUDE.md + add internal-docs.md | ✅ shipped | #396 + #399 + #400 |
| F004 remove validation / bench / million-user / upgrade-report | ✅ shipped | #400 |
| F005 untrack runtime experience + remove spike data | ✅ shipped | #396 |
| F006 rewrite delivery-status / roadmap / introduction / local-nightly / mcp-channels-playbook | ✅ shipped | #401 |
| F007 drop "boss" wording from skill / router-group READMEs + align MCP paths | ✅ shipped | #402 |
| F008 .gitignore hardening | ✅ shipped | #396 |
| F009 committer / husky hardening | ✅ shipped | #397 |
| F010 gitleaks rules + workflow split + public-hygiene workflow | ✅ shipped | #397 + #398 + #399 |
| F011 public_repo_hygiene.py + tests + npm/CI entrypoints | ✅ shipped | #398 |
| **F012 history-exposure-assessment.md** | ✅ **this PR** | this |
| **F013 hygiene-verify.md** | ✅ **this PR** | this |

## Test plan

- [x] `tests/unit/` (fast subset): **602 passed** in 7.33s.
- [x] `test -f docs/security/history-exposure-assessment.md && grep -nE "P0|P1|P2|real secret|history rewrite|git filter-repo" docs/security/history-exposure-assessment.md` → all keywords present (F012 S1–S4 verifies pass).
- [x] V5 of `hygiene-verify.md` passes locally (the pytest line above).
- [ ] CI green on this PR.
- [ ] After all 8 hygiene PRs merge, run V1–V6 from `hygiene-verify.md` on a fresh `main` checkout and confirm green.

## Out of scope

- Running V1–V6 *now* — the verifications need a clean `main` post-merge. Running them on this branch (which doesn't include the other 7 PRs' changes) would surface the very leaks they will collectively close.
- A `pyproject.toml` console-script entry for `autosearch-hygiene` — non-blocking, can be added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)