### PR TITLE
test(video-to-text): align source assertion with P0-2 sanitization (unblocks main CI)

### DIFF
--- a/tests/skills/tools/video_to_text_groq/test_video_to_text_groq.py
+++ b/tests/skills/tools/video_to_text_groq/test_video_to_text_groq.py
@@ -76,7 +76,9 @@ def test_url_happy_path_returns_text_srt_metadata(
         "backend": "groq",
     }
     assert result["audio_path"] == str(fake_mp3)
-    assert result["source"] == "https://www.youtube.com/watch?v=example"
+    # P0-2: source URL is sanitized via redact_url — query string stripped
+    # to avoid leaking signed-URL credentials (access_token, X-Amz-Signature, …).
+    assert result["source"] == "https://www.youtube.com/watch"
 
 
 def test_local_audio_happy_path_skips_yt_dlp(

--- a/tests/skills/tools/video_to_text_local/test_video_to_text_local.py
+++ b/tests/skills/tools/video_to_text_local/test_video_to_text_local.py
@@ -70,7 +70,9 @@ def test_url_happy_path_returns_text_srt_metadata(
         "backend": "mlx-whisper",
     }
     assert result["audio_path"] == str(fake_mp3)
-    assert result["source"] == "https://www.youtube.com/watch?v=example"
+    # P0-2: source URL is sanitized via redact_url — query string stripped
+    # to avoid leaking signed-URL credentials (access_token, X-Amz-Signature, …).
+    assert result["source"] == "https://www.youtube.com/watch"
     assert captured["audio_path"] == str(fake_mp3)
     assert captured["model"] == "mlx-community/whisper-large-v3-turbo"
 

--- a/tests/skills/tools/video_to_text_openai/test_video_to_text_openai.py
+++ b/tests/skills/tools/video_to_text_openai/test_video_to_text_openai.py
@@ -78,7 +78,9 @@ def test_url_happy_path_returns_text_srt_metadata(
         "backend": "openai",
     }
     assert result["audio_path"] == str(fake_mp3)
-    assert result["source"] == "https://www.youtube.com/watch?v=example"
+    # P0-2: source URL is sanitized via redact_url — query string stripped
+    # to avoid leaking signed-URL credentials (access_token, X-Amz-Signature, …).
+    assert result["source"] == "https://www.youtube.com/watch"
 
 
 def test_local_audio_happy_path_skips_yt_dlp(


### PR DESCRIPTION
## Summary

**Unblocks main**: PR #408 (P0-2 redact_url) introduced `redact_url()` that strips query strings from `source` URLs in fetch/video tools, but 3 existing tests in \`tests/skills/tools/video_to_text_{groq,openai,local}/\` still asserted the **un-sanitized** URL. They've been red on main since #408 merged.

This PR updates those 3 assertions to match the new (correct) sanitized contract: \`source\` no longer echoes back signed-URL credentials.

## Why this slipped past PR #408 CI

PR #408's pre-push verification ran \`tests/unit/ tests/smoke/ tests/tools/\`, missing \`tests/skills/\` where these regression tests live. CI on PR #408 caught it but auto-merge proceeded anyway because branch protection on main has \`required_status_checks.contexts: []\` — no checks are gated, so the auto-merge workflow's \`gh pr merge --auto\` immediately merges instead of waiting for green.

(Branch-protection / auto-merge fix to be filed as a follow-up — that's a separate concern from unblocking main.)

## Test plan

- [x] \`pytest tests/ -q -m "not real_llm and not slow and not network" --ignore=tests/e2b --ignore=tests/eval --ignore=tests/perf --ignore=tests/feasibility\` → 1066 passed, 3 skipped
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)