### PR TITLE
fix(cli): structlog→stderr + P1-7 first-use smoke + bump v2026.04.25.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Self-evolving deep research. Gets smarter every time you use it.",
-    "version": "2026.04.25.9"
+    "version": "2026.04.25.10"
   },
   "plugins": [
     {
       "name": "autosearch",
       "source": "./",
       "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
-      "version": "2026.04.25.9",
+      "version": "2026.04.25.10",
       "author": {
         "name": "0xmariowu"
       },
@@ -30,5 +30,5 @@
       "category": "research"
     }
   ],
-  "version": "2026.04.25.9"
+  "version": "2026.04.25.10"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autosearch",
-  "version": "2026.04.25.9",
+  "version": "2026.04.25.10",
   "description": "Self-evolving deep research. Gets smarter every time you use it. Searches across channels, synthesizes cited reports, and learns which queries and platforms work best.",
   "author": {
     "name": "0xmariowu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.04.25.10 — 2026-04-25
+
+- **`autosearch query "..." --json` is now parseable.** The CLI was leaking structlog `[info]` lines onto stdout, so piping into `jq` failed with "Extra data". Logs now route to stderr (matching the MCP path), and a fresh-install smoke test (`tests/smoke/test_first_use_flow.py`) locks the contract in: markdown brief + JSON envelope + `--help` all pass without network or LLM keys, closing the P1-7 first-use loop from the production-critical-fix-plan-v2.
+- **Public-repo hygiene rollup.** Bumps in PRs #395–#403 were intentionally deferred per the "bump once after a merge batch" rule; this release ships them: install paths unified to npx / AI-agent / curl with `--yes` removed (#395); internal docs + runtime experience stripped from HEAD (#396); committer / husky / gitleaks tooling layer (#397); `public_repo_hygiene.py` + tests + npm/CI entrypoints (#398); gitleaks split into public/private notes (#399); CLAUDE.md cleanup + stale validation/bench/plan docs removed (#400); 5 user-facing docs rewritten to drop internal voice (#401); "boss" wording removed from skill READMEs + `public-repo-policy.md` added (#402); history-exposure assessment + verification procedure (#403).
+
 ## 2026.04.25.9 — 2026-04-25
 
 Hotfix on top of `.25.8`. PR #387 wired `pre_release_check.py` into
@@ -588,7 +593,7 @@ This is the first production release of AutoSearch v2 tool-supplier architecture
 - W3.3 pipeline-removal multi-PR plan at `docs/proposals/2026-04-22-w3-3-pipeline-removal-plan.md`. Splits the destructive legacy-removal work into 5 sequenced PRs (A freeze research() surface → B delete orphan tests → C delete m3/m7 prompt markdowns → D gut pipeline internals → E delete Pipeline class). Each PR ≤ 1000 lines changed, self-contained, rollbackable. Respects CLAUDE.md "do not take overly destructive actions" by sequencing. Next action after plan merges: boss go for PR A.
 - Migration guide `docs/migration/legacy-research-to-tool-supplier.md` (W3.3 first safe step). Documents how runtime AI moves from the legacy `research()` MCP pipeline to the v2 trio (`list_skills` + `run_clarify` + `run_channel`). Includes minimum migration pattern, quick-research pattern, deep-research composition with wave-3 meta skills, cost comparison, and FAQ.
 - Runtime `DeprecationWarning` on `research()` MCP tool invocation pointing to the migration guide. Legacy pipeline continues to run; the warning surfaces in tool output so integrators notice the v2 path without breaking existing flows. MCP server `instructions` string also updated to steer new integrations toward the trio.
-- 8 new workflow skill candidates landed (W3.6, from v2 proposal §3.7). All docs-only meta skills that codify runtime-AI workflow patterns borrowed from prior art in `~/Armory/Search/` — they do not add Python code, the runtime AI is the implementer:
+- 8 new workflow skill candidates landed (W3.6, from v2 proposal §3.7). All docs-only meta skills that codify runtime-AI workflow patterns borrowed from prior art in external deep-research reference repos — they do not add Python code, the runtime AI is the implementer:
   - `delegate-subtask` (Standard) — execution contract for isolated sub-tasks (input / budget / output / stop-conditions). Sources: MiroThinker + DeepAgents + deer-flow + DeepResearchAgent.
   - `trace-harvest` (Standard) — distills successful session trace into promote-candidate experience events. Sources: MiroThinker collect-trace + DeepResearchAgent memory system.
   - `reflective-search-loop` (Best) — explicit multi-round loop state (gaps / visited / bad_urls / evaluator failures / stop conditions). Sources: WebThinker + node-deepresearch + Scira extreme-search.

--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -72,6 +72,13 @@ def main(
         ),
     ] = None,
 ) -> None:
+    # Route structlog to stderr so `--json` output stays parseable and CLI
+    # users don't see info logs interleaved with the brief on stdout. (MCP
+    # path does the same in autosearch/mcp/cli.py.)
+    import structlog
+
+    structlog.configure(logger_factory=structlog.WriteLoggerFactory(file=sys.stderr))
+
     # Push ~/.config/ai-secrets.env keys into process env so subcommands and
     # any provider/channel that does `os.getenv("FOO_API_KEY")` actually sees
     # what the user configured via `autosearch configure`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.9"
+version = "2026.04.25.10"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 license = "MIT"

--- a/tests/smoke/test_first_use_flow.py
+++ b/tests/smoke/test_first_use_flow.py
@@ -1,0 +1,94 @@
+"""P1-7: fresh-install first-use flow smoke test.
+
+A user who runs `pipx install autosearch` and immediately tries
+`autosearch query "..."` must not be blocked by missing API keys, missing
+network, or pipeline crashes. This test exercises the full CLI → pipeline →
+render path under `AUTOSEARCH_LLM_MODE=dummy` so it runs offline and proves
+the closed loop: the binary exits 0 and emits a structured brief (or a
+deterministic "no evidence" brief when no real channels are reachable).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from tests.smoke.conftest import console_script_command, smoke_env
+
+
+@pytest.mark.smoke
+def test_query_markdown_loop_exits_zero() -> None:
+    """`autosearch query "..."` returns a markdown brief and exits 0 in dummy mode."""
+    result = subprocess.run(
+        [*console_script_command("autosearch", "autosearch.cli.main"), "query", "smoke test query"],
+        capture_output=True,
+        text=True,
+        env=smoke_env(AUTOSEARCH_LLM_MODE="dummy"),
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"query exited {result.returncode}; stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+    )
+    assert "Traceback" not in result.stderr, f"unexpected traceback:\n{result.stderr}"
+
+    # Pipeline must produce one of the three documented brief shapes —
+    # evidence, no-evidence, or clarification — never an empty stdout.
+    out = result.stdout
+    assert out.strip(), "expected non-empty markdown brief on stdout"
+    assert any(
+        marker in out
+        for marker in (
+            "# AutoSearch evidence brief",
+            "# No evidence found",
+            "# Clarification needed",
+        )
+    ), f"output missing expected brief heading; got:\n{out[:500]}"
+
+
+@pytest.mark.smoke
+def test_query_json_loop_emits_valid_envelope() -> None:
+    """`autosearch query "..." --json` emits a parseable envelope with the documented fields."""
+    result = subprocess.run(
+        [
+            *console_script_command("autosearch", "autosearch.cli.main"),
+            "query",
+            "smoke test query",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env=smoke_env(AUTOSEARCH_LLM_MODE="dummy"),
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"query --json exited {result.returncode}; stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+    )
+
+    payload = json.loads(result.stdout)
+    for field in ("query", "channels_used", "evidence_count", "evidence"):
+        assert field in payload, f"missing field {field!r} in JSON envelope: {payload}"
+    assert payload["query"] == "smoke test query"
+    assert isinstance(payload["channels_used"], list)
+    assert isinstance(payload["evidence"], list)
+    assert payload["evidence_count"] == len(payload["evidence"])
+
+
+@pytest.mark.smoke
+def test_query_help_lists_subcommand() -> None:
+    """`autosearch query --help` proves the v2 thin-orchestration CLI is wired up."""
+    result = subprocess.run(
+        [*console_script_command("autosearch", "autosearch.cli.main"), "query", "--help"],
+        capture_output=True,
+        text=True,
+        env=smoke_env(),
+        timeout=15,
+    )
+
+    assert result.returncode == 0, (
+        f"query --help exited {result.returncode}; stderr:\n{result.stderr}"
+    )
+    assert "query" in result.stdout.lower(), f"help missing 'query'; got:\n{result.stdout[:400]}"


### PR DESCRIPTION
## Summary

- **`autosearch query --json` now actually parseable.** structlog `[info]` lines were leaking to stdout, breaking `| jq`. Routed structlog to stderr in the CLI callback, mirroring `mcp/cli.py`.
- **P1-7 fresh-install smoke test added** (`tests/smoke/test_first_use_flow.py`): markdown brief, `--json` envelope, and `--help` all pass under `AUTOSEARCH_LLM_MODE=dummy` — closes the last open item in `production-critical-fix-plan-v2`.
- **Version bump v2026.04.25.9 → .25.10**, rolling up the previously deferred bumps for the public-repo hygiene batch (PRs #395–#403). Also a one-line surgical sanitization of an old CHANGELOG entry that referenced an internal codename (was blocking the pre-commit codename gate).

## Test plan

- [x] `pytest tests/unit/ tests/smoke/ -x -q -m "not real_llm and not slow and not network"` → 1045 passed, 3 skipped (locally)
- [x] `ruff check && ruff format --check` → clean
- [x] `pytest -xvs tests/smoke/test_first_use_flow.py` → 3/3 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)