### PR TITLE
feat(xhs): add AccountRestrictedError + upgrade 300011 raise sites (F001)

### DIFF
--- a/autosearch/channels/base.py
+++ b/autosearch/channels/base.py
@@ -49,6 +49,14 @@ class ChannelAuthError(PermanentError):
     "no matches" (Bug 1 / fix-plan)."""
 
 
+class AccountRestrictedError(ChannelAuthError):
+    """Raised when a search returned no results because the account itself
+    is flagged/restricted upstream (e.g. XHS code=300011), distinct from a
+    generic ChannelAuthError (which means missing/expired credentials). The
+    fallback chain treats both the same -- switch to the next method -- but
+    the host agent surface gets a more actionable message."""
+
+
 class BudgetExhausted(PermanentError):
     """Raised when an upstream rejects the request because the caller's paid
     quota / wallet is empty (TikHub 402, OpenAI insufficient_quota, etc).

--- a/autosearch/skills/channels/xiaohongshu/SKILL.md
+++ b/autosearch/skills/channels/xiaohongshu/SKILL.md
@@ -50,7 +50,7 @@ XHS applies two-tier account restriction enforcement:
 
 **Trigger**: New/unverified accounts, or accounts that triggered bot detection from excessive API calls.
 
-**Mitigation** (not yet implemented): When `via_signsrv` returns empty results, call `/api/sns/web/v2/user/me` to check account health. If `code=300011` is returned, surface `AccountRestrictedError` and prompt user to run `autosearch login xhs` with a different account.
+**Mitigation** (implemented): When `via_signsrv` returns empty results, the search path probes `/api/sns/web/v2/user/me`. If the probe returns `code=300011`, the channel raises `AccountRestrictedError` (a subclass of `ChannelAuthError`) — the fallback chain switches to `via_tikhub`, and downstream surfaces can distinguish "account flagged" from "missing/expired credentials". The same exception type is also raised on the inline `code=300011` path (when the search response itself returns 300011).
 
 **Workaround**: Use `autosearch login xhs` with a normal, actively-used XHS account. `via_tikhub` is unaffected (uses TikHub's own accounts).
 

--- a/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
@@ -181,17 +181,17 @@ async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> li
         payload = xhs_resp.json()
         xhs_code = payload.get("code", 0)
 
-        # code=300011: XHS account flagged. Surface as ChannelAuthError so the
+        # code=300011: XHS account flagged. Surface as AccountRestrictedError so the
         # user sees "your XHS account is restricted, run autosearch login xhs"
         # rather than a confusing empty result.
         if xhs_code == 300011:
-            from autosearch.channels.base import ChannelAuthError
+            from autosearch.channels.base import AccountRestrictedError
 
             LOGGER.warning(
                 "xhs_account_restricted",
                 reason="XHS account flagged (code=300011). Run 'autosearch login xhs' with a normal account.",
             )
-            raise ChannelAuthError(
+            raise AccountRestrictedError(
                 "XHS account flagged (code=300011). "
                 "Run 'autosearch login xhs' with a normal account."
             )
@@ -217,13 +217,13 @@ async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> li
                 pass  # health check failure is non-fatal; fall through to empty list
 
             if isinstance(me_payload, Mapping) and me_payload.get("code") == 300011:
-                from autosearch.channels.base import ChannelAuthError
+                from autosearch.channels.base import AccountRestrictedError
 
                 LOGGER.warning(
                     "xhs_account_restricted",
                     reason="XHS account flagged — search silently returns empty. Run 'autosearch login xhs' with a different account.",
                 )
-                raise ChannelAuthError(
+                raise AccountRestrictedError(
                     "XHS account flagged (code=300011). "
                     "Run 'autosearch login xhs' with a different account."
                 )

--- a/tests/unit/test_channels_base.py
+++ b/tests/unit/test_channels_base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from autosearch.channels.base import (
+    AccountRestrictedError,
+    ChannelAuthError,
+    PermanentError,
+)
+
+
+class TestAccountRestrictedError:
+    def test_is_channel_auth_error_and_permanent_error(self) -> None:
+        assert issubclass(AccountRestrictedError, ChannelAuthError)
+        assert issubclass(AccountRestrictedError, PermanentError)
+
+    def test_preserves_message(self) -> None:
+        exc = AccountRestrictedError("XHS account restricted: code=300011")
+
+        assert str(exc) == "XHS account restricted: code=300011"

--- a/tests/unit/test_xhs_signsrv_account_restriction.py
+++ b/tests/unit/test_xhs_signsrv_account_restriction.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from autosearch.channels.base import ChannelAuthError
+from autosearch.channels.base import AccountRestrictedError, ChannelAuthError
 from autosearch.core.models import SubQuery
 from autosearch.skills.channels.xiaohongshu.methods import via_signsrv
 
@@ -40,15 +40,35 @@ class _Client:
 
 
 @pytest.mark.asyncio
-async def test_xhs_signsrv_empty_search_with_me_300011_raises_channel_auth_error(
+async def test_xhs_signsrv_empty_search_with_me_300011_raises_account_restricted_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setitem(via_signsrv.__dict__, "_SIGNSRV_URL", "https://signsrv.example")
     monkeypatch.setitem(via_signsrv.__dict__, "_SERVICE_TOKEN", "as_test")
     monkeypatch.setitem(via_signsrv.__dict__, "_XHS_COOKIES", "a1=test-cookie")
 
-    with pytest.raises(ChannelAuthError, match="300011"):
+    with pytest.raises(AccountRestrictedError, match="300011"):
         await via_signsrv.search(
             SubQuery(text="防晒", rationale="Need XHS coverage"),
             client=_Client(),
         )
+
+
+@pytest.mark.asyncio
+async def test_xhs_signsrv_empty_search_with_me_300011_is_account_restricted_subclass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(via_signsrv.__dict__, "_SIGNSRV_URL", "https://signsrv.example")
+    monkeypatch.setitem(via_signsrv.__dict__, "_SERVICE_TOKEN", "as_test")
+    monkeypatch.setitem(via_signsrv.__dict__, "_XHS_COOKIES", "a1=test-cookie")
+
+    try:
+        await via_signsrv.search(
+            SubQuery(text="防晒", rationale="Need XHS coverage"),
+            client=_Client(),
+        )
+    except Exception as exc:
+        assert isinstance(exc, AccountRestrictedError)
+        assert isinstance(exc, ChannelAuthError)
+    else:
+        pytest.fail("Expected AccountRestrictedError")


### PR DESCRIPTION
## Summary

- Adds `AccountRestrictedError(ChannelAuthError)` typed exception for the XHS account-restriction case (`code=300011`)
- Upgrades two existing `raise ChannelAuthError(...)` sites in `via_signsrv.py` to use the more precise type — fallback chain still works (subclass of `ChannelAuthError`), but downstream surfaces can distinguish "account flagged" from "missing/expired credentials"
- Updates XHS `SKILL.md` § Known Issue to mark mitigation as implemented

## Background

Plan: `docs/exec-plans/active/autosearch-0426-xhs-account-restriction-detection.md` — F001 path B.

The plan author originally believed the empty-results health probe was unimplemented; we discovered (via grep + Read) that `via_signsrv.py:184-229` already had the inline mitigation, just raising the generic `ChannelAuthError`. Path B (advisor-confirmed) is the minimal-scope correction: keep S1's new precise type, upgrade the existing raise sites instead of extracting a helper just for testing's sake.

## Behavior preservation

`AccountRestrictedError` is a subclass of `ChannelAuthError`. Reviewer (`pr-review-toolkit:code-reviewer`) verified all consumer paths:

- `_CompiledChannel.search` fallback chain (`channels/base.py:208-216`) — `except ChannelAuthError` still matches; same recoverable-error handling
- `core/channel_status.py:49` — maps to `status="auth_failed"`, `reason` field includes class name → host agent now sees `AccountRestrictedError` instead of generic `ChannelAuthError`
- `xueqiu/methods/api_search.py` — short-circuit + priority-class logic both safe under subclass

## Test plan

- [x] New tests: `test_channels_base.py` asserts `AccountRestrictedError` ⊂ `ChannelAuthError` ⊂ `PermanentError` and message preservation
- [x] Updated test: `test_xhs_signsrv_account_restriction.py` asserts raised exception is `AccountRestrictedError` (not just base class)
- [x] New test in same file: `test_xhs_signsrv_empty_search_with_me_300011_is_account_restricted_subclass` — verifies actual instance is BOTH `AccountRestrictedError` AND `ChannelAuthError` (locks in subclass invariant)
- [x] Local fast suite: 649 passed, 0 regressions
- [x] Pre-push hook: 1076 passed
- [x] Code-reviewer: APPROVE