### PR TITLE
fix(hygiene): add gitleaks rule for autosearch-signsrv access tokens (as_hex32)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -84,6 +84,17 @@ keywords = ["docs/plans", "docs/proposals", "docs/spikes", "docs/channel-hunt", 
   paths = ['''^CHANGELOG\.md$''', '''docs/migration/.*\.md$''', '''docs/testing/TEST_PLAN\.md$''', '''docs/delivery-status\.md$''']
 
 [[rules]]
+id = "autosearch-signsrv-token"
+description = "AutoSearch signsrv access token (as_<hex32>) — KV-backed worker auth, must not appear in public files"
+regex = '''\bas_[a-f0-9]{32}\b'''
+tags = ["secret", "signsrv-token"]
+keywords = ["as_"]
+
+  [[rules.allowlists]]
+  description = "This rule file legitimately documents the token format"
+  paths = ['''^\.gitleaks\.toml$''']
+
+[[rules]]
 id = "runtime-experience-jsonl"
 description = "Runtime experience JSONL files should never be tracked (patterns-jsonl)"
 regex = '''experience/patterns\.jsonl'''


### PR DESCRIPTION
## Summary

A historical leak (`as_14cec8a1d495e3ff34470abb0f37c2ea`) sat in three pre-hygiene commits before the gate existed. Investigation today (2026-04-26) found the leaked token is **already dead**: \`TOKENS_KV\` is empty, so the worker's \`!tokenData\` branch returns \`invalid_token\` for any \`as_*\` token — the leaked string is toothless.

But the **pattern** is the right thing to gate going forward. Anyone (or any AI) who writes a fresh \`as_<hex32>\` into a tracked file from now on will be blocked at gitleaks.

## Rule

\`\`\`toml
[[rules]]
id = "autosearch-signsrv-token"
description = "AutoSearch signsrv access token (as_<hex32>) — KV-backed worker auth, must not appear in public files"
regex = '''\bas_[a-f0-9]{32}\b'''
tags = ["secret", "signsrv-token"]
keywords = ["as_"]
\`\`\`

Allowlist: \`.gitleaks.toml\` itself (it documents the pattern by example).

## Test plan

- [x] Local probe: \`echo "as_14cec8a1d495e3ff34470abb0f37c2ea" | gitleaks detect --config .gitleaks.toml --no-git\` → \`leaks found: 1\` ✅
- [ ] CI gitleaks workflow green on this PR (no leak should be introduced by the rule itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced secret detection with improved pattern matching for identifying sensitive tokens in repository commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->