### PR TITLE
feat(cli): revive autosearch query as thin MCP orchestrator (P1-7 B')

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -156,18 +156,42 @@ def query(
     if not normalized_query:
         _exit_query_failure("Query must not be empty.", exit_code=2, json_output=json_output)
 
-    # v2: legacy pipeline removed. Direct CLI query is deprecated.
-    _exit_query_failure(
-        "autosearch query is deprecated in v2.\n"
-        "Use the MCP tools instead: list_skills / run_clarify / run_channel.\n"
-        "See docs/migration/legacy-research-to-tool-supplier.md",
-        exit_code=1,
-        json_output=json_output,
-    )
+    # v2 P1-7: thin orchestration over MCP tools. Autosearch does NOT synthesize a
+    # report — output is structured evidence + citations the user pastes into a
+    # runtime AI (Claude / ChatGPT / Cursor) for synthesis.
+    import asyncio
 
-    # Dead code below — kept as reference until full pipeline removal is complete.
-    # The deprecation exit above prevents any of this from running.
-    _ = normalized_query  # suppress unused variable warning
+    from autosearch.cli.query_pipeline import render_json, render_markdown, run_query
+
+    # `mode` is the clarifier hint (fast/deep/comprehensive). `depth` is the
+    # legacy CLI alias; map it to a SearchMode if it matches a known value.
+    effective_mode: SearchMode | None = mode
+    if effective_mode is None and depth is not None:
+        depth_value = depth.value if hasattr(depth, "value") else str(depth)
+        try:
+            effective_mode = SearchMode(depth_value)
+        except ValueError:
+            effective_mode = None
+
+    try:
+        result = asyncio.run(
+            run_query(
+                normalized_query, mode_hint=effective_mode, top_k_channels=3, per_channel_k=top_k
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — boundary; surface a structured error
+        _exit_query_failure(
+            f"query pipeline failed: {type(exc).__name__}: {exc}",
+            exit_code=1,
+            json_output=json_output,
+        )
+
+    if json_output:
+        typer.echo(render_json(result))
+    else:
+        typer.echo(render_markdown(result))
+
+    raise typer.Exit(code=0)
 
 
 @app.command()

--- a/autosearch/cli/query_pipeline.py
+++ b/autosearch/cli/query_pipeline.py
@@ -1,0 +1,206 @@
+"""Thin CLI orchestrator that wires the v2 MCP tools into a single command-line query.
+
+Per public-repo-hygiene-plan v2 §P1-7 Option B': autosearch DOES NOT synthesize.
+The CLI runs:
+  1. run_clarify   → channel_priority list (top N)
+  2. run_channel × N (concurrent) → evidence list
+  3. render markdown brief with citations + "paste into Claude/ChatGPT" footer
+
+This is the maintainer-side smoke path: a fresh `pipx install autosearch &&
+autosearch query "..."` returns evidence + citations without a runtime AI.
+For a synthesized report, the user pastes the output into Claude / ChatGPT /
+Cursor.
+
+The orchestration deliberately reuses `_invoke_clarifier` and
+`_search_single_channel` from `autosearch.mcp.server` so the CLI and the MCP
+tool layer share one code path; if the MCP tools regress, the CLI smoke
+path catches it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from autosearch.core.models import SearchMode
+
+
+@dataclass
+class QueryResult:
+    """Structured result from `run_query`. Always-set fields kept first."""
+
+    query: str
+    channels_used: list[str] = field(default_factory=list)
+    evidence: list[dict[str, Any]] = field(default_factory=list)
+    clarify_question: str | None = None
+    clarify_options: list[str] = field(default_factory=list)
+
+
+async def run_query(
+    query: str,
+    *,
+    mode_hint: SearchMode | None = None,
+    top_k_channels: int = 3,
+    per_channel_k: int = 5,
+) -> QueryResult:
+    """Run the thin orchestration pipeline and return structured result.
+
+    No LLM synthesis happens here — the runtime AI / human reads the
+    returned evidence and decides what to do with it.
+
+    Returns a QueryResult with:
+      - clarify_question populated if the clarifier needs disambiguation
+        (in which case channels_used / evidence stay empty); or
+      - channels_used + evidence populated when the search ran.
+    """
+    # Imports deferred to avoid circular import via autosearch.cli.main
+    from autosearch.core.channel_runtime import get_channel_runtime
+    from autosearch.mcp.server import _invoke_clarifier, _search_single_channel
+
+    clarify = await _invoke_clarifier(query, mode_hint)
+
+    if clarify.need_clarification and clarify.question:
+        return QueryResult(
+            query=query,
+            clarify_question=clarify.question,
+            clarify_options=list(clarify.question_options),
+        )
+
+    channels = list(clarify.channel_priority)[:top_k_channels]
+    if not channels:
+        # Clarifier returned no priority (rare). Use a sensible English-leaning default
+        # that exercises three independent free channels.
+        channels = ["arxiv", "ddgs", "github"][:top_k_channels]
+
+    runtime = get_channel_runtime()
+    name_to_channel = {c.name: c for c in runtime.channels}
+
+    async def _safe_run(name: str) -> list[Any]:
+        ch = name_to_channel.get(name)
+        if ch is None:
+            return []
+        try:
+            return await _search_single_channel(ch, query, rationale=query)
+        except Exception:  # noqa: BLE001 — channel boundary; one failure shouldn't kill the run
+            return []
+
+    results = await asyncio.gather(*(_safe_run(name) for name in channels))
+
+    evidence: list[dict[str, Any]] = []
+    for ch_evidence in results:
+        for ev in ch_evidence[:per_channel_k]:
+            evidence.append(ev.to_slim_dict())
+
+    return QueryResult(
+        query=query,
+        channels_used=channels,
+        evidence=evidence,
+    )
+
+
+def render_markdown(result: QueryResult) -> str:
+    """Render the result as a markdown evidence brief with citations."""
+    if result.clarify_question:
+        lines = [
+            "# Clarification needed",
+            "",
+            f"**Query**: {result.query}",
+            "",
+            f"**Question**: {result.clarify_question}",
+        ]
+        if result.clarify_options:
+            lines.append("")
+            lines.append("**Options**:")
+            for option in result.clarify_options:
+                lines.append(f"- {option}")
+        lines.extend(
+            [
+                "",
+                "Re-run with the clarified query, e.g.:",
+                "",
+                "```",
+                'autosearch query "<your refined question>"',
+                "```",
+            ]
+        )
+        return "\n".join(lines)
+
+    if not result.evidence:
+        return "\n".join(
+            [
+                "# No evidence found",
+                "",
+                f"**Query**: {result.query}",
+                f"**Channels tried**: {', '.join(result.channels_used) or '(none)'}",
+                "",
+                "Try broadening the query or run `autosearch doctor` to check channel availability.",
+            ]
+        )
+
+    lines = [
+        "# AutoSearch evidence brief",
+        "",
+        f"**Query**: {result.query}",
+        f"**Channels**: {', '.join(result.channels_used)}",
+        f"**Evidence count**: {len(result.evidence)}",
+        "",
+        "## Evidence",
+        "",
+    ]
+
+    for i, ev in enumerate(result.evidence, start=1):
+        title = ev.get("title") or "(no title)"
+        url = ev.get("url") or ""
+        snippet = ev.get("snippet") or ev.get("content") or ""
+        source = ev.get("source_channel") or ""
+        published = ev.get("published_at") or ""
+
+        lines.append(f"### [{i}] {title}")
+        if url:
+            lines.append(f"- URL: <{url}>")
+        if source:
+            lines.append(f"- Source: {source}")
+        if published:
+            lines.append(f"- Published: {published}")
+        if snippet:
+            short = snippet[:300].rstrip()
+            lines.append(f"- Snippet: {short}{'…' if len(snippet) > 300 else ''}")
+        lines.append("")
+
+    lines.append("## Citations")
+    lines.append("")
+    for i, ev in enumerate(result.evidence, start=1):
+        url = ev.get("url") or ""
+        title = ev.get("title") or "(no title)"
+        lines.append(f"[{i}] {title} — <{url}>")
+
+    lines.extend(
+        [
+            "",
+            "---",
+            "",
+            "**Note**: AutoSearch does not synthesize a report from this evidence.",
+            "Paste the brief above into Claude / ChatGPT / Cursor to get a synthesized answer with citations.",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def render_json(result: QueryResult) -> str:
+    """Render the result as JSON for programmatic consumption."""
+    return json.dumps(
+        {
+            "query": result.query,
+            "channels_used": result.channels_used,
+            "evidence_count": len(result.evidence),
+            "clarify_question": result.clarify_question,
+            "clarify_options": result.clarify_options,
+            "evidence": result.evidence,
+        },
+        indent=2,
+        default=str,
+        ensure_ascii=False,
+    )

--- a/docs/migration/legacy-research-to-tool-supplier.md
+++ b/docs/migration/legacy-research-to-tool-supplier.md
@@ -3,6 +3,13 @@
 > Status: wave-3 migration guide.
 > Audience: runtime AI (Claude Code / Cursor / Zed) and their developers.
 > Supersedes: direct use of `research()` MCP tool for new code.
+>
+> CLI status (2026-04-25): `autosearch query "<topic>"` is **back** as a thin
+> orchestrator over the v2 MCP tools (`run_clarify` → top-3 `run_channel`).
+> It returns evidence + citations as a markdown brief, **not** a synthesized
+> report — paste the brief into Claude / ChatGPT / Cursor for synthesis.
+> See `autosearch/cli/query_pipeline.py` for the orchestrator and
+> `tests/unit/test_query_pipeline.py` for behavior coverage.
 
 ## TL;DR
 

--- a/tests/unit/test_cli_interactive_prompt.py
+++ b/tests/unit/test_cli_interactive_prompt.py
@@ -1,30 +1,43 @@
-"""autosearch CLI interactive prompt — v2 deprecation behaviour.
+"""autosearch CLI flag-acceptance regression tests.
 
-After pipeline removal, the query command exits with a deprecation notice
-before reaching scope resolution or interactive prompts.
+These tests confirm that legacy v1 flags (`--interactive`, `--no-interactive`,
+`--json`) are still accepted by the v2 query command without raising a Typer
+parse error. They do not assert behavior of the underlying pipeline — that's
+covered by `test_cli_query.py` and `test_query_pipeline.py` with the orchestrator
+stubbed out.
 """
 
 from __future__ import annotations
 
+import pytest
 from typer.testing import CliRunner
 
 from autosearch.cli.main import app
+from autosearch.cli.query_pipeline import QueryResult
 
 runner = CliRunner()
 
 
-def test_interactive_flags_accepted_but_deprecation_exits() -> None:
+@pytest.fixture(autouse=True)
+def stub_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the orchestrator so these tests don't hit network."""
+
+    async def _fake_run_query(query: str, **_kwargs: object) -> QueryResult:
+        return QueryResult(query=query, channels_used=["arxiv"], evidence=[])
+
+    monkeypatch.setattr("autosearch.cli.query_pipeline.run_query", _fake_run_query)
+
+
+def test_interactive_flag_accepted() -> None:
     result = runner.invoke(app, ["query", "test", "--interactive"])
-    assert result.exit_code != 0
-    combined = (result.output or "") + (result.stderr or "")
-    assert "deprecated" in combined.lower() or "list_skills" in combined
+    assert result.exit_code == 0
 
 
 def test_no_interactive_flag_accepted() -> None:
     result = runner.invoke(app, ["query", "test", "--no-interactive"])
-    assert result.exit_code != 0
+    assert result.exit_code == 0
 
 
 def test_json_mode_flag_accepted() -> None:
     result = runner.invoke(app, ["query", "test", "--json"])
-    assert result.exit_code != 0
+    assert result.exit_code == 0

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -11,11 +11,18 @@ from autosearch.cli import main as cli_main
 runner = CliRunner()
 
 
-def test_cli_exits_nonzero_with_deprecation_message() -> None:
+def test_cli_query_smoke_renders_brief(monkeypatch) -> None:
+    """The v2 `query` command runs the thin orchestrator and renders an
+    evidence brief. Stub the pipeline so this test stays offline."""
+    from autosearch.cli.query_pipeline import QueryResult
+
+    async def _fake_run_query(query: str, **_kwargs: object) -> QueryResult:
+        return QueryResult(query=query, channels_used=["arxiv"], evidence=[])
+
+    monkeypatch.setattr("autosearch.cli.query_pipeline.run_query", _fake_run_query)
     result = runner.invoke(cli_main.app, ["query", "test", "--no-stream"])
-    assert result.exit_code != 0
-    combined = (result.output or "") + (result.stderr or "")
-    assert "deprecated" in combined.lower() or "list_skills" in combined
+    assert result.exit_code == 0
+    assert "No evidence found" in result.stdout or "evidence brief" in result.stdout.lower()
 
 
 def test_cli_rejects_empty_query() -> None:

--- a/tests/unit/test_cli_query.py
+++ b/tests/unit/test_cli_query.py
@@ -1,25 +1,94 @@
-"""autosearch query CLI — v2 deprecation behaviour.
+"""autosearch query CLI — v2 P1-7 thin orchestration behaviour.
 
-The legacy pipeline-based ``autosearch query`` command now exits immediately with
-a deprecation notice directing users to the v2 MCP tools instead.
+The CLI runs `run_clarify` → top-N `run_channel` calls → renders evidence.
+No LLM synthesis happens; the user pastes the brief into a runtime AI.
+
+Tests stub the orchestrator so they run without network access.
 """
 
 from __future__ import annotations
 
+import json
+
+import pytest
 from typer.testing import CliRunner
 
+from autosearch.cli import main as cli_main
 from autosearch.cli.main import app
+from autosearch.cli.query_pipeline import QueryResult
 
 runner = CliRunner()
 
 
-def test_cli_query_exits_nonzero_with_deprecation_message() -> None:
-    result = runner.invoke(app, ["query", "test research question"])
-    assert result.exit_code != 0
+@pytest.fixture
+def stub_pipeline(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    async def _fake_run_query(query: str, **kwargs: object) -> QueryResult:
+        captured["query"] = query
+        captured["kwargs"] = kwargs
+        return QueryResult(
+            query=query,
+            channels_used=["arxiv"],
+            evidence=[
+                {
+                    "url": "https://arxiv.org/abs/2026.0001",
+                    "title": "Stub paper",
+                    "snippet": "stub snippet",
+                    "source_channel": "arxiv",
+                }
+            ],
+        )
+
+    monkeypatch.setattr("autosearch.cli.query_pipeline.run_query", _fake_run_query)
+    return captured
+
+
+def test_cli_query_renders_markdown_brief(stub_pipeline: dict[str, object]) -> None:
+    result = runner.invoke(app, ["query", "transformers 2026"])
+    assert result.exit_code == 0
+    assert "AutoSearch evidence brief" in result.stdout
+    assert "Stub paper" in result.stdout
+    assert "## Citations" in result.stdout
+    assert "Paste the brief above" in result.stdout
+
+
+def test_cli_query_json_emits_valid_envelope(stub_pipeline: dict[str, object]) -> None:
+    result = runner.invoke(app, ["query", "transformers 2026", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["query"] == "transformers 2026"
+    assert payload["channels_used"] == ["arxiv"]
+    assert payload["evidence_count"] == 1
+    assert payload["evidence"][0]["title"] == "Stub paper"
+
+
+def test_cli_query_rejects_empty_query() -> None:
+    result = runner.invoke(app, ["query", "   "])
+    assert result.exit_code == 2  # argparse-style usage error
     combined = (result.output or "") + (result.stderr or "")
-    assert "deprecated" in combined.lower() or "list_skills" in combined
+    assert "Query must not be empty" in combined or "must not be empty" in combined
 
 
-def test_cli_bare_query_routes_to_query_command() -> None:
-    result = runner.invoke(app, ["query", "anything"])
-    assert result.exit_code in (1, 2)
+def test_cli_query_pipeline_failure_surfaces_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _failing(_query: str, **_kwargs: object) -> QueryResult:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("autosearch.cli.query_pipeline.run_query", _failing)
+    result = runner.invoke(app, ["query", "anything", "--json"])
+    assert result.exit_code == 1
+    combined = (result.output or "") + (result.stderr or "")
+    assert "boom" in combined or "RuntimeError" in combined or "query pipeline failed" in combined
+
+
+def test_cli_query_top_k_passed_through(stub_pipeline: dict[str, object]) -> None:
+    result = runner.invoke(app, ["query", "x", "--top-k", "12"])
+    assert result.exit_code == 0
+    kwargs = stub_pipeline["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["per_channel_k"] == 12
+
+
+def test_cli_module_main_attribute_present() -> None:
+    # Sanity: the module still exposes `app` for the entry point.
+    assert hasattr(cli_main, "app")

--- a/tests/unit/test_cli_scope_flags.py
+++ b/tests/unit/test_cli_scope_flags.py
@@ -1,16 +1,28 @@
-"""autosearch CLI scope flags — v2 deprecation behaviour.
+"""autosearch CLI scope flags — Typer parse behaviour for v2 query command.
 
-After pipeline removal, ``autosearch query`` exits with a deprecation notice
-before scope resolution. Flag validation (typer) still happens before that.
+The v2 thin-orchestration `query` command keeps backward-compat flag surface
+(`--depth`, `--channel-scope`, `--no-interactive`, etc.). These tests confirm
+Typer still parses or rejects the flag values correctly, with the orchestrator
+stubbed so no network is hit.
 """
 
 from __future__ import annotations
 
+import pytest
 from typer.testing import CliRunner
 
 from autosearch.cli.main import app
+from autosearch.cli.query_pipeline import QueryResult
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def stub_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_run_query(query: str, **_kwargs: object) -> QueryResult:
+        return QueryResult(query=query, channels_used=["arxiv"], evidence=[])
+
+    monkeypatch.setattr("autosearch.cli.query_pipeline.run_query", _fake_run_query)
 
 
 def test_query_invalid_depth_is_bad_parameter() -> None:
@@ -24,12 +36,9 @@ def test_invalid_channel_scope_rejected() -> None:
     assert result.exit_code == 2
 
 
-def test_query_with_any_valid_flags_exits_deprecation() -> None:
-    # Valid flags parse correctly; deprecation exit fires before pipeline is reached.
+def test_query_with_valid_flags_runs_pipeline() -> None:
     result = runner.invoke(
         app,
         ["query", "test", "--depth", "deep", "--channel-scope", "zh_only", "--no-interactive"],
     )
-    assert result.exit_code != 0
-    combined = (result.output or "") + (result.stderr or "")
-    assert "deprecated" in combined.lower() or "list_skills" in combined
+    assert result.exit_code == 0

--- a/tests/unit/test_query_pipeline.py
+++ b/tests/unit/test_query_pipeline.py
@@ -1,0 +1,255 @@
+"""Tests for autosearch.cli.query_pipeline (P1-7 thin CLI orchestration).
+
+These tests mock the clarifier and channel runtime so they run without
+network access. The behaviors covered:
+
+- clarifier `need_clarification=True` → result returns the question
+- clarifier returns `channel_priority` → top-N channels are searched
+- per-channel exception is swallowed (one failure doesn't kill the run)
+- empty `channel_priority` → falls back to a default trio
+- markdown / JSON renderers handle clarification, empty, and populated states
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from autosearch.cli.query_pipeline import (
+    QueryResult,
+    render_json,
+    render_markdown,
+    run_query,
+)
+from autosearch.core.models import Evidence
+
+
+def _evidence(url: str, title: str, channel: str = "arxiv") -> Evidence:
+    return Evidence(
+        url=url,
+        title=title,
+        snippet="snippet text",
+        source_channel=channel,
+        fetched_at=datetime.now(UTC),
+    )
+
+
+class _FakeChannel:
+    def __init__(
+        self, name: str, evidence: list[Evidence] | None = None, raises: bool = False
+    ) -> None:
+        self.name = name
+        self._evidence = evidence or []
+        self._raises = raises
+
+    async def search(self, _subquery: Any) -> list[Evidence]:
+        if self._raises:
+            raise RuntimeError(f"channel {self.name} failed")
+        return self._evidence
+
+
+class _FakeRuntime:
+    def __init__(self, channels: list[_FakeChannel]) -> None:
+        self.channels = channels
+
+
+def _patch_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    clarify_response: Any,
+    channels: list[_FakeChannel],
+) -> None:
+    async def _fake_clarify(_query: str, _mode_hint: Any) -> Any:
+        return clarify_response
+
+    def _fake_runtime() -> _FakeRuntime:
+        return _FakeRuntime(channels)
+
+    monkeypatch.setattr("autosearch.mcp.server._invoke_clarifier", _fake_clarify)
+    monkeypatch.setattr("autosearch.core.channel_runtime.get_channel_runtime", _fake_runtime)
+
+
+# ---------- run_query ----------
+
+
+class TestRunQuery:
+    def test_clarification_short_circuits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clarify = type(
+            "Resp",
+            (),
+            {
+                "need_clarification": True,
+                "question": "Which language?",
+                "question_options": ["en", "zh"],
+                "channel_priority": [],
+            },
+        )()
+        _patch_pipeline(monkeypatch, clarify_response=clarify, channels=[])
+
+        result = asyncio.run(run_query("ambiguous"))
+
+        assert result.clarify_question == "Which language?"
+        assert result.clarify_options == ["en", "zh"]
+        assert result.channels_used == []
+        assert result.evidence == []
+
+    def test_top_n_channels_searched_with_evidence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ch1 = _FakeChannel(
+            "arxiv", [_evidence(f"https://a.example/{i}", f"a-{i}") for i in range(3)]
+        )
+        ch2 = _FakeChannel(
+            "github", [_evidence(f"https://g.example/{i}", f"g-{i}", "github") for i in range(2)]
+        )
+        ch3 = _FakeChannel("ddgs", [_evidence("https://d.example/0", "d-0", "ddgs")])
+        ch_extra = _FakeChannel("ignored", [_evidence("https://x.example/0", "x-0")])
+
+        clarify = type(
+            "Resp",
+            (),
+            {
+                "need_clarification": False,
+                "question": "",
+                "question_options": [],
+                "channel_priority": ["arxiv", "github", "ddgs", "ignored"],
+            },
+        )()
+        _patch_pipeline(monkeypatch, clarify_response=clarify, channels=[ch1, ch2, ch3, ch_extra])
+
+        result = asyncio.run(run_query("transformers", top_k_channels=3, per_channel_k=5))
+
+        assert result.channels_used == ["arxiv", "github", "ddgs"]
+        assert "ignored" not in result.channels_used
+        # 3 + 2 + 1 = 6 evidence rows
+        assert len(result.evidence) == 6
+
+    def test_per_channel_failure_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ok_channel = _FakeChannel("arxiv", [_evidence("https://a/1", "a1")])
+        bad_channel = _FakeChannel("github", raises=True)
+
+        clarify = type(
+            "Resp",
+            (),
+            {
+                "need_clarification": False,
+                "question": "",
+                "question_options": [],
+                "channel_priority": ["arxiv", "github"],
+            },
+        )()
+        _patch_pipeline(monkeypatch, clarify_response=clarify, channels=[ok_channel, bad_channel])
+
+        result = asyncio.run(run_query("test", top_k_channels=2))
+
+        assert "arxiv" in result.channels_used
+        assert "github" in result.channels_used  # name still listed even if its search failed
+        assert len(result.evidence) == 1  # only arxiv contributed evidence
+
+    def test_unknown_channel_name_yields_no_evidence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clarify = type(
+            "Resp",
+            (),
+            {
+                "need_clarification": False,
+                "question": "",
+                "question_options": [],
+                "channel_priority": ["nonexistent_channel"],
+            },
+        )()
+        _patch_pipeline(monkeypatch, clarify_response=clarify, channels=[])
+
+        result = asyncio.run(run_query("test", top_k_channels=1))
+
+        assert result.channels_used == ["nonexistent_channel"]
+        assert result.evidence == []
+
+    def test_empty_priority_falls_back_to_default_trio(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        clarify = type(
+            "Resp",
+            (),
+            {
+                "need_clarification": False,
+                "question": "",
+                "question_options": [],
+                "channel_priority": [],
+            },
+        )()
+        # Don't register any matching channels — fallback names will resolve to nothing.
+        _patch_pipeline(monkeypatch, clarify_response=clarify, channels=[])
+
+        result = asyncio.run(run_query("test", top_k_channels=3))
+
+        assert result.channels_used == ["arxiv", "ddgs", "github"]
+
+
+# ---------- renderers ----------
+
+
+class TestRenderMarkdown:
+    def test_clarification(self) -> None:
+        out = render_markdown(
+            QueryResult(
+                query="x",
+                clarify_question="What language?",
+                clarify_options=["en", "zh"],
+            )
+        )
+        assert "Clarification needed" in out
+        assert "What language?" in out
+        assert "- en" in out
+        assert "- zh" in out
+
+    def test_empty_evidence(self) -> None:
+        out = render_markdown(QueryResult(query="x", channels_used=["arxiv"]))
+        assert "No evidence found" in out
+        assert "arxiv" in out
+
+    def test_populated_evidence_has_citations_and_handoff(self) -> None:
+        result = QueryResult(
+            query="transformers 2026",
+            channels_used=["arxiv"],
+            evidence=[
+                {
+                    "url": "https://arxiv.org/abs/2026.0001",
+                    "title": "Paper One",
+                    "snippet": "About transformers.",
+                    "source_channel": "arxiv",
+                    "published_at": "2026-04-01",
+                }
+            ],
+        )
+        out = render_markdown(result)
+        assert "AutoSearch evidence brief" in out
+        assert "## Evidence" in out
+        assert "Paper One" in out
+        assert "arxiv" in out
+        assert "## Citations" in out
+        assert "[1] Paper One" in out
+        assert "Paste the brief above into Claude / ChatGPT / Cursor" in out
+
+
+class TestRenderJSON:
+    def test_round_trips(self) -> None:
+        result = QueryResult(
+            query="x",
+            channels_used=["arxiv"],
+            evidence=[{"url": "u", "title": "t"}],
+        )
+        parsed = json.loads(render_json(result))
+        assert parsed["query"] == "x"
+        assert parsed["channels_used"] == ["arxiv"]
+        assert parsed["evidence_count"] == 1
+        assert parsed["evidence"] == [{"url": "u", "title": "t"}]
+        assert parsed["clarify_question"] is None
+
+    def test_clarification_serialized(self) -> None:
+        result = QueryResult(query="x", clarify_question="Q?", clarify_options=["a", "b"])
+        parsed = json.loads(render_json(result))
+        assert parsed["clarify_question"] == "Q?"
+        assert parsed["clarify_options"] == ["a", "b"]
+        assert parsed["evidence_count"] == 0


### PR DESCRIPTION
## Summary

Closes the only remaining substantive item from the v2 production-critical fix plan — §P1-7. The CLI command \`autosearch query "<topic>"\` is back, but as a **thin orchestrator** over the v2 MCP tools (Option B' from the discussion thread): no LLM synthesis, just structured evidence + citations the user pastes into a runtime AI for synthesis.

## What's in this PR (3 commits)

| Commit | Action |
|---|---|
| \`feat(cli): add query_pipeline thin orchestrator\` | New \`autosearch/cli/query_pipeline.py\` + wires \`autosearch/cli/main.py:query\` to call it. Pipeline: \`run_clarify\` → top-3 channels from \`channel_priority\` → \`run_channel × 3\` (concurrent) → render markdown brief or JSON envelope. Reuses \`_invoke_clarifier\` and \`_search_single_channel\` helpers from \`autosearch.mcp.server\` so CLI and MCP share one code path. |
| \`test(cli): cover query_pipeline + retire 4 deprecation-era tests\` | 10 new unit tests for the orchestrator (clarification short-circuit, top-N channel selection, per-channel failure tolerance, default-trio fallback, markdown / JSON renderers). 4 existing tests that asserted "deprecation exit" rewritten to stub the orchestrator and assert the new flow. |
| \`docs(migration): note CLI is back as thin orchestrator\` | Adds a CLI status note to \`docs/migration/legacy-research-to-tool-supplier.md\` so readers don't think CLI is permanently deprecated. |

## Why B' over plain restoration

- **A** (permanent deprecation): would leave \`README\` first line ("AutoSearch fixes this in one line") at odds with reality, and leave non-MCP users with no path.
- **B** (full pipeline restored, with synthesis): would re-introduce the Gate 12 weakness — autosearch's pipeline lost 0/62 to native Claude on synthesis, which is exactly why v2 stopped synthesizing.
- **B'** (thin orchestration, no synthesis): keeps the install-smoke / non-MCP-user path AND the v2 architectural commitment. The CLI hands the user evidence + citations and an explicit "paste this into Claude/ChatGPT" footer — autosearch supplies tools, the runtime AI synthesizes.

## Behavior

\`\`\`
$ autosearch query "transformers long-context 2026"
# AutoSearch evidence brief

**Query**: transformers long-context 2026
**Channels**: arxiv, ddgs, github
**Evidence count**: 9

## Evidence

### [1] <title>
- URL: <https://...>
- Source: arxiv
- Snippet: ...

[... evidence 2..9 ...]

## Citations
[1] <title> — <url>
...

---

**Note**: AutoSearch does not synthesize a report from this evidence.
Paste the brief above into Claude / ChatGPT / Cursor to get a synthesized
answer with citations.
\`\`\`

\`--json\` switches to a structured envelope. Clarifier ambiguity short-circuits to a "what did you mean?" prompt.

## Per-channel failure tolerance

If one channel raises (network glitch, missing key), the orchestrator swallows the exception and continues. The channel name still appears in \`channels_used\` but contributes zero evidence rows. Tests assert this.

## Test plan

- [x] \`tests/unit/test_query_pipeline.py\`: **10 passed** (clarification, top-N, failure tolerance, fallback, both renderers, both modes).
- [x] \`tests/unit/test_cli_query.py\`: **6 passed** (markdown, JSON, empty rejection, failure surface, top_k passthrough, module sanity).
- [x] Full unit suite: **631 passed** in 7.58s (was 617; +14 net new from test_query_pipeline.py and the 4 reworked tests).
- [ ] CI green on this PR.
- [ ] Manual: \`autosearch query "RAG evaluation 2026"\` against a clean install — verify markdown brief renders with at least one channel's evidence.

## Out of scope

- A first-use smoke test under \`tests/smoke/test_first_use_flow.py\` that exercises the real channel layer end-to-end. The existing unit tests cover the orchestrator with mocked dependencies (no network); a real-network smoke test is a separate add-on if maintainers want it for release-gate evidence.
- README first-screen rewrite to feature \`autosearch query "..."\` as an example. The current README install paths already include \`npx autosearch-ai\` / \`pipx install autosearch\` / \`curl install.sh\`; calling out \`query\` as the smoke command can come in a small docs PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `autosearch query` now executes a complete query pipeline including clarification and channel search
  * Results are rendered as evidence briefs with citations in Markdown or JSON format
  * Improved error handling with descriptive failure messages

* **Documentation**
  * Updated CLI migration guide documenting v2 query command behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->