### PR TITLE
fix(citation): default-redact signed URLs at export + MCP boundary (P0-3)

### DIFF
--- a/autosearch/core/citation_index.py
+++ b/autosearch/core/citation_index.py
@@ -9,6 +9,8 @@ import re
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import uuid
 
+from autosearch.core.redact import redact_signed_url
+
 
 _TRACKING_QUERY_PARAMS = {
     "fbclid",
@@ -95,7 +97,7 @@ def add_citation(index_id: str, url: str, title: str = "", source: str = "") -> 
     return num
 
 
-def export_citations(index_id: str) -> str:
+def export_citations(index_id: str, *, raw_urls: bool = False) -> str:
     """Export citation index as a Markdown reference list.
 
     Format: [N] title — source (url)
@@ -104,9 +106,11 @@ def export_citations(index_id: str) -> str:
     lines: list[str] = []
     for entry in sorted(idx._entries, key=lambda e: e["num"]):
         num = entry["num"]
-        title = entry["title"] or entry["url"]
-        source = entry["source"]
         url = entry["url"]
+        if not raw_urls:
+            url = redact_signed_url(url)
+        title = entry["title"] or url
+        source = entry["source"]
         if source:
             lines.append(f"[{num}] {title} — {source} ({url})")
         else:

--- a/autosearch/core/redact.py
+++ b/autosearch/core/redact.py
@@ -48,19 +48,40 @@ _COOKIE_PAIR_PATTERN = re.compile(r"(?P<name>[^=;\s]+)=(?P<value>[^;]*)")
 _SIGNED_URL_QUERY_KEYS = {
     key.lower()
     for key in {
+        # Generic
         "Signature",
-        "X-Amz-Signature",
-        "X-Goog-Signature",
+        "signature",
         "sig",
         "token",
         "Expires",
-        "X-Amz-Expires",
-        "X-Goog-Expires",
+        # AWS SigV4 (S3 / CloudFront / etc.)
+        "X-Amz-Signature",
+        "X-Amz-Credential",
+        "X-Amz-Algorithm",
+        "X-Amz-SignedHeaders",
+        "X-Amz-Security-Token",
         "X-Amz-Date",
+        "X-Amz-Expires",
+        # Google Cloud Storage
+        "X-Goog-Signature",
+        "X-Goog-Expires",
+        # Azure Blob SAS
         "se",
         "sp",
         "sv",
-        "signature",
+        "srt",
+        "ss",
+        "st",
+        "spr",
+        "skoid",
+        "sktid",
+        "skt",
+        "ske",
+        "sks",
+        "skv",
+        # CloudFront signed URLs
+        "Policy",
+        "Key-Pair-Id",
     }
 }
 

--- a/autosearch/core/redact.py
+++ b/autosearch/core/redact.py
@@ -11,7 +11,7 @@ Conservative match list — must NOT alter ordinary user prose.
 from __future__ import annotations
 
 import re
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
 
 _SECRET_KEY_PATTERN = (
     r"(?:"
@@ -45,6 +45,24 @@ _COOKIE_ASSIGNMENT_PATTERN = re.compile(
 )
 _COOKIE_HEADER_PATTERN = re.compile(r"(?im)(?P<prefix>\bCookie:\s*)(?P<cookies>[^\r\n]*)")
 _COOKIE_PAIR_PATTERN = re.compile(r"(?P<name>[^=;\s]+)=(?P<value>[^;]*)")
+_SIGNED_URL_QUERY_KEYS = {
+    key.lower()
+    for key in {
+        "Signature",
+        "X-Amz-Signature",
+        "X-Goog-Signature",
+        "sig",
+        "token",
+        "Expires",
+        "X-Amz-Expires",
+        "X-Goog-Expires",
+        "X-Amz-Date",
+        "se",
+        "sp",
+        "sv",
+        "signature",
+    }
+}
 
 
 def _replacer(match: re.Match) -> str:
@@ -98,4 +116,22 @@ def redact_url(url: str, *, strip_query: bool = True) -> str:
         return url
 
     query = "" if strip_query else parts.query
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+
+
+def redact_signed_url(url: str) -> str:
+    """Default-redact signed URL params at the citation MCP boundary."""
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+
+    if not parts.scheme:
+        return url
+
+    query_items = parse_qsl(parts.query, keep_blank_values=True)
+    filtered_query = [
+        (name, value) for name, value in query_items if name.lower() not in _SIGNED_URL_QUERY_KEYS
+    ]
+    query = urlencode(filtered_query)
     return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -22,6 +22,7 @@ from autosearch.core.loop_state import get_gaps as _ls_get_gaps
 from autosearch.core.loop_state import init_loop as _ls_init
 from autosearch.core.loop_state import update_loop as _ls_update
 from autosearch.core.models import ClarifyRequest, SearchMode, SubQuery
+from autosearch.core.redact import redact_signed_url
 from autosearch.core.search_scope import SearchScope, depth_to_mode
 from autosearch.llm.client import LLMClient
 
@@ -831,7 +832,7 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
             num = _ci_add(index_id, url, title=title, source=source)
         except KeyError:
             return {"ok": False, "reason": "invalid_index_id", "index_id": index_id}
-        return {"index_id": index_id, "citation_number": num, "url": url}
+        return {"index_id": index_id, "citation_number": num, "url": redact_signed_url(url)}
 
     @server.tool()
     def citation_export(index_id: str) -> dict:

--- a/docs/security/citation-redaction.md
+++ b/docs/security/citation-redaction.md
@@ -1,0 +1,67 @@
+# Citation URL Redaction
+
+> Status: enforced as of P0-3 fix (`fix/p0-3-citation-signed-url-redact`).
+> `autosearch.core.citation_index.export_citations` redacts signed URL
+> parameters by default; the MCP citation tools never expose a raw-URL
+> opt-in.
+
+## Threat model
+
+A search session frequently produces evidence URLs that are **signed**
+(time-limited, capability-bearing tokens embedded in query parameters):
+S3 presigned downloads, GCS signed object URLs, Azure SAS, and arbitrary
+APIs that pass `?token=…&Expires=…` for temporary access.
+
+If the citation index stores these URLs raw and exports them to the
+agent, the agent's transcript / log / downstream tool calls now carry a
+working credential. Worse, the MCP `citation_add` tool used to echo the
+URL straight back in its response, so a single signed URL in the
+research stream propagated to:
+
+- The agent's memory + transcript (visible to other tools / MCP servers).
+- Any downstream tool that consumes citations.
+- Logs, telemetry, and on-disk experience writes.
+
+## Defense
+
+Two pieces of infrastructure:
+
+1. **`autosearch.core.redact.redact_signed_url(url) -> str`** —
+   parses the URL, drops query parameters whose name (case-insensitive)
+   appears in the signed-URL key set: `Signature`, `X-Amz-Signature`,
+   `X-Goog-Signature`, `sig`, `token`, `Expires`, `X-Amz-Expires`,
+   `X-Goog-Expires`, `X-Amz-Date`, `se`, `sp`, `sv`, `signature`. The
+   path and remaining business parameters are preserved.
+2. **`export_citations(index_id, *, raw_urls=False)`** —
+   default `raw_urls=False` runs every URL through `redact_signed_url`
+   before formatting the markdown reference list. `raw_urls=True` is
+   the Python-only opt-in for callers that genuinely need the original
+   URL (e.g. immediately re-issuing a download with the still-valid
+   token).
+
+## MCP boundary
+
+The MCP `citation_add` and `citation_export` tools **always redact**.
+Neither tool exposes a `raw_urls` parameter. External agents cannot
+request raw signed URLs through MCP under any circumstance — the only
+way to get a raw URL out of the citation index is via the in-process
+Python API.
+
+Why no opt-in at the MCP boundary: external agents are part of the
+threat surface. A compromised or prompt-injected agent could request
+raw URLs and exfiltrate them. The cost of removing the opt-in is
+near-zero (no production caller needs raw URLs at the MCP boundary —
+the in-process `pipeline_factory` or pipeline writers can use the
+Python API directly when they do).
+
+## Coverage
+
+- `tests/unit/test_redact.py::TestRedactSignedUrl` — AWS SigV4, GCS,
+  Azure SAS, generic token/signature/Expires regression.
+- `tests/unit/test_citation_redact.py` — `export_citations` default-
+  redact + `raw_urls=True` opt-in.
+- `tests/unit/test_mcp_citation_redact.py` — MCP `citation_add` and
+  `citation_export` always redact; tool signature does not accept
+  `raw_urls`.
+
+Source: `docs/security/autosearch-0426-p0-deep-scan-report.md` § P0-3.

--- a/tests/unit/test_citation_redact.py
+++ b/tests/unit/test_citation_redact.py
@@ -1,0 +1,29 @@
+"""Tests for citation export URL redaction."""
+
+from __future__ import annotations
+
+from autosearch.core.citation_index import add_citation, create_index, export_citations
+
+
+def test_export_citations_default_redacts_signed_urls() -> None:
+    index_id = create_index()
+    add_citation(
+        index_id,
+        "https://bucket.s3.amazonaws.com/key.txt?X-Amz-Signature=abc&keepme=ok",
+    )
+
+    output = export_citations(index_id)
+
+    assert "X-Amz-Signature" not in output
+
+
+def test_export_citations_raw_urls_keeps_signed() -> None:
+    index_id = create_index()
+    add_citation(
+        index_id,
+        "https://bucket.s3.amazonaws.com/key.txt?X-Amz-Signature=abc&keepme=ok",
+    )
+
+    output = export_citations(index_id, raw_urls=True)
+
+    assert "X-Amz-Signature" in output

--- a/tests/unit/test_mcp_citation_redact.py
+++ b/tests/unit/test_mcp_citation_redact.py
@@ -1,0 +1,51 @@
+"""MCP citation tools must not expose raw signed URLs."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from autosearch.mcp.server import create_server
+
+_SIGNED_URL = "https://bucket.s3.amazonaws.com/key.txt?X-Amz-Signature=abc&keepme=ok"
+
+
+@pytest.mark.asyncio
+async def test_citation_add_redacts_signed_url_in_response() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    create = await tm.call_tool("citation_create", {})
+    index_id = create["index_id"]
+
+    result = await tm.call_tool(
+        "citation_add",
+        {"index_id": index_id, "url": _SIGNED_URL},
+    )
+
+    assert "X-Amz-Signature" not in result["url"]
+    assert "keepme=ok" in result["url"]
+
+
+@pytest.mark.asyncio
+async def test_citation_export_redacts_signed_url_in_markdown() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tm = server._tool_manager
+    create = await tm.call_tool("citation_create", {})
+    index_id = create["index_id"]
+    await tm.call_tool(
+        "citation_add",
+        {"index_id": index_id, "url": _SIGNED_URL, "title": "Signed URL"},
+    )
+
+    result = await tm.call_tool("citation_export", {"index_id": index_id})
+
+    assert "X-Amz-Signature" not in result["markdown"]
+
+
+def test_citation_export_no_raw_urls_param_at_mcp_boundary() -> None:
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    tool = server._tool_manager.get_tool("citation_export")
+
+    assert tool is not None
+    assert "raw_urls" not in inspect.signature(tool.fn).parameters

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -196,3 +196,42 @@ class TestRedactSignedUrl:
         assert "signature=" not in out
         assert "Expires=" not in out
         assert "keepme=ok" in out
+
+    def test_redact_signed_url_strips_aws_credential(self) -> None:
+        """X-Amz-Credential leaks the AKIA access-key-id + region scope."""
+        url = (
+            "https://bucket.s3.amazonaws.com/key.txt?"
+            "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+            "X-Amz-Credential=AKIAEXAMPLE/20260426/us-east-1/s3/aws4_request&"
+            "X-Amz-SignedHeaders=host&"
+            "X-Amz-Security-Token=session-token-abc&"
+            "X-Amz-Signature=abc&keepme=ok"
+        )
+
+        out = redact_signed_url(url)
+
+        assert "X-Amz-Credential" not in out
+        assert "AKIAEXAMPLE" not in out
+        assert "X-Amz-Algorithm" not in out
+        assert "X-Amz-SignedHeaders" not in out
+        assert "X-Amz-Security-Token" not in out
+        assert "session-token-abc" not in out
+        assert "keepme=ok" in out
+
+    def test_redact_signed_url_strips_cloudfront_policy(self) -> None:
+        """CloudFront signed URLs use Policy + Signature + Key-Pair-Id."""
+        url = (
+            "https://d111111abcdef8.cloudfront.net/private.mp4?"
+            "Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiKiJ9XX0&"
+            "Signature=cf-sig-value&"
+            "Key-Pair-Id=APKAEXAMPLE&keepme=ok"
+        )
+
+        out = redact_signed_url(url)
+
+        assert "Policy" not in out
+        assert "eyJTdGF" not in out  # base64 policy body
+        assert "Signature" not in out
+        assert "Key-Pair-Id" not in out
+        assert "APKAEXAMPLE" not in out
+        assert "keepme=ok" in out

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from autosearch.core.redact import redact, redact_url
+from autosearch.core.redact import redact, redact_signed_url, redact_url
 
 
 def test_redact_bearer_token_with_plus_slash_equals_redacts_full_token() -> None:
@@ -146,3 +146,53 @@ def test_redact_url_malformed_url_returns_as_is() -> None:
     url = "http://[::1"
 
     assert redact_url(url) == url
+
+
+class TestRedactSignedUrl:
+    def test_redact_signed_url_strips_aws_sig(self) -> None:
+        url = (
+            "https://bucket.s3.amazonaws.com/key.txt?"
+            "X-Amz-Signature=abc123def&X-Amz-Expires=3600&"
+            "X-Amz-Date=20260426T000000Z&keepme=ok"
+        )
+
+        out = redact_signed_url(url)
+
+        assert "X-Amz-Signature" not in out
+        assert "X-Amz-Expires" not in out
+        assert "X-Amz-Date" not in out
+        assert "keepme=ok" in out
+        assert "/key.txt" in out
+
+    def test_redact_signed_url_strips_gcs_sig(self) -> None:
+        url = (
+            "https://storage.googleapis.com/b/o.json?"
+            "X-Goog-Signature=xyz789&X-Goog-Expires=3600&keepme=yes"
+        )
+
+        out = redact_signed_url(url)
+
+        assert "X-Goog-Signature" not in out
+        assert "X-Goog-Expires" not in out
+        assert "keepme=yes" in out
+
+    def test_redact_signed_url_strips_azure_sas(self) -> None:
+        url = (
+            "https://acct.blob.core.windows.net/c/o.json?"
+            "sig=verysecret&se=2026-04-27T00:00:00Z&sp=r&keepme=1"
+        )
+
+        out = redact_signed_url(url)
+
+        assert "sig=" not in out
+        assert "keepme=1" in out
+
+    def test_redact_signed_url_strips_generic_token(self) -> None:
+        url = "https://example.com/path?token=abc&signature=def&Expires=123&keepme=ok"
+
+        out = redact_signed_url(url)
+
+        assert "token=" not in out
+        assert "signature=" not in out
+        assert "Expires=" not in out
+        assert "keepme=ok" in out


### PR DESCRIPTION
## Summary

Closes deep-scan **P0-3** (citation MCP tools return raw signed URLs → token leak via agent transcript / downstream tool calls).

Two pieces:
1. **`redact_signed_url(url) -> str`** in `autosearch/core/redact.py` — case-insensitive strip of signed-URL query params: `Signature` / `X-Amz-Signature` / `X-Goog-Signature` / `sig` / `token` / `Expires` / `X-Amz-Expires` / `X-Goog-Expires` / `X-Amz-Date` / `se` / `sp` / `sv` / `signature`. Path + business params preserved.
2. **`export_citations(index_id, *, raw_urls=False)`** — default redacts every URL before formatting the markdown reference list. `raw_urls=True` is the Python-only opt-in.

**MCP boundary always redacts.** Neither `citation_add` nor `citation_export` exposes a `raw_urls` parameter. External agents cannot request raw signed URLs through MCP under any circumstance.

## Background

Plan: `docs/exec-plans/active/autosearch-0426-p0-deep-scan-fix.md` § F005.
Deep-scan source: `docs/security/autosearch-0426-p0-deep-scan-report.md` § P0-3.

Decision Log note: F004 (delegate ChannelRuntime) and this PR both touch `mcp/server.py`. F005 ships first (smaller, simpler refactor); F004 will rebase after merge.

## Test plan

- [x] `tests/unit/test_redact.py::TestRedactSignedUrl` (4 tests: AWS / GCS / Azure / generic)
- [x] `tests/unit/test_citation_redact.py` (default redact + raw_urls opt-in)
- [x] `tests/unit/test_mcp_citation_redact.py` (citation_add, citation_export, MCP signature-no-raw_urls)
- [x] Full local suite: 1090 passed, 3 skipped, 27 deselected
- [x] Ruff check + format-check clean
- [ ] Code-reviewer: pending background run