### PR TITLE
fix(auto-merge): wait for codex + copilot reviews before enabling

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,17 @@
 name: Auto merge
 
+# Trigger only after a review is submitted. We then check whether both
+# required bot reviewers (codex + copilot) have reviewed; if so, enable
+# auto-merge so GitHub finishes the merge once all CI / thread-resolution
+# requirements are met.
+#
+# Why not `on: pull_request: [opened]`? That fires before any review can
+# arrive, and GitHub's auto-merge cleared `required_conversation_resolution`
+# while bot review threads were still in flight (race window observed on
+# PR 412 / 417 / AgentLint 204).
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
 
 permissions: {}
 
@@ -11,9 +20,34 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      # enablePullRequestAutoMerge (called by `gh pr merge --auto`) needs
+      # contents:write — pull-requests:write alone returns "Resource not
+      # accessible by integration."
       contents: write
+      pull-requests: write
     steps:
-      - run: gh pr merge --auto --squash --repo "${{ github.repository }}" "${{ github.event.pull_request.number }}"
+      - name: Enable auto-merge once codex + copilot have both reviewed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -e
+          existing=$(gh pr view "$PR" --repo "$REPO" --json autoMergeRequest --jq '.autoMergeRequest')
+          if [ "$existing" != "null" ] && [ -n "$existing" ]; then
+            echo "Auto-merge already enabled."
+            exit 0
+          fi
+          required="chatgpt-codex-connector copilot-pull-request-reviewer"
+          missing=()
+          for r in $required; do
+            n=$(gh api "/repos/$REPO/pulls/$PR/reviews" \
+                  --jq "[.[] | select(.user.login == \"$r\")] | length")
+            [ "$n" -lt 1 ] && missing+=("$r")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "Waiting for review from: ${missing[*]}"
+            exit 0
+          fi
+          echo "Both required reviewers have reviewed. Enabling auto-merge."
+          gh pr merge --auto --squash --repo "$REPO" "$PR"


### PR DESCRIPTION
## Summary

- Trigger changes from `pull_request: [opened]` to `pull_request_review: [submitted]`
- Gate auto-merge enable on both `chatgpt-codex-connector` and `copilot-pull-request-reviewer` having submitted at least one review
- Idempotent: skip if auto-merge already enabled

## Why

Previous trigger fired 9 seconds after PR open and immediately enabled auto-merge. Required CI typically completed in 2 minutes; bot reviews arrived later. Result: PR 417 merged before any review existed; PR 204 hit the same path on AgentLint.

`required_conversation_resolution: true` only blocks _existing_ unresolved threads — when bot reviews haven't arrived yet, there are no threads to block on, and auto-merge fires past the intended guardrail.

## Test plan

- [x] yaml lint clean
- [ ] Open a follow-up PR after this lands; verify Auto-merge workflow doesn't fire on `opened` and only fires after both bot reviews submit