### PR TITLE
fix(transcribe): default-deny path guard for local files (P0-1)

### DIFF
--- a/autosearch/core/transcribe_path_guard.py
+++ b/autosearch/core/transcribe_path_guard.py
@@ -1,0 +1,112 @@
+"""Default-deny local path guard for transcription inputs.
+
+Local transcription can expose arbitrary files to downstream tooling. This guard
+only permits resolved paths that live under an explicit
+``AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS`` entry, and denies all local files by
+default when no allowlist is configured.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+from pathlib import Path
+
+_DENIED_GLOBS = (
+    ".env",
+    ".env.*",
+    "*.env",
+    "*.key",
+    "*.pem",
+    "*/.ssh/*",
+    "*/.config/*",
+    "/etc/*",
+)
+
+_AUDIO_VIDEO_EXTS = {
+    ".mp3",
+    ".m4a",
+    ".wav",
+    ".aac",
+    ".ogg",
+    ".opus",
+    ".flac",
+    ".wma",
+    ".aif",
+    ".aiff",
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".avi",
+    ".webm",
+    ".flv",
+    ".m4v",
+    ".mpg",
+    ".mpeg",
+    ".3gp",
+    ".wmv",
+}
+
+_AUDIO_VIDEO_MAGIC_BYTES = (
+    (b"ID3", "mp3-id3"),
+    (b"\xff\xfb", "mp3"),
+    (b"\xff\xf3", "mp3"),
+    (b"\xff\xf2", "mp3"),
+    (b"OggS", "ogg"),
+    (b"fLaC", "flac"),
+    (b"RIFF", "wav-or-avi"),
+    (b"\x00\x00\x00\x18ftyp", "mp4-isobmff-18"),
+    (b"\x00\x00\x00\x20ftyp", "mp4-isobmff-20"),
+    (b"\x1a\x45\xdf\xa3", "matroska-webm"),
+)
+
+
+def _is_denied(resolved_path: Path) -> bool:
+    path_text = str(resolved_path)
+    path_name = resolved_path.name
+    for pattern in _DENIED_GLOBS:
+        if fnmatch.fnmatch(path_text, pattern):
+            return True
+        if "/" not in pattern and fnmatch.fnmatch(path_name, pattern):
+            return True
+    return False
+
+
+def validate_local_path(path: str | Path) -> Path:
+    """Return a resolved path only when it is inside the configured allowlist."""
+    allowed_dirs = os.environ.get("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS")
+    if not allowed_dirs:
+        raise PermissionError(
+            "transcribe path guard: AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS not set; "
+            "no local files allowed"
+        )
+
+    resolved_path = Path(path).expanduser().resolve()
+    if _is_denied(resolved_path):
+        raise PermissionError(f"transcribe path guard: {path} matches a hard-deny pattern")
+
+    for allowed_dir in allowed_dirs.split(os.pathsep):
+        if not allowed_dir:
+            continue
+        resolved_allowed_dir = Path(allowed_dir).expanduser().resolve()
+        if resolved_path.is_relative_to(resolved_allowed_dir):
+            suffix = resolved_path.suffix.lower()
+            if suffix not in _AUDIO_VIDEO_EXTS:
+                raise PermissionError(
+                    f"transcribe path guard: extension {suffix} is not an allowed audio/video type"
+                )
+            with resolved_path.open("rb") as file:
+                head_bytes = file.read(16)
+            has_audio_video_magic = any(
+                head_bytes.startswith(prefix) for prefix, _label in _AUDIO_VIDEO_MAGIC_BYTES
+            )
+            if not has_audio_video_magic and b"ftyp" not in head_bytes:
+                raise PermissionError(
+                    "transcribe path guard: file does not look like audio/video "
+                    "(magic bytes mismatch)"
+                )
+            return resolved_path
+
+    raise PermissionError(
+        f"transcribe path guard: {path} is not inside any AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS entry"
+    )

--- a/autosearch/skills/tools/video-to-text-groq/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-groq/transcribe.py
@@ -219,7 +219,9 @@ def _prepare_audio(url_or_path: str) -> str:
     if _looks_like_url(url_or_path):
         return _extract_audio(url_or_path)
 
-    source_path = Path(url_or_path).expanduser()
+    from autosearch.core.transcribe_path_guard import validate_local_path
+
+    source_path = validate_local_path(url_or_path)
     if not source_path.exists():
         raise FileNotFoundError(f"Local input file not found: {source_path}")
 

--- a/autosearch/skills/tools/video-to-text-local/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-local/transcribe.py
@@ -182,7 +182,9 @@ def _prepare_audio(url_or_path: str) -> str:
     if _looks_like_url(url_or_path):
         return _extract_audio(url_or_path)
 
-    source_path = Path(url_or_path).expanduser()
+    from autosearch.core.transcribe_path_guard import validate_local_path
+
+    source_path = validate_local_path(url_or_path)
     if not source_path.exists():
         raise FileNotFoundError(f"Local input file not found: {source_path}")
 

--- a/autosearch/skills/tools/video-to-text-openai/transcribe.py
+++ b/autosearch/skills/tools/video-to-text-openai/transcribe.py
@@ -219,7 +219,9 @@ def _prepare_audio(url_or_path: str) -> str:
     if _looks_like_url(url_or_path):
         return _extract_audio(url_or_path)
 
-    source_path = Path(url_or_path).expanduser()
+    from autosearch.core.transcribe_path_guard import validate_local_path
+
+    source_path = validate_local_path(url_or_path)
     if not source_path.exists():
         raise FileNotFoundError(f"Local input file not found: {source_path}")
 

--- a/docs/security/transcribe-allowlist.md
+++ b/docs/security/transcribe-allowlist.md
@@ -1,0 +1,88 @@
+# Transcribe Path Guard — `AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS`
+
+> Status: enforced as of P0-1 fix (`fix/p0-1-transcribe-path-guard`). All
+> three transcribe backends (`video-to-text-openai`,
+> `video-to-text-groq`, `video-to-text-local`) route every local-path
+> input through `autosearch.core.transcribe_path_guard.validate_local_path`.
+
+## Threat model
+
+The transcribe tools accept either a remote URL (downloaded with
+`yt-dlp`) or a local path. The local-path branch is dangerous: an agent
+runtime, MCP tool, or skill that takes a free-form `path` argument can
+hand the tool any file the autosearch process can read — `.env`, SSH
+keys, browser cookies, tokens — and that file becomes the audio payload
+uploaded to OpenAI / Groq.
+
+Without a path guard, this is a one-call data exfiltration primitive.
+
+## Defense layers
+
+`validate_local_path(path)` enforces four checks, in order:
+
+1. **Default-deny allowlist.** If `AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS`
+   is unset or empty, every local path is rejected with
+   `PermissionError`. Remote URLs (yt-dlp branch) are unaffected — only
+   local-disk inputs require the env var.
+2. **Hard-deny patterns.** `_DENIED_GLOBS` rejects paths matching
+   `.env`, `.env.*`, `*.env`, `*.key`, `*.pem`, `*/.ssh/*`,
+   `*/.config/*`, `/etc/*` even if they sit inside an allowlisted
+   directory. This catches the obvious shape of "allowlist is `~`,
+   attacker requests `~/.ssh/id_rsa`".
+3. **Extension whitelist.** Only common audio/video file extensions
+   pass: `.mp3`, `.m4a`, `.wav`, `.aac`, `.ogg`, `.opus`, `.flac`,
+   `.wma`, `.aif`, `.aiff`, `.mp4`, `.mov`, `.mkv`, `.avi`, `.webm`,
+   `.flv`, `.m4v`, `.mpg`, `.mpeg`, `.3gp`, `.wmv`. A `.txt` or `.py`
+   file with a hand-crafted name is refused before any I/O.
+4. **Magic-bytes check.** The first 16 bytes of the file must match a
+   known audio/video container signature (`ID3`, MP3 frame markers,
+   `OggS`, `fLaC`, `RIFF`, MP4 `ftyp`, Matroska/WebM EBML). A
+   `.mp3`-named text file is rejected. A best-effort check, not a full
+   demuxer — a sufficiently crafted file could still bypass, but the
+   layered defense (allowlist + denylist + extension) makes this
+   strictly harder.
+
+## Configuration
+
+Allow a directory tree:
+
+```bash
+export AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS="$HOME/Recordings:$HOME/Downloads/Podcasts"
+```
+
+The value is colon-separated (PATH-style on macOS / Linux). Each entry
+is `expanduser()` + `resolve()` before comparison, so symlinks and
+relative paths are normalized.
+
+Disallow all local paths (default — recommended for headless / agent
+runtimes):
+
+```bash
+unset AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS
+```
+
+## Why default-deny
+
+The alternative is default-allow with a denylist of known-sensitive
+paths. That is unworkable: every new sensitive file pattern (a fresh
+config tool, a new credential store, a service-specific cache) creates
+a hole until the denylist catches up. Default-deny inverts the burden —
+the operator who knows which directory is safe lists exactly that
+directory. Anything outside is rejected by construction.
+
+The `_DENIED_GLOBS` layer exists for the case where the operator chose
+a too-broad allowlist (e.g. `~`); it is a safety net, not the primary
+defense.
+
+## Tests that lock this in
+
+- `tests/unit/test_transcribe_path_guard.py` — all four layers
+  individually (default-deny, extension whitelist, magic-bytes,
+  blacklist).
+- `tests/skills/tools/video_to_text_openai/test_path_guard.py` —
+  end-to-end via the OpenAI transcribe entry.
+- `tests/skills/tools/video_to_text_groq/` and
+  `tests/skills/tools/video_to_text_local/` — backend-specific
+  regression coverage.
+
+Source: `docs/security/autosearch-0426-p0-deep-scan-report.md` § P0-1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ markers = [
     "flaky_live: anti-scrape-prone live tests excluded from the default live suite",
     "e2e: end-to-end research flow tests (all mock, no real API needed)",
     "avo: AVO self-evolution cycle tests (slow, run before release)",
+    "mime: tests for media type sniffing and file signature checks",
 ]
 
 [tool.ruff]

--- a/tests/skills/tools/video_to_text_groq/test_video_to_text_groq.py
+++ b/tests/skills/tools/video_to_text_groq/test_video_to_text_groq.py
@@ -86,8 +86,9 @@ def test_local_audio_happy_path_skips_yt_dlp(
     tmp_path: Path,
 ) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
     monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     def fail_extract(source: str) -> str:
         raise AssertionError(f"yt-dlp should not run for local audio: {source}")
@@ -110,8 +111,9 @@ def test_missing_groq_api_key_returns_structured_error(
     tmp_path: Path,
 ) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     result = VIDEO_TO_TEXT_GROQ.transcribe(str(fake_mp3))
 
@@ -122,8 +124,9 @@ def test_missing_groq_api_key_returns_structured_error(
 
 def test_groq_429_returns_rate_limited(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
     monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(429, text="too many requests", request=request)

--- a/tests/skills/tools/video_to_text_local/test_video_to_text_local.py
+++ b/tests/skills/tools/video_to_text_local/test_video_to_text_local.py
@@ -82,7 +82,8 @@ def test_local_audio_happy_path_skips_yt_dlp(
     tmp_path: Path,
 ) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     def fail_extract(source: str) -> str:
         raise AssertionError(f"yt-dlp should not run for local audio: {source}")
@@ -107,7 +108,8 @@ def test_mlx_whisper_unavailable_returns_structured_error(
     tmp_path: Path,
 ) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
     monkeypatch.setattr(VIDEO_TO_TEXT_LOCAL, "_load_mlx_whisper", lambda: None)
 
     result = VIDEO_TO_TEXT_LOCAL.transcribe(str(fake_mp3))
@@ -123,8 +125,9 @@ def test_custom_model_via_env_var_is_passed(
     tmp_path: Path,
 ) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
     monkeypatch.setenv("AUTOSEARCH_MLX_WHISPER_MODEL", "mlx-community/whisper-tiny")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     captured: dict[str, object] = {}
 
@@ -173,7 +176,8 @@ def test_mlx_runtime_error_returns_structured_error(
     tmp_path: Path,
 ) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     def fake_transcribe(audio_path: str, *, path_or_hf_repo: str) -> dict[str, object]:
         raise RuntimeError("metal kernel launch failed")

--- a/tests/skills/tools/video_to_text_openai/test_path_guard.py
+++ b/tests/skills/tools/video_to_text_openai/test_path_guard.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_video_to_text_openai() -> ModuleType:
+    root = Path(__file__).resolve().parents[4]
+    transcribe_path = (
+        root / "autosearch" / "skills" / "tools" / "video-to-text-openai" / "transcribe.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "video_to_text_openai_path_guard_under_test", transcribe_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VIDEO_TO_TEXT_OPENAI = _load_video_to_text_openai()
+
+
+def test_local_path_rejected_when_no_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", raising=False)
+
+    try:
+        result = VIDEO_TO_TEXT_OPENAI.transcribe("/tmp/x.mp3")
+    except PermissionError as exc:
+        assert "transcribe path guard" in str(exc)
+        return
+
+    assert result["ok"] is False
+    assert "transcribe path guard" in str(result.get("message") or result.get("reason") or "")

--- a/tests/skills/tools/video_to_text_openai/test_video_to_text_openai.py
+++ b/tests/skills/tools/video_to_text_openai/test_video_to_text_openai.py
@@ -88,8 +88,9 @@ def test_local_audio_happy_path_skips_yt_dlp(
     tmp_path: Path,
 ) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     def fail_extract(source: str) -> str:
         raise AssertionError(f"yt-dlp should not run for local audio: {source}")
@@ -127,8 +128,9 @@ def test_missing_openai_api_key_returns_structured_error(
 
 def test_openai_429_returns_rate_limited(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     fake_mp3 = tmp_path / "local.mp3"
-    fake_mp3.write_bytes(b"fake mp3")
+    fake_mp3.write_bytes(b"ID3 fake mp3")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(429, text="too many requests", request=request)

--- a/tests/unit/test_transcribe_path_guard.py
+++ b/tests/unit/test_transcribe_path_guard.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_default_deny_unknown_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", raising=False)
+
+    import autosearch.core.transcribe_path_guard
+
+    with pytest.raises(PermissionError):
+        autosearch.core.transcribe_path_guard.validate_local_path("/tmp/random.mp3")
+
+
+def test_rejects_non_audio_extension(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", "/tmp")
+    candidate = Path("/tmp") / f"{tmp_path.name}.txt"
+    candidate.write_text("not media", encoding="utf-8")
+
+    import autosearch.core.transcribe_path_guard
+
+    try:
+        with pytest.raises(PermissionError, match="extension"):
+            autosearch.core.transcribe_path_guard.validate_local_path(candidate)
+    finally:
+        candidate.unlink(missing_ok=True)
+
+
+def test_rejects_blacklisted_path_even_in_allowlist(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
+    candidate = tmp_path / ".env"
+    candidate.write_text("SECRET=value", encoding="utf-8")
+
+    import autosearch.core.transcribe_path_guard
+
+    with pytest.raises(PermissionError, match="hard-deny"):
+        autosearch.core.transcribe_path_guard.validate_local_path(candidate)
+
+
+@pytest.mark.mime
+def test_rejects_text_file_with_mp3_extension(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS", str(tmp_path))
+    candidate = tmp_path / "fake.mp3"
+    candidate.write_text("hello world", encoding="utf-8")
+
+    import autosearch.core.transcribe_path_guard
+
+    with pytest.raises(PermissionError, match="magic"):
+        autosearch.core.transcribe_path_guard.validate_local_path(candidate)


### PR DESCRIPTION
## Summary

Closes deep-scan finding **P0-1** (transcribe tools accept arbitrary local paths → arbitrary file exfiltration to OpenAI/Groq).

`autosearch.core.transcribe_path_guard.validate_local_path` enforces four layered defenses, applied at the local-path entry of all three transcribe backends (`video-to-text-openai`, `video-to-text-groq`, `video-to-text-local`):

1. **Default-deny allowlist** — `AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS` (colon-separated PATH-style). Unset = no local files accepted.
2. **Hard-deny patterns** — `.env*`, `*.key`, `*.pem`, `*/.ssh/*`, `*/.config/*`, `/etc/*` rejected even inside an allowlisted directory.
3. **Extension whitelist** — only common audio/video extensions pass.
4. **Magic-bytes check** — first 16 bytes must match a known audio/video container signature.

Remote URLs (yt-dlp branch) are unaffected — only local-disk inputs require the env var.

## Background

Plan: `docs/exec-plans/active/autosearch-0426-p0-deep-scan-fix.md` § F003.
Deep-scan source: `docs/security/autosearch-0426-p0-deep-scan-report.md` § P0-1.

## Test plan

- [x] `tests/unit/test_transcribe_path_guard.py` (4 tests, all four layers)
- [x] `tests/skills/tools/video_to_text_openai/test_path_guard.py` (default-deny end-to-end)
- [x] Existing backend tests (openai/groq/local) updated to set the allowlist env + use real ID3 magic bytes — all pass
- [x] 21 tests pass locally across the 4 transcribe test dirs
- [x] Ruff check + format-check clean
- [ ] Code-reviewer: pending background run

## Note on commits

Originally executed as 9 atomic TDD steps; squashed to 4 commits to fit project's 5-commit PR cap. Each commit = one logical layer with paired tests bundled.

## Breaking change for local-path users

Users who previously called transcribe with a local file path will hit `PermissionError` on first run after upgrade. They must set `AUTOSEARCH_TRANSCRIBE_ALLOWED_DIRS` to a directory containing their audio files. Documented in `docs/security/transcribe-allowlist.md`.