### PR TITLE
fix(auto-merge): include [bot] suffix in required reviewer logins

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -38,7 +38,10 @@ jobs:
             echo "Auto-merge already enabled."
             exit 0
           fi
-          required="chatgpt-codex-connector copilot-pull-request-reviewer"
+          # Bot user.login from /pulls/<n>/reviews carries the [bot] suffix
+          # (REST format) — without it the comparison silently never matches and
+          # the gate stays permanently "missing", verified against PR 417 reviews.
+          required="chatgpt-codex-connector[bot] copilot-pull-request-reviewer[bot]"
           missing=()
           for r in $required; do
             n=$(gh api "/repos/$REPO/pulls/$PR/reviews" \


### PR DESCRIPTION
## Summary

Follow-up to #419. The required reviewer list compared `user.login` from `/pulls/<n>/reviews` against `chatgpt-codex-connector` / `copilot-pull-request-reviewer`, but the REST endpoint returns those logins with a `[bot]` suffix. Mismatch meant the gate stayed permanently "missing" regardless of actual review state.

## Why this slipped past

I verified bot logins via GraphQL `author.login` (no suffix) but the workflow uses REST `/pulls/<n>/reviews` (with suffix). The two endpoints disagree on bot login formatting.

## Fix

```bash
required="chatgpt-codex-connector[bot] copilot-pull-request-reviewer[bot]"
```

Verified live against PR 417's `/pulls/417/reviews` response.

## Test plan

- [x] yaml lint clean
- [ ] Open follow-up PR after this lands; verify auto-merge actually fires once both bots review