### PR TITLE
fix(hygiene): enable full content scan in CI + allowlist 3 docs that describe the rule (P0-3)

### DIFF
--- a/.github/workflows/public-hygiene.yml
+++ b/.github/workflows/public-hygiene.yml
@@ -22,8 +22,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Run path-level hygiene check
-        # `--paths-only` until batch 3 finishes rewriting docs that still
-        # carry internal voice. Once the doc rewrites land, drop the flag
-        # so content rules also gate.
-        run: python scripts/validate/public_repo_hygiene.py --paths-only
+      - name: Run full hygiene check (path + content rules)
+        # Full scan: path rules + content rules. Content rules include the
+        # `dangerously-skip-permissions` regex. Docs that legitimately
+        # describe the rule (3 hygiene docs under docs/) are allowlisted in
+        # `scripts/validate/public_repo_hygiene.py` itself.
+        run: python scripts/validate/public_repo_hygiene.py --tracked

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -53,7 +53,9 @@ fi
 
 # Public-repo hygiene content check — flag dangerous flags / unsafe shortcuts
 # (Markdown docs included — these strings should never appear in published docs)
-HYGIENE_CONTENT_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.gitleaks\.toml$|\.husky/|\.github/workflows/|docs/exec-plans/)' || true)
+# Allowlist must mirror scripts/validate/public_repo_hygiene.py CONTENT_RULES
+# allowlist_paths: files that legitimately describe the rule by literal name.
+HYGIENE_CONTENT_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v -E '(\.gitleaks\.toml$|\.husky/|\.github/workflows/|docs/exec-plans/|^tests/.*\.(py|yaml|yml)$|^scripts/validate/public_repo_hygiene\.py$|^docs/internal-docs\.md$|^docs/public-repo-policy\.md$|^docs/security/hygiene-verify\.md$)' || true)
 if [ -n "$HYGIENE_CONTENT_FILES" ]; then
   HYGIENE_MATCHES=$(echo "$HYGIENE_CONTENT_FILES" | while IFS= read -r f; do grep -nEH 'dangerously-skip-permissions' "$f" 2>/dev/null; done || true)
   if [ -n "$HYGIENE_MATCHES" ]; then

--- a/scripts/validate/public_repo_hygiene.py
+++ b/scripts/validate/public_repo_hygiene.py
@@ -82,6 +82,10 @@ CONTENT_RULES: tuple[Rule, ...] = (
             re.compile(r"^\.husky/"),
             re.compile(r"^\.github/workflows/"),
             re.compile(r"^scripts/validate/public_repo_hygiene\.py$"),
+            # Hygiene docs that legitimately describe the rule by literal name.
+            re.compile(r"^docs/internal-docs\.md$"),
+            re.compile(r"^docs/public-repo-policy\.md$"),
+            re.compile(r"^docs/security/hygiene-verify\.md$"),
         ),
     ),
 )


### PR DESCRIPTION
## Summary

Closes **P0-3** from `docs/exec-plans/active/autosearch-0425-p0-scan-report.md`: the public-hygiene CI workflow ran with `--paths-only`, so the `dangerously-skip-permissions` content rule never gated PRs/main. Three docs (`docs/internal-docs.md`, `docs/public-repo-policy.md`, `docs/security/hygiene-verify.md`) contained the literal — these docs **describe the rule itself** and need the literal to be readable.

- **`.github/workflows/public-hygiene.yml`**: dropped `--paths-only`; CI now runs the full path + content scan.
- **`scripts/validate/public_repo_hygiene.py`**: added 3 hygiene-doc paths to the existing `CONTENT_RULES.allowlist_paths` (same pattern that already allowlists `tests/`, `.gitleaks.toml`, `.husky/`, `.github/workflows/`, and the script itself). The docs that **define** the rule by name are legitimately allowed to contain it.
- **`.husky/pre-commit`**: synced the inline `grep -v` exclusion to mirror the script's allowlist, so local commits and CI agree on which paths can carry the literal.

## Why allowlist instead of rewriting the docs

The 3 docs are: (a) `internal-docs.md` listing what's blocked, (b) `public-repo-policy.md` documenting what AutoSearch refuses to publish, (c) `security/hygiene-verify.md` showing a runnable `git grep` command that contains the regex pattern. All three need the literal string to remain useful. Rewriting them as "the dangerous skip-permissions flag" loses information the maintainer needs when triaging a real violation. The allowlist mirror is the same pattern already established for tests and the script itself.

## Test plan

- [x] \`pytest tests/unit/test_public_repo_hygiene.py -x -q\` → 15/15 pass
- [x] \`pytest tests/unit/ tests/smoke/ -x -q -m "not real_llm and not slow and not network"\` → 657 passed, 3 skipped
- [x] \`python scripts/validate/public_repo_hygiene.py --tracked\` → \`OK: 639 tracked files clean\`
- [x] \`npm run public:hygiene\` → same clean result (CI parity)
- [ ] CI green (this PR's hygiene workflow now runs the full scan against itself — should still pass because the new allowlist covers the 3 docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)