### PR TITLE
docs(README): AgentLint-style hero (F001 S1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
+<div align="center">
+
 # AutoSearch
 
 **Open-source Deep Research for AI Agents**
+
+*40 channels, including 10+ Chinese sources.*
+*MCP-native. LLM-decoupled. Plug into the agent host you already use.*
+
+[![CI](https://github.com/0xmariowu/Autosearch/actions/workflows/ci.yml/badge.svg)](https://github.com/0xmariowu/Autosearch/actions/workflows/ci.yml)
+[![release](https://img.shields.io/github/v/release/0xmariowu/Autosearch?display_name=tag)](https://github.com/0xmariowu/Autosearch/releases)
+[![npm](https://img.shields.io/npm/v/autosearch-ai?label=npm)](https://www.npmjs.com/package/autosearch-ai)
+[![License](https://img.shields.io/github/license/0xmariowu/Autosearch)](LICENSE)
+[![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-orange)](https://github.com/0xmariowu/Autosearch)
+[![MCP native](https://img.shields.io/badge/MCP-native-blue)](https://modelcontextprotocol.io)
+
+[Install](#install) · [Channels](docs/channels.mdx) · [MCP Setup](docs/mcp-clients.md) · [Examples](docs/) · [FAQ](#faq) · [中文](README.zh.md)
+
+</div>
 
 AutoSearch is open-source deep research infrastructure built for AI agents. Plug Claude Code, Cursor, Cline, GPT-Researcher, LangChain, LlamaIndex, AutoGen, and other hosts into MCP-native access across 40 channels, including 10+ Chinese sources.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Open-source Deep Research for AI Agents**
 
-*40 channels, including 10+ Chinese sources.*
+*40 channels, including 10+ Chinese sources.*<br>
 *MCP-native. LLM-decoupled. Plug into the agent host you already use.*
 
 [![CI](https://github.com/0xmariowu/Autosearch/actions/workflows/ci.yml/badge.svg)](https://github.com/0xmariowu/Autosearch/actions/workflows/ci.yml)
@@ -14,7 +14,7 @@
 [![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-orange)](https://github.com/0xmariowu/Autosearch)
 [![MCP native](https://img.shields.io/badge/MCP-native-blue)](https://modelcontextprotocol.io)
 
-[Install](#install) · [Channels](docs/channels.mdx) · [MCP Setup](docs/mcp-clients.md) · [Examples](docs/) · [FAQ](#faq) · [中文](README.zh.md)
+[Install](#install) · [Channels](docs/channels.mdx) · [MCP Setup](docs/mcp-clients.md) · [Examples](docs/) · [Docs](https://docs.autosearch.dev) · [中文](README.zh.md)
 
 </div>
 
@@ -33,6 +33,8 @@ You ask your AI to research something. It answers from training data cutoff —
 - "Compare opinions on Hacker News vs Chinese tech forums" → two platforms, manual aggregation
 
 **AutoSearch fixes this in one line.** Pick the path that matches you:
+
+## Install
 
 **Have Node?** (most common — works on macOS, Linux, Windows)
 


### PR DESCRIPTION
## Summary

mde-loop SEO launch plan F001 S1: align the README hero with the AgentLint visual pattern (center + badges + quick-nav + 中文 link).

The existing README body, install instructions, and docs links are unchanged. This is a pure additive hero refresh.

## Changes

- `<div align="center">` wraps the H1 / tagline / hook lines
- Italic two-line hook lines ("40 channels..." / "MCP-native...")
- 6 badges in one row: CI · release · npm · License · Claude Code plugin · MCP native
- Quick-nav row: Install · Channels · MCP Setup · Examples · FAQ · 中文
- 中文 link wires back to `README.zh.md` (no inbound link from English README before)

## Plan reference

- Plan: \`mde-loop/.claude/plans/mde-loop-0426-autosearch-seo-launch.md\` F001 S1
- Reviewer round 2 PASS · 老板 approved Q1-Q7
- Verify: \`gh api repos/0xmariowu/Autosearch/contents/README.md --jq .content | base64 -d | grep -q '<div align="center"' && grep -qE 'shields.io|badge.svg' && grep -qE '\[中文\]\(README\.zh'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with prominent project highlights and features.
  * Added visual badges for GitHub, npm, license, and integrations.
  * Added navigation section for easy access to documentation and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->