### PR TITLE
fix(redact): sanitize signed-URL secrets across 6 fetch/video tools (P0-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 2026.04.25.11 — 2026-04-25
+## 2026.04.25.11 — 2026-04-26
 
-- 
+- **No more signed-URL secret leaks from fetch / video tools.** `autosearch.core.redact` gains `redact_url(url, *, strip_query=True)`; six MCP-visible tools (`fetch-jina`, `fetch-crawl4ai`, `fetch-firecrawl`, `video-to-text-openai`, `video-to-text-groq`, `video-to-text-local`) now sanitize URLs at every output boundary (return fields + log calls). Previously a user passing `https://example.com/foo?access_token=SECRET&X-Amz-Signature=...` would see the credential echoed back in the tool result and structured logs. A new integration suite (`tests/tools/test_url_leak_prevention.py`) parametrizes 6 leak scenarios and locks the contract. Closes P0-2 from `docs/exec-plans/active/autosearch-0425-p0-scan-report.md`.
+- **Rolls up #406** (CN→EN cleanup residuals — workflow comment, e2b harness stdout, scenario docstring) and syncs `pyproject.toml` to `2026.04.25.11` (the bump in #406 missed this file, leaving `test_version_consistency` failing on main).
 
 ## 2026.04.25.10 — 2026-04-25
 

--- a/autosearch/core/redact.py
+++ b/autosearch/core/redact.py
@@ -11,6 +11,7 @@ Conservative match list — must NOT alter ordinary user prose.
 from __future__ import annotations
 
 import re
+from urllib.parse import urlsplit, urlunsplit
 
 _SECRET_KEY_PATTERN = (
     r"(?:"
@@ -84,3 +85,17 @@ def redact(text: str) -> str:
     for pat in _SECRET_PATTERNS:
         out = pat.sub(_replacer, out)
     return out
+
+
+def redact_url(url: str, *, strip_query: bool = True) -> str:
+    """Return `url` with query-string secrets removed."""
+    if not isinstance(url, str):
+        raise TypeError("url must be str")
+
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+
+    query = "" if strip_query else parts.query
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))

--- a/autosearch/skills/tools/fetch-crawl4ai/fetch.py
+++ b/autosearch/skills/tools/fetch-crawl4ai/fetch.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import structlog
 
+from autosearch.core.redact import redact_url
+
 LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="fetch-crawl4ai")
 
 DEFAULT_TIMEOUT_SECONDS = 30.0
@@ -79,7 +81,7 @@ def fetch(
     except Exception as exc:  # crawl4ai intentionally stays optional at import time.
         elapsed_sec = time.perf_counter() - started
         reason = _classify_exception(exc)
-        LOGGER.warning("fetch_crawl4ai_failed", url=url, reason=reason, error=str(exc))
+        LOGGER.warning("fetch_crawl4ai_failed", url=redact_url(url), reason=reason, error=str(exc))
         return _failure(
             source=url,
             reason=reason,
@@ -134,14 +136,14 @@ def fetch(
         "ok": True,
         "markdown": markdown,
         "title": title,
-        "url": final_url,
+        "url": redact_url(final_url),
         "meta": {
             "status_code": status_code,
             "backend": "crawl4ai",
             "browser": "chromium",
             "elapsed_sec": elapsed_sec,
         },
-        "source": url,
+        "source": redact_url(url),
     }
 
 
@@ -171,7 +173,7 @@ async def _crawl_once(
 
 
 def _failure(*, source: str, reason: str, **extra: object) -> FetchCrawl4AIResult:
-    result: FetchCrawl4AIResult = {"ok": False, "reason": reason, "source": source}
+    result: FetchCrawl4AIResult = {"ok": False, "reason": reason, "source": redact_url(source)}
     result.update({key: value for key, value in extra.items() if value is not None})
     return result
 

--- a/autosearch/skills/tools/fetch-firecrawl/methods/scrape.py
+++ b/autosearch/skills/tools/fetch-firecrawl/methods/scrape.py
@@ -10,6 +10,7 @@ import structlog
 
 from autosearch.channels.base import MethodUnavailable
 from autosearch.core.models import Evidence, SubQuery
+from autosearch.core.redact import redact_url
 
 LOGGER = structlog.get_logger(__name__).bind(component="tool", channel="fetch-firecrawl")
 
@@ -25,7 +26,7 @@ async def search(query: SubQuery) -> list[Evidence]:
 
     url = query.text.strip()
     if not url.startswith(("http://", "https://")):
-        LOGGER.warning("firecrawl_invalid_url", url=url)
+        LOGGER.warning("firecrawl_invalid_url", url=redact_url(url))
         return []
 
     try:
@@ -33,7 +34,7 @@ async def search(query: SubQuery) -> list[Evidence]:
     except MethodUnavailable:
         raise
     except Exception as exc:
-        LOGGER.warning("firecrawl_scrape_failed", url=url, reason=str(exc))
+        LOGGER.warning("firecrawl_scrape_failed", url=redact_url(url), reason=str(exc))
         return []
 
 
@@ -45,7 +46,7 @@ async def _scrape(url: str, api_key: str) -> list[Evidence]:
         resp.raise_for_status()
     data = resp.json()
     markdown = (data.get("data") or {}).get("markdown") or ""
-    title = (data.get("data") or {}).get("metadata", {}).get("title") or url
+    title = (data.get("data") or {}).get("metadata", {}).get("title") or redact_url(url)
 
     if not markdown:
         return []
@@ -53,7 +54,7 @@ async def _scrape(url: str, api_key: str) -> list[Evidence]:
     return [
         Evidence(
             title=title,
-            url=url,
+            url=redact_url(url),
             content=markdown[:4000],
             score=0.9,
             source_channel="fetch-firecrawl",

--- a/autosearch/skills/tools/fetch-jina/fetch.py
+++ b/autosearch/skills/tools/fetch-jina/fetch.py
@@ -6,6 +6,8 @@ from urllib.parse import urlparse
 import httpx
 import structlog
 
+from autosearch.core.redact import redact_url
+
 LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="fetch-jina")
 
 DEFAULT_TIMEOUT_SECONDS = 30.0
@@ -45,7 +47,7 @@ async def fetch(
     try:
         response = await _get(reader_url, timeout_seconds=timeout_seconds, http_client=http_client)
     except httpx.TimeoutException as exc:
-        LOGGER.warning("fetch_jina_timeout", url=url, reason=str(exc))
+        LOGGER.warning("fetch_jina_timeout", url=redact_url(url), reason=str(exc))
         return _failure(
             url=url,
             reader_url=reader_url,
@@ -53,7 +55,7 @@ async def fetch(
             message="Jina Reader request timed out",
         )
     except httpx.HTTPError as exc:
-        LOGGER.warning("fetch_jina_http_error", url=url, reason=str(exc))
+        LOGGER.warning("fetch_jina_http_error", url=redact_url(url), reason=str(exc))
         return _failure(
             url=url,
             reader_url=reader_url,
@@ -61,7 +63,7 @@ async def fetch(
             message=str(exc) or exc.__class__.__name__,
         )
     except Exception as exc:  # pragma: no cover - defensive boundary for runtime tools
-        LOGGER.warning("fetch_jina_unexpected_error", url=url, reason=str(exc))
+        LOGGER.warning("fetch_jina_unexpected_error", url=redact_url(url), reason=str(exc))
         return _failure(
             url=url,
             reader_url=reader_url,
@@ -98,8 +100,8 @@ async def fetch(
 
     return {
         "ok": True,
-        "url": url,
-        "reader_url": reader_url,
+        "url": redact_url(url),
+        "reader_url": redact_url(reader_url),
         "markdown": markdown,
         "metadata": _metadata(
             status=status_code,
@@ -139,8 +141,8 @@ def _failure(
 ) -> FetchJinaResult:
     result: FetchJinaResult = {
         "ok": False,
-        "url": url,
-        "reader_url": reader_url,
+        "url": redact_url(url),
+        "reader_url": redact_url(reader_url),
         "markdown": None,
         "reason": reason,
         "message": message,

--- a/autosearch/skills/tools/video-to-text-groq/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-groq/transcribe.py
@@ -10,6 +10,8 @@ from urllib.parse import urlparse
 import httpx
 import structlog
 
+from autosearch.core.redact import redact_url
+
 LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="video-to-text-groq")
 
 DEFAULT_TIMEOUT_SECONDS = 120.0
@@ -95,7 +97,11 @@ def transcribe(
             http_client=http_client,
         )
     except YtDlpError as exc:
-        LOGGER.warning("video_to_text_groq_yt_dlp_failed", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_groq_yt_dlp_failed",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="yt_dlp_failed",
@@ -103,24 +109,36 @@ def transcribe(
         )
     except subprocess.CalledProcessError as exc:
         stderr_tail = _stderr_tail(exc.stderr)
-        LOGGER.warning("video_to_text_groq_yt_dlp_failed", source=url_or_path, reason=stderr_tail)
+        LOGGER.warning(
+            "video_to_text_groq_yt_dlp_failed",
+            source=redact_url(url_or_path),
+            reason=stderr_tail,
+        )
         return _failure(
             source=url_or_path,
             reason="yt_dlp_failed",
             stderr_tail=stderr_tail,
         )
     except FFmpegMissingError:
-        LOGGER.warning("video_to_text_groq_ffmpeg_missing", source=url_or_path)
+        LOGGER.warning("video_to_text_groq_ffmpeg_missing", source=redact_url(url_or_path))
         return _failure(source=url_or_path, reason="ffmpeg_missing")
     except FFmpegFailedError as exc:
-        LOGGER.warning("video_to_text_groq_ffmpeg_failed", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_groq_ffmpeg_failed",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="ffmpeg_failed",
             stderr_tail=exc.stderr_tail,
         )
     except httpx.HTTPError as exc:
-        LOGGER.warning("video_to_text_groq_http_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_groq_http_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="groq_api_error",
@@ -128,14 +146,22 @@ def transcribe(
             body=_truncate_body(str(exc) or exc.__class__.__name__),
         )
     except OSError as exc:
-        LOGGER.warning("video_to_text_groq_local_file_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_groq_local_file_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="local_file_error",
             message=str(exc) or exc.__class__.__name__,
         )
     except Exception as exc:  # pragma: no cover - defensive boundary for runtime tools
-        LOGGER.warning("video_to_text_groq_unexpected_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_groq_unexpected_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="unexpected_error",
@@ -160,7 +186,11 @@ def transcribe(
     try:
         payload = response.json()
     except ValueError as exc:
-        LOGGER.warning("video_to_text_groq_invalid_json", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_groq_invalid_json",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="groq_api_error",
@@ -181,7 +211,7 @@ def transcribe(
             "backend": GROQ_BACKEND,
         },
         "audio_path": audio_path,
-        "source": url_or_path,
+        "source": redact_url(url_or_path),
     }
 
 
@@ -366,6 +396,6 @@ def _truncate_body(body: str, *, max_chars: int = 500) -> str:
 
 
 def _failure(*, source: str, reason: str, **extra: object) -> VideoToTextGroqResult:
-    result: VideoToTextGroqResult = {"ok": False, "source": source, "reason": reason}
+    result: VideoToTextGroqResult = {"ok": False, "source": redact_url(source), "reason": reason}
     result.update(extra)
     return result

--- a/autosearch/skills/tools/video-to-text-local/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-local/transcribe.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 
 import structlog
 
+from autosearch.core.redact import redact_url
+
 LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="video-to-text-local")
 
 DEFAULT_MODEL = "mlx-community/whisper-large-v3-turbo"
@@ -86,24 +88,40 @@ def transcribe(
     try:
         audio_path = _prepare_audio(url_or_path)
     except YtDlpError as exc:
-        LOGGER.warning("video_to_text_local_yt_dlp_failed", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_local_yt_dlp_failed",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(source=url_or_path, reason="yt_dlp_failed", stderr_tail=exc.stderr_tail)
     except subprocess.CalledProcessError as exc:
         stderr_tail = _stderr_tail(exc.stderr)
-        LOGGER.warning("video_to_text_local_yt_dlp_failed", source=url_or_path, reason=stderr_tail)
+        LOGGER.warning(
+            "video_to_text_local_yt_dlp_failed",
+            source=redact_url(url_or_path),
+            reason=stderr_tail,
+        )
         return _failure(source=url_or_path, reason="yt_dlp_failed", stderr_tail=stderr_tail)
     except FFmpegMissingError:
-        LOGGER.warning("video_to_text_local_ffmpeg_missing", source=url_or_path)
+        LOGGER.warning("video_to_text_local_ffmpeg_missing", source=redact_url(url_or_path))
         return _failure(source=url_or_path, reason="ffmpeg_missing")
     except FFmpegFailedError as exc:
-        LOGGER.warning("video_to_text_local_ffmpeg_failed", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_local_ffmpeg_failed",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="ffmpeg_failed",
             stderr_tail=exc.stderr_tail,
         )
     except OSError as exc:
-        LOGGER.warning("video_to_text_local_local_file_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_local_local_file_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="local_file_error",
@@ -114,7 +132,9 @@ def transcribe(
         payload = mlx.transcribe(audio_path, path_or_hf_repo=model)
     except ModelDownloadError as exc:
         LOGGER.warning(
-            "video_to_text_local_model_download_failed", source=url_or_path, reason=str(exc)
+            "video_to_text_local_model_download_failed",
+            source=redact_url(url_or_path),
+            reason=str(exc),
         )
         return _failure(
             source=url_or_path,
@@ -123,7 +143,11 @@ def transcribe(
             suggest="检查网络并重试，或预先下载模型到 ~/.cache/huggingface/hub/",
         )
     except Exception as exc:  # pragma: no cover - defensive boundary for runtime tools
-        LOGGER.warning("video_to_text_local_runtime_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_local_runtime_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="mlx_whisper_runtime_error",
@@ -143,7 +167,7 @@ def transcribe(
             "backend": LOCAL_BACKEND,
         },
         "audio_path": audio_path,
-        "source": url_or_path,
+        "source": redact_url(url_or_path),
     }
 
 
@@ -300,6 +324,6 @@ def _stderr_tail(stderr: object, *, max_chars: int = 1000) -> str:
 
 
 def _failure(*, source: str, reason: str, **extra: object) -> VideoToTextLocalResult:
-    result: VideoToTextLocalResult = {"ok": False, "source": source, "reason": reason}
+    result: VideoToTextLocalResult = {"ok": False, "source": redact_url(source), "reason": reason}
     result.update(extra)
     return result

--- a/autosearch/skills/tools/video-to-text-openai/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-openai/transcribe.py
@@ -10,6 +10,8 @@ from urllib.parse import urlparse
 import httpx
 import structlog
 
+from autosearch.core.redact import redact_url
+
 LOGGER = structlog.get_logger(__name__).bind(component="tool", skill="video-to-text-openai")
 
 DEFAULT_TIMEOUT_SECONDS = 120.0
@@ -95,7 +97,11 @@ def transcribe(
             http_client=http_client,
         )
     except YtDlpError as exc:
-        LOGGER.warning("video_to_text_openai_yt_dlp_failed", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_openai_yt_dlp_failed",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="yt_dlp_failed",
@@ -103,24 +109,36 @@ def transcribe(
         )
     except subprocess.CalledProcessError as exc:
         stderr_tail = _stderr_tail(exc.stderr)
-        LOGGER.warning("video_to_text_openai_yt_dlp_failed", source=url_or_path, reason=stderr_tail)
+        LOGGER.warning(
+            "video_to_text_openai_yt_dlp_failed",
+            source=redact_url(url_or_path),
+            reason=stderr_tail,
+        )
         return _failure(
             source=url_or_path,
             reason="yt_dlp_failed",
             stderr_tail=stderr_tail,
         )
     except FFmpegMissingError:
-        LOGGER.warning("video_to_text_openai_ffmpeg_missing", source=url_or_path)
+        LOGGER.warning("video_to_text_openai_ffmpeg_missing", source=redact_url(url_or_path))
         return _failure(source=url_or_path, reason="ffmpeg_missing")
     except FFmpegFailedError as exc:
-        LOGGER.warning("video_to_text_openai_ffmpeg_failed", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_openai_ffmpeg_failed",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="ffmpeg_failed",
             stderr_tail=exc.stderr_tail,
         )
     except httpx.HTTPError as exc:
-        LOGGER.warning("video_to_text_openai_http_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_openai_http_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="openai_api_error",
@@ -128,14 +146,22 @@ def transcribe(
             body=_truncate_body(str(exc) or exc.__class__.__name__),
         )
     except OSError as exc:
-        LOGGER.warning("video_to_text_openai_local_file_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_openai_local_file_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="local_file_error",
             message=str(exc) or exc.__class__.__name__,
         )
     except Exception as exc:  # pragma: no cover - defensive boundary for runtime tools
-        LOGGER.warning("video_to_text_openai_unexpected_error", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_openai_unexpected_error",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="unexpected_error",
@@ -160,7 +186,11 @@ def transcribe(
     try:
         payload = response.json()
     except ValueError as exc:
-        LOGGER.warning("video_to_text_openai_invalid_json", source=url_or_path, reason=str(exc))
+        LOGGER.warning(
+            "video_to_text_openai_invalid_json",
+            source=redact_url(url_or_path),
+            reason=str(exc),
+        )
         return _failure(
             source=url_or_path,
             reason="openai_api_error",
@@ -181,7 +211,7 @@ def transcribe(
             "backend": OPENAI_BACKEND,
         },
         "audio_path": audio_path,
-        "source": url_or_path,
+        "source": redact_url(url_or_path),
     }
 
 
@@ -366,6 +396,6 @@ def _truncate_body(body: str, *, max_chars: int = 500) -> str:
 
 
 def _failure(*, source: str, reason: str, **extra: object) -> VideoToTextOpenAIResult:
-    result: VideoToTextOpenAIResult = {"ok": False, "source": source, "reason": reason}
+    result: VideoToTextOpenAIResult = {"ok": False, "source": redact_url(source), "reason": reason}
     result.update(extra)
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autosearch"
-version = "2026.04.25.10"
+version = "2026.04.25.11"
 description = "MCP research tool supplier for coding agents, with 39 academic, web, developer, and Chinese-source channels"
 readme = "README.md"
 license = "MIT"

--- a/tests/tools/test_url_leak_prevention.py
+++ b/tests/tools/test_url_leak_prevention.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import httpx
+import pytest
+
+from autosearch.core.models import SubQuery
+
+ROOT = Path(__file__).resolve().parents[2]
+SECRET_TOKEN = "P0_SECRET_TOKEN_1234567890"
+SECRET_SIG = "X_AMZ_SECRET_SIG"
+SIGNED_URL = (
+    f"https://example.com/video.mp4?access_token={SECRET_TOKEN}&X-Amz-Signature={SECRET_SIG}"
+)
+
+
+class TimeoutClient:
+    async def get(self, *_args: object, **_kwargs: object) -> httpx.Response:
+        raise httpx.TimeoutException("timed out")
+
+    async def post(self, *_args: object, **_kwargs: object) -> httpx.Response:
+        raise httpx.TimeoutException("timed out")
+
+
+class SyncTimeoutClient:
+    def post(self, *_args: object, **_kwargs: object) -> httpx.Response:
+        raise httpx.TimeoutException("timed out")
+
+
+def _load_tool(tool_key: str, relative_path: str) -> ModuleType:
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(f"{tool_key}_leak_under_test", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _audio_file(tmp_path: Path) -> str:
+    path = tmp_path / "audio.mp3"
+    path.write_bytes(b"fake mp3")
+    return str(path)
+
+
+def _run_fetch_jina(_monkeypatch: pytest.MonkeyPatch, _tmp_path: Path) -> Any:
+    module = _load_tool("fetch_jina", "autosearch/skills/tools/fetch-jina/fetch.py")
+    return asyncio.run(module.fetch(SIGNED_URL, http_client=TimeoutClient()))
+
+
+def _run_fetch_crawl4ai(_monkeypatch: pytest.MonkeyPatch, _tmp_path: Path) -> Any:
+    module = _load_tool("fetch_crawl4ai", "autosearch/skills/tools/fetch-crawl4ai/fetch.py")
+
+    class CacheMode:
+        BYPASS = object()
+
+    class BrowserConfig:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+    class CrawlerRunConfig:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+    class AsyncWebCrawler:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "AsyncWebCrawler":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def arun(self, *_args: object, **_kwargs: object) -> object:
+            raise TimeoutError("timed out")
+
+    crawl4ai = ModuleType("crawl4ai")
+    crawl4ai.CacheMode = CacheMode
+    crawl4ai.BrowserConfig = BrowserConfig
+    crawl4ai.CrawlerRunConfig = CrawlerRunConfig
+    crawl4ai.AsyncWebCrawler = AsyncWebCrawler
+    return module.fetch(SIGNED_URL, crawl4ai_module=crawl4ai)
+
+
+def _run_fetch_firecrawl(monkeypatch: pytest.MonkeyPatch, _tmp_path: Path) -> Any:
+    module = _load_tool(
+        "fetch_firecrawl", "autosearch/skills/tools/fetch-firecrawl/methods/scrape.py"
+    )
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"data": {"markdown": "body", "metadata": {}}}
+
+    class AsyncClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "AsyncClient":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def post(self, *_args: object, **_kwargs: object) -> Response:
+            return Response()
+
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "test-key")
+    monkeypatch.setattr(module.httpx, "AsyncClient", AsyncClient)
+    result = asyncio.run(module.search(SubQuery(text=SIGNED_URL, rationale="leak test")))
+    return [item.model_dump(mode="json") for item in result]
+
+
+def _run_video_openai(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    module = _load_tool(
+        "video_openai", "autosearch/skills/tools/video-to-text-openai/transcribe.py"
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(module, "_prepare_audio", lambda _source: _audio_file(tmp_path))
+    return module.transcribe(SIGNED_URL, http_client=SyncTimeoutClient())
+
+
+def _run_video_groq(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    module = _load_tool("video_groq", "autosearch/skills/tools/video-to-text-groq/transcribe.py")
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    monkeypatch.setattr(module, "_prepare_audio", lambda _source: _audio_file(tmp_path))
+    return module.transcribe(SIGNED_URL, http_client=SyncTimeoutClient())
+
+
+def _run_video_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    module = _load_tool("video_local", "autosearch/skills/tools/video-to-text-local/transcribe.py")
+    monkeypatch.setattr(module, "_prepare_audio", lambda _source: _audio_file(tmp_path))
+
+    class MlxWhisper:
+        @staticmethod
+        def transcribe(*_args: object, **_kwargs: object) -> dict[str, object]:
+            raise module.ModelDownloadError("offline")
+
+    return module.transcribe(SIGNED_URL, mlx_whisper_module=MlxWhisper)
+
+
+@pytest.mark.parametrize(
+    ("tool_key", "runner"),
+    [
+        ("fetch_jina", _run_fetch_jina),
+        ("fetch_crawl4ai", _run_fetch_crawl4ai),
+        ("fetch_firecrawl", _run_fetch_firecrawl),
+        ("video_openai", _run_video_openai),
+        ("video_groq", _run_video_groq),
+        ("video_local", _run_video_local),
+    ],
+    ids=[
+        "fetch_jina_leak",
+        "fetch_crawl4ai_leak",
+        "fetch_firecrawl_leak",
+        "video_openai_leak",
+        "video_groq_leak",
+        "video_local_leak",
+    ],
+)
+def test_tool_does_not_leak_url_secrets(
+    tool_key: str,
+    runner: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result = runner(monkeypatch, tmp_path)
+    serialized = json.dumps(result, sort_keys=True)
+    assert tool_key
+    assert SECRET_TOKEN not in serialized
+    assert SECRET_SIG not in serialized

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from autosearch.core.redact import redact
+import pytest
+
+from autosearch.core.redact import redact, redact_url
 
 
 def test_redact_bearer_token_with_plus_slash_equals_redacts_full_token() -> None:
@@ -73,3 +75,74 @@ def test_redact_common_cookie_env_assignment() -> None:
     out = redact("SESSDATA=xyz; _uuid=abc")
 
     assert out == "SESSDATA=[REDACTED]; _uuid=[REDACTED]"
+
+
+@pytest.mark.parametrize(
+    "query_key",
+    [
+        "access_token",
+        "X-Amz-Signature",
+        "X-Amz-Credential",
+        "sig",
+        "token",
+        "expires",
+    ],
+)
+def test_redact_url_strips_high_risk_query_key_values(query_key: str) -> None:
+    url = f"https://example.com/path?{query_key}=SECRET_VALUE_PLACEHOLDER"
+
+    out = redact_url(url)
+
+    assert "SECRET_VALUE_PLACEHOLDER" not in out
+    assert out == "https://example.com/path"
+
+
+def test_redact_url_without_query_is_unchanged() -> None:
+    url = "https://example.com/path"
+
+    assert redact_url(url) == url
+
+
+def test_redact_url_preserves_fragment_after_stripping_query() -> None:
+    out = redact_url("https://example.com/path?token=SECRET_VALUE_PLACEHOLDER#foo")
+
+    assert out == "https://example.com/path#foo"
+
+
+def test_redact_url_preserves_port_after_stripping_query() -> None:
+    out = redact_url("https://example.com:8080/path?token=SECRET_VALUE_PLACEHOLDER")
+
+    assert out == "https://example.com:8080/path"
+
+
+def test_redact_url_strips_multiple_query_keys() -> None:
+    out = redact_url(
+        "https://example.com/path?token=SECRET_VALUE_PLACEHOLDER&expires=123&safe=value"
+    )
+
+    assert "SECRET_VALUE_PLACEHOLDER" not in out
+    assert "expires=123" not in out
+    assert "safe=value" not in out
+    assert out == "https://example.com/path"
+
+
+@pytest.mark.parametrize("scheme", ["https", "http"])
+def test_redact_url_strips_query_for_http_and_https_variants(scheme: str) -> None:
+    out = redact_url(f"{scheme}://example.com/path?token=SECRET_VALUE_PLACEHOLDER")
+
+    assert out == f"{scheme}://example.com/path"
+
+
+def test_redact_url_empty_string_is_unchanged() -> None:
+    assert redact_url("") == ""
+
+
+def test_redact_url_none_input_raises_type_error() -> None:
+    with pytest.raises(TypeError):
+        redact_url(None)  # type: ignore[arg-type]
+
+
+def test_redact_url_malformed_url_returns_as_is() -> None:
+    url = "http://[::1"
+
+    assert redact_url(url) == url


### PR DESCRIPTION
## Summary

Closes **P0-2** from `docs/exec-plans/active/autosearch-0425-p0-scan-report.md`: signed-URL query parameters (`access_token`, `X-Amz-Signature`, `X-Amz-Credential`, `sig`, `token`, `expires`) leak into MCP tool output and structured logs across 6 tools.

- **New helper**: `redact_url(url, *, strip_query=True)` in `autosearch/core/redact.py` — drops the entire query string by default, preserves scheme / host / port / path / fragment via stdlib `urllib.parse`.
- **Wired in 6 tools at the output boundary** (return fields + log calls): `fetch-jina`, `fetch-crawl4ai`, `fetch-firecrawl`, `video-to-text-openai`, `video-to-text-groq`, `video-to-text-local`.
- **Integration test** `tests/tools/test_url_leak_prevention.py` — 6 parametrized scenarios exercise each tool with a URL containing `P0_SECRET_TOKEN_…` and assert the secret never appears in `json.dumps(result)`.
- **Rollup of #406**: that PR bumped `plugin.json` / `marketplace.json` / `CHANGELOG` to `2026.04.25.11` but missed `pyproject.toml`, leaving `tests/unit/test_static_checks.py::test_version_consistency` red on main. This PR syncs `pyproject.toml` and ships everything as `2026.04.25.11`.

## Test plan

- [x] \`pytest tests/tools/test_url_leak_prevention.py -x -q\` → 6/6 pass
- [x] \`pytest tests/unit/ tests/smoke/ tests/tools/ -x -q -m "not real_llm and not slow and not network"\` → 663 passed, 3 skipped
- [x] \`pytest tests/unit/test_redact.py -k "url" -x -q\` → 15 pass
- [x] \`pytest tests/unit/test_static_checks.py::test_version_consistency\` → pass
- [x] \`ruff check && ruff format --check\` → clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)