### PR TITLE
feat(cli): autosearch login xhs --check-health (F002)

### DIFF
--- a/autosearch/cli/main.py
+++ b/autosearch/cli/main.py
@@ -573,18 +573,31 @@ def login(
             help="Read the cookie string from stdin (avoids shell-history leak).",
         ),
     ] = False,
+    check_health: Annotated[
+        bool,
+        typer.Option(
+            "--check-health",
+            help=(
+                "Check cookie health (xhs only) by probing the me endpoint. "
+                "Skips cookie import. Exits 0 if healthy, 1 if account flagged."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Import cookies from your local browser — no copy-paste needed.
 
-    Three input modes (preferred → discouraged):
+    Four modes:
       1. Default: read cookies straight from the browser session.
       2. --stdin: pipe the cookie string in (no shell-history leak).
       3. --from-string: cookie on the command line (DEPRECATED — leaks).
+      4. --check-health: probe a previously imported cookie to see whether
+         the account is currently flagged (xhs only — code=300011).
 
     Examples:
         autosearch login xhs
         autosearch login twitter --browser firefox
         printf 'SESSDATA=xxx; bili_jct=yyy' | autosearch login bilibili --stdin
+        autosearch login xhs --check-health
 
     Supported platforms: xhs, twitter, bilibili, weibo, douyin, zhihu, xueqiu
     """
@@ -606,6 +619,16 @@ def login(
             err=True,
         )
         raise typer.Exit(code=1)
+
+    if check_health:
+        if platform != "xhs":
+            typer.echo(
+                "--check-health is currently only supported for xhs.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        _run_xhs_health_check()
+        return
 
     domains, env_key = _PLATFORM_SPECS[platform]
 
@@ -677,6 +700,65 @@ def login(
     cookie_str = "; ".join(f"{c['name']}={c['value']}" for c in raw)
     _write_cookie_to_secrets(env_key, cookie_str, platform, n_cookies=len(raw))
     typer.echo(f"Done. {platform} searches will now use your {browser} session.")
+
+
+def _run_xhs_health_check() -> None:
+    """Probe XHS me endpoint with the currently-configured cookies.
+
+    Exits 0 if the account is healthy; exits 1 if flagged (code=300011)
+    or if no cookies are configured.
+    """
+    import asyncio
+    import os
+
+    cookies = (
+        os.environ.get("XHS_COOKIES")
+        or os.environ.get("XIAOHONGSHU_COOKIES")
+        or os.environ.get("XHS_A1_COOKIE", "")
+    )
+    if not cookies:
+        typer.echo(
+            "No XHS_COOKIES found. Run `autosearch login xhs` first to import cookies.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    headers = {
+        "Cookie": cookies,
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        ),
+        "Referer": "https://www.xiaohongshu.com/",
+        "Accept": "application/json, text/plain, */*",
+    }
+
+    from autosearch.skills.channels.xiaohongshu.methods.via_signsrv import (
+        _check_account_health,
+    )
+
+    async def _probe() -> tuple[bool, str | None]:
+        async with httpx.AsyncClient(timeout=10) as client:
+            return await _check_account_health(client, headers)
+
+    healthy, code = asyncio.run(_probe())
+
+    if healthy:
+        typer.echo("OK: XHS cookies appear healthy (account not flagged).")
+        return
+
+    if code == "300011":
+        typer.echo(
+            "FLAGGED: XHS account is restricted (code=300011). "
+            "Re-run `autosearch login xhs` with a different account.",
+            err=True,
+        )
+    else:
+        typer.echo(
+            f"UNKNOWN: probe returned restricted with code={code}",
+            err=True,
+        )
+    raise typer.Exit(code=1)
 
 
 def _write_cookie_to_secrets(

--- a/autosearch/skills/channels/xiaohongshu/SKILL.md
+++ b/autosearch/skills/channels/xiaohongshu/SKILL.md
@@ -54,6 +54,8 @@ XHS applies two-tier account restriction enforcement:
 
 **Workaround**: Use `autosearch login xhs` with a normal, actively-used XHS account. `via_tikhub` is unaffected (uses TikHub's own accounts).
 
+**Proactive check**: `autosearch login xhs --check-health` probes the me endpoint with the currently-imported cookies and reports whether the account is flagged — without having to run a search. Exits 0 (healthy), 1 (flagged or missing cookies), 2 (unsupported platform).
+
 # Quality Bar
 
 - Evidence items have non-empty title and url.

--- a/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
+++ b/autosearch/skills/channels/xiaohongshu/methods/via_signsrv.py
@@ -95,6 +95,34 @@ def _to_evidence(item: Mapping[str, object], *, fetched_at: datetime) -> Evidenc
     )
 
 
+async def _check_account_health(
+    client: httpx.AsyncClient,
+    headers: Mapping[str, str],
+) -> tuple[bool, str | None]:
+    """Probe the XHS me endpoint to detect account restriction.
+
+    Returns (healthy, code).
+    - healthy=True, code=None  -> account OK (or probe failed; failure is non-fatal upstream)
+    - healthy=False, code='300011' -> account flagged
+    - healthy=True, code=None on probe network failure (caller treats as non-fatal)
+    The XHS me endpoint does NOT require search-call signing - only the cookies.
+    """
+    try:
+        resp = await client.get(
+            "https://edith.xiaohongshu.com/api/sns/web/v2/user/me",
+            headers={k: v for k, v in headers.items() if k != "Content-Type"},
+            timeout=8,
+        )
+        payload = resp.json()
+    except Exception:
+        # Probe failures are non-fatal; return healthy and let the caller decide.
+        return (True, None)
+
+    if isinstance(payload, Mapping) and payload.get("code") == 300011:
+        return (False, "300011")
+    return (True, None)
+
+
 async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> list[Evidence]:
     """Search XHS via Signing Worker + native XHS API.
 
@@ -205,18 +233,8 @@ async def search(query: SubQuery, client: httpx.AsyncClient | None = None) -> li
 
         # Empty results on a seemingly successful response → check if account is restricted
         if not items and xhs_code == 0:
-            me_payload: Mapping[str, object] | None = None
-            try:
-                me_resp = await _client.get(
-                    "https://edith.xiaohongshu.com/api/sns/web/v2/user/me",
-                    headers={k: v for k, v in xhs_headers.items() if k not in ("Content-Type",)},
-                    timeout=8,
-                )
-                me_payload = me_resp.json()
-            except Exception:
-                pass  # health check failure is non-fatal; fall through to empty list
-
-            if isinstance(me_payload, Mapping) and me_payload.get("code") == 300011:
+            healthy, code = await _check_account_health(_client, xhs_headers)
+            if not healthy and code == "300011":
                 from autosearch.channels.base import AccountRestrictedError
 
                 LOGGER.warning(

--- a/tests/unit/test_cli_login_health.py
+++ b/tests/unit/test_cli_login_health.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from autosearch.cli.main import app
+from autosearch.skills.channels.xiaohongshu.methods import via_signsrv
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolate_secrets_file(tmp_path, monkeypatch):
+    """Point AUTOSEARCH_SECRETS_FILE at a fresh, empty file so the CLI's
+    inject_into_env() does not bleed the developer's real ~/.config/ai-secrets.env
+    cookies into the test process — that would mask the missing-cookies branch."""
+    secrets_file = tmp_path / "ai-secrets.env"
+    secrets_file.write_text("", encoding="utf-8")
+    monkeypatch.setenv("AUTOSEARCH_SECRETS_FILE", str(secrets_file))
+    monkeypatch.delenv("XHS_COOKIES", raising=False)
+    monkeypatch.delenv("XIAOHONGSHU_COOKIES", raising=False)
+    monkeypatch.delenv("XHS_A1_COOKIE", raising=False)
+
+
+@pytest.fixture
+def patch_health(monkeypatch: pytest.MonkeyPatch):
+    def _install(result: tuple[bool, str | None]) -> None:
+        async def _fake_check(client: object, headers: object) -> tuple[bool, str | None]:
+            return result
+
+        monkeypatch.setattr(via_signsrv, "_check_account_health", _fake_check)
+
+    return _install
+
+
+def test_check_health_reports_healthy_on_ok(monkeypatch: pytest.MonkeyPatch, patch_health) -> None:
+    monkeypatch.setenv("XHS_COOKIES", "a1=test-cookie")
+    patch_health((True, None))
+
+    result = runner.invoke(app, ["login", "xhs", "--check-health"])
+
+    assert result.exit_code == 0
+    assert "OK:" in result.output
+    assert "healthy" in result.output
+
+
+def test_check_health_reports_flagged_on_300011(
+    monkeypatch: pytest.MonkeyPatch, patch_health
+) -> None:
+    monkeypatch.setenv("XHS_COOKIES", "a1=test-cookie")
+    patch_health((False, "300011"))
+
+    result = runner.invoke(app, ["login", "xhs", "--check-health"])
+
+    assert result.exit_code == 1
+    assert "FLAGGED:" in result.output
+    assert "300011" in result.output
+
+
+def test_check_health_exits_when_cookies_missing() -> None:
+    result = runner.invoke(app, ["login", "xhs", "--check-health"])
+
+    assert result.exit_code == 1
+    assert "No XHS_COOKIES" in result.output
+
+
+def test_check_health_rejects_non_xhs_platform() -> None:
+    result = runner.invoke(app, ["login", "twitter", "--check-health"])
+
+    assert result.exit_code == 2
+    assert "only supported for xhs" in result.output

--- a/tests/unit/test_via_signsrv_health.py
+++ b/tests/unit/test_via_signsrv_health.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from autosearch.skills.channels.xiaohongshu.methods.via_signsrv import (
+    _check_account_health,
+)
+
+_HEADERS = {
+    "Cookie": "a1=test",
+    "X-s": "sig",
+    "Content-Type": "application/json",
+}
+
+
+class _Response:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def json(self) -> object:
+        return self._payload
+
+
+class _ClientReturning:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    async def get(self, url: str, **kwargs: object) -> _Response:
+        _ = url
+        _ = kwargs
+        return _Response(self._payload)
+
+
+class _ClientRaising:
+    async def get(self, url: str, **kwargs: object) -> _Response:
+        _ = url
+        _ = kwargs
+        raise httpx.RequestError("boom")
+
+
+@pytest.mark.asyncio
+async def test_check_account_health_returns_healthy_on_code_zero() -> None:
+    client = _ClientReturning({"code": 0})
+
+    healthy, code = await _check_account_health(client, _HEADERS)
+
+    assert healthy is True
+    assert code is None
+
+
+@pytest.mark.asyncio
+async def test_check_account_health_returns_restricted_on_300011() -> None:
+    client = _ClientReturning({"code": 300011})
+
+    healthy, code = await _check_account_health(client, _HEADERS)
+
+    assert healthy is False
+    assert code == "300011"
+
+
+@pytest.mark.asyncio
+async def test_check_account_health_returns_healthy_on_network_failure() -> None:
+    client = _ClientRaising()
+
+    healthy, code = await _check_account_health(client, _HEADERS)
+
+    assert healthy is True
+    assert code is None


### PR DESCRIPTION
## Summary

- Adds `autosearch login xhs --check-health` — proactively probe whether your already-imported XHS cookies are flagged (code=300011), without having to run a search.
- Refactors the inline empty-results health probe in `via_signsrv.py` into a reusable module-level `_check_account_health` helper (motivated by the new CLI caller).
- Documented in XHS SKILL.md and `autosearch login --help`.

## Background

Plan: `docs/exec-plans/active/autosearch-0426-xhs-account-restriction-detection.md` — F002 (P1 optional in original plan, executed after F001 PR #416 merged).

F001 made the search path raise `AccountRestrictedError` when XHS returns code=300011. F002 closes the UX loop: the user can now check cookie health any time without triggering a real search.

## Behavior

```
$ autosearch login xhs --check-health        # exits 0 if healthy
OK: XHS cookies appear healthy (account not flagged).

$ autosearch login xhs --check-health        # exits 1 if flagged
FLAGGED: XHS account is restricted (code=300011). Re-run autosearch login xhs with a different account.

$ autosearch login xhs --check-health        # exits 1 if no cookies imported yet
No XHS_COOKIES found. Run autosearch login xhs first to import cookies.

$ autosearch login twitter --check-health    # exits 2 (xhs only for now)
--check-health is currently only supported for xhs.
```

## Test plan

- [x] `tests/unit/test_via_signsrv_health.py` — 3 tests for the helper (healthy / restricted / network failure)
- [x] `tests/unit/test_cli_login_health.py` — 4 tests for the CLI flag (4 paths, including non-xhs platform). Fixture isolates `AUTOSEARCH_SECRETS_FILE` so the dev's real cookies don't bleed in
- [x] Local fast suite: 656 passed, 0 regressions
- [x] Pre-push hook full suite: 1083 passed
- [x] Code-reviewer: APPROVE (verified refactor is behavior-preserving + test fixture is correct + lazy-import + monkeypatch interaction works)

## Refactor note (commit 1)

The new helper is a pure extraction of the inline empty-results probe at the old `via_signsrv.py:207-229`. Same URL, same timeout, same Content-Type stripping, same broad-except-on-probe-failure non-fatal contract, same 300011 detection. The 2 existing `test_xhs_signsrv_account_restriction.py` tests still pass against the refactored search path.