### PR TITLE
fix(delegate): require shared runtime + dedupe + concurrency cap (P0-4)

### DIFF
--- a/autosearch/core/delegate.py
+++ b/autosearch/core/delegate.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 
+from autosearch.core.channel_runtime import ChannelRuntime
+
 
 @dataclass
 class SubtaskResult:
@@ -21,14 +23,14 @@ async def run_subtask(
     query: str,
     max_per_channel: int = 5,
     *,
+    channel_runtime: ChannelRuntime,
     _search_fn=None,  # injectable for tests
 ) -> SubtaskResult:
     """Run query across channels concurrently and return a SubtaskResult."""
-    from autosearch.core.channel_bootstrap import _build_channels  # noqa: PLC0415
     from autosearch.core.models import SubQuery  # noqa: PLC0415
 
     if _search_fn is None:
-        all_channels = {c.name: c for c in _build_channels()}
+        all_channels = {c.name: c for c in channel_runtime.channels}
 
         async def _search_fn(channel_name: str) -> list[dict]:
             ch = all_channels.get(channel_name)

--- a/autosearch/core/delegate.py
+++ b/autosearch/core/delegate.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from dataclasses import dataclass, field
 
 from autosearch.core.channel_runtime import ChannelRuntime
+
+_DEFAULT_CONCURRENCY_CAP = 5
+
+
+def _resolve_concurrency_cap() -> int:
+    raw = os.environ.get("AUTOSEARCH_DELEGATE_CONCURRENCY", str(_DEFAULT_CONCURRENCY_CAP))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_CONCURRENCY_CAP
 
 
 @dataclass
@@ -26,8 +37,19 @@ async def run_subtask(
     channel_runtime: ChannelRuntime,
     _search_fn=None,  # injectable for tests
 ) -> SubtaskResult:
-    """Run query across channels concurrently and return a SubtaskResult."""
+    """Run query across channels concurrently and return a SubtaskResult.
+
+    All channel calls go through the shared ``channel_runtime`` so the
+    rate limiter, health tracker, and cost tracker accumulate across
+    delegate runs (P0-4). The channel list is order-preserving deduped
+    so the same name passed twice is only run once. A semaphore caps
+    in-flight calls (default 5; override via
+    ``AUTOSEARCH_DELEGATE_CONCURRENCY``) to protect paid APIs from burst.
+    """
     from autosearch.core.models import SubQuery  # noqa: PLC0415
+
+    channels = list(dict.fromkeys(channels))
+    semaphore = asyncio.Semaphore(_resolve_concurrency_cap())
 
     if _search_fn is None:
         all_channels = {c.name: c for c in channel_runtime.channels}
@@ -43,11 +65,12 @@ async def run_subtask(
     result = SubtaskResult()
 
     async def _run_one(name: str) -> tuple[str, list[dict] | Exception]:
-        try:
-            evidence = await _search_fn(name)
-            return name, evidence[:max_per_channel]
-        except Exception as exc:  # noqa: BLE001
-            return name, exc
+        async with semaphore:
+            try:
+                evidence = await _search_fn(name)
+                return name, evidence[:max_per_channel]
+            except Exception as exc:  # noqa: BLE001
+                return name, exc
 
     outcomes = await asyncio.gather(*(_run_one(ch) for ch in channels))
 

--- a/autosearch/mcp/server.py
+++ b/autosearch/mcp/server.py
@@ -893,9 +893,17 @@ def create_server(pipeline_factory: Callable[[], Any] | None = None) -> FastMCP:
         Use when you want to search several channels in parallel for the same query.
         Returns {evidence_by_channel, summary, failed_channels, failed_channel_details, budget_used}.
         """
+        from autosearch.core.channel_runtime import get_channel_runtime  # noqa: PLC0415
         from autosearch.core.delegate import run_subtask  # noqa: PLC0415
 
-        result = await run_subtask(task_description, channels, query, max_per_channel)
+        runtime = get_channel_runtime()
+        result = await run_subtask(
+            task_description,
+            channels,
+            query,
+            max_per_channel,
+            channel_runtime=runtime,
+        )
         return {
             "evidence_by_channel": result.evidence_by_channel,
             "summary": result.summary,

--- a/docs/architecture/delegate.md
+++ b/docs/architecture/delegate.md
@@ -1,0 +1,81 @@
+# Delegate (`run_subtask`) Architecture Contract
+
+> Status: enforced as of P0-4 fix (`fix/p0-4-delegate-channel-runtime`).
+> `autosearch.core.delegate.run_subtask` is the only public entry for
+> parallel multi-channel search dispatch.
+
+## Why this exists
+
+`delegate_subtask` is the MCP tool that fans a single query out to
+several channels in parallel. Without discipline, three failure modes
+appear:
+
+1. **Cost blowout.** A caller passes the same channel name twice
+   (intentional or accidental) and a paid API gets billed twice for
+   identical work.
+2. **Burst spend.** A caller passes 50 channels and they all fire at
+   once — no rate limiter, no concurrency cap, no protection against a
+   bug that explodes the channel list.
+3. **Stale rate-limit / cost state.** If `delegate_subtask` builds its
+   own `Channel` objects via `_build_channels()`, the per-process
+   rate limiter and cost tracker that `run_channel` and `doctor` share
+   are bypassed — quota is invisible across delegate calls.
+
+## Contract
+
+`run_subtask(task_description, channels, query, max_per_channel=5, *,
+channel_runtime: ChannelRuntime, _search_fn=None)`.
+
+### Required: `channel_runtime` is a keyword-only required argument
+
+No default. The caller MUST pass the shared `ChannelRuntime`
+(`get_channel_runtime()`) so the rate limiter, health tracker, and cost
+tracker in that runtime accumulate across every search — `run_channel`,
+`delegate_subtask`, `doctor`. There is no per-call runtime construction.
+
+### Order-preserving dedupe
+
+`channels = list(dict.fromkeys(channels))` runs at function entry. The
+same channel name passed N times runs once, in the position of its
+first occurrence. Cost stats and evidence are reported per name, so
+dedupe also ensures `budget_used[name]` reflects the actual call count.
+
+### Concurrency cap
+
+`asyncio.Semaphore(N)` wraps every `_search_fn` call. Default `N=5`;
+override via `AUTOSEARCH_DELEGATE_CONCURRENCY` env var (parsed as int;
+invalid value silently falls back to 5; values <1 clamped to 1).
+
+### Test injection
+
+`_search_fn` (private) lets tests inject a synthetic search function
+that bypasses real channel lookup. When `_search_fn` is provided,
+`channel_runtime` is unused but still required by signature — forces
+every test call site to think about runtime ownership.
+
+## Wiring
+
+- `autosearch/mcp/server.py:delegate_subtask` (the MCP tool entry):
+  fetches `runtime = get_channel_runtime()` and passes
+  `channel_runtime=runtime`.
+- No other code path constructs a `Channel` set for delegate. Adding
+  one is a contract violation.
+
+## Coverage
+
+- `tests/unit/test_delegate.py`:
+  - `test_run_subtask_requires_channel_runtime` — signature-level
+    check, no default for the kwarg.
+  - `test_run_subtask_propagates_runtime_rate_limit` — `RateLimited`
+    raised from `_search_fn` becomes `failed_channels[].status =
+    "rate_limited"`.
+  - `test_run_subtask_dedupes_repeated_channels` — `[a, b, a]` runs
+    each name once.
+  - `test_run_subtask_respects_concurrency_cap` — under
+    `AUTOSEARCH_DELEGATE_CONCURRENCY=2`, observed in-flight count
+    never exceeds 2.
+- `tests/unit/test_mcp_delegate.py::test_delegate_subtask_passes_shared_runtime`
+  — MCP tool call captures the runtime kwarg and asserts it `is`
+  `get_channel_runtime()`.
+
+Source: `docs/security/autosearch-0426-p0-deep-scan-report.md` § P0-4.

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import cast
 
 import pytest
 
@@ -11,7 +12,10 @@ from autosearch.channels.base import (
     MethodUnavailable,
     RateLimited,
 )
+from autosearch.core.channel_runtime import ChannelRuntime
 from autosearch.core.delegate import run_subtask
+
+_UNUSED_RUNTIME = cast(ChannelRuntime, object())
 
 
 async def _fake_search(name: str, results: list[dict], fail: bool = False):
@@ -28,7 +32,13 @@ async def test_parallel_returns_evidence_from_all_channels():
     async def _search(channel_name: str) -> list[dict]:
         return [{"url": f"https://{channel_name}.com/1", "title": "t"}]
 
-    result = await run_subtask("task", ["ch_a", "ch_b"], "query", _search_fn=_search)
+    result = await run_subtask(
+        "task",
+        ["ch_a", "ch_b"],
+        "query",
+        channel_runtime=_UNUSED_RUNTIME,
+        _search_fn=_search,
+    )
     assert "ch_a" in result.evidence_by_channel
     assert "ch_b" in result.evidence_by_channel
     assert result.failed_channels == []
@@ -41,7 +51,13 @@ async def test_failed_channel_recorded_not_raised():
             raise RuntimeError("boom")
         return [{"url": "https://ok.com"}]
 
-    result = await run_subtask("task", ["ok", "bad"], "query", _search_fn=_search)
+    result = await run_subtask(
+        "task",
+        ["ok", "bad"],
+        "query",
+        channel_runtime=_UNUSED_RUNTIME,
+        _search_fn=_search,
+    )
     assert "ok" in result.evidence_by_channel
     assert "bad" in result.failed_channels
     assert "bad" not in result.evidence_by_channel
@@ -54,7 +70,14 @@ async def test_max_per_channel_limits_evidence():
     async def _search(channel_name: str) -> list[dict]:
         return [{"url": f"https://x.com/{i}"} for i in range(20)]
 
-    result = await run_subtask("task", ["ch"], "query", max_per_channel=3, _search_fn=_search)
+    result = await run_subtask(
+        "task",
+        ["ch"],
+        "query",
+        max_per_channel=3,
+        channel_runtime=_UNUSED_RUNTIME,
+        _search_fn=_search,
+    )
     assert len(result.evidence_by_channel["ch"]) <= 3
 
 
@@ -76,7 +99,13 @@ async def test_failed_channel_details_preserve_typed_statuses(
     async def _search(_channel_name: str) -> list[dict]:
         raise exc
 
-    result = await run_subtask("task", ["bad"], "query", _search_fn=_search)
+    result = await run_subtask(
+        "task",
+        ["bad"],
+        "query",
+        channel_runtime=_UNUSED_RUNTIME,
+        _search_fn=_search,
+    )
 
     assert result.failed_channels == ["bad"]
     assert result.failed_channel_details[0]["channel"] == "bad"

--- a/tests/unit/test_delegate.py
+++ b/tests/unit/test_delegate.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import inspect
+
+from autosearch.core.delegate import run_subtask
+
+
+def test_run_subtask_requires_channel_runtime() -> None:
+    signature = inspect.signature(run_subtask)
+    channel_runtime = signature.parameters.get("channel_runtime")
+
+    assert channel_runtime is not None
+    assert channel_runtime.default is inspect.Parameter.empty

--- a/tests/unit/test_delegate.py
+++ b/tests/unit/test_delegate.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
+from typing import cast
 
+import pytest
+
+from autosearch.channels.base import RateLimited
+from autosearch.core.channel_runtime import ChannelRuntime
 from autosearch.core.delegate import run_subtask
+
+_UNUSED_RUNTIME = cast(ChannelRuntime, object())
 
 
 def test_run_subtask_requires_channel_runtime() -> None:
@@ -11,3 +19,76 @@ def test_run_subtask_requires_channel_runtime() -> None:
 
     assert channel_runtime is not None
     assert channel_runtime.default is inspect.Parameter.empty
+
+
+@pytest.mark.asyncio
+async def test_run_subtask_propagates_runtime_rate_limit() -> None:
+    """A RateLimited from the search path surfaces as a failed_channel
+    with rate_limited status — the runtime contract callers depend on."""
+
+    async def _search(name: str) -> list[dict]:
+        raise RateLimited(f"rate-limited: {name}.search retry_after=10s")
+
+    result = await run_subtask(
+        "task",
+        ["alpha"],
+        "query",
+        channel_runtime=_UNUSED_RUNTIME,
+        _search_fn=_search,
+    )
+
+    assert result.failed_channels == ["alpha"]
+    assert result.failed_channel_details[0]["status"] == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_run_subtask_dedupes_repeated_channels() -> None:
+    """The same channel name passed twice must only run once."""
+    call_counts: dict[str, int] = {}
+
+    async def _search(name: str) -> list[dict]:
+        call_counts[name] = call_counts.get(name, 0) + 1
+        return [{"channel": name}]
+
+    result = await run_subtask(
+        "task",
+        ["alpha", "beta", "alpha"],
+        "query",
+        channel_runtime=_UNUSED_RUNTIME,
+        _search_fn=_search,
+    )
+
+    assert call_counts == {"alpha": 1, "beta": 1}
+    assert set(result.evidence_by_channel.keys()) == {"alpha", "beta"}
+
+
+@pytest.mark.asyncio
+async def test_run_subtask_respects_concurrency_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTOSEARCH_DELEGATE_CONCURRENCY caps in-flight channel calls."""
+    monkeypatch.setenv("AUTOSEARCH_DELEGATE_CONCURRENCY", "2")
+
+    in_flight = 0
+    max_in_flight = 0
+    lock = asyncio.Lock()
+
+    async def _search(name: str) -> list[dict]:
+        nonlocal in_flight, max_in_flight
+        async with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.02)
+        async with lock:
+            in_flight -= 1
+        return [{"channel": name}]
+
+    channels = [f"ch{i}" for i in range(8)]
+
+    await run_subtask(
+        "task",
+        channels,
+        "query",
+        channel_runtime=_UNUSED_RUNTIME,
+        _search_fn=_search,
+    )
+
+    assert max_in_flight <= 2, f"expected cap 2, observed {max_in_flight}"

--- a/tests/unit/test_mcp_delegate.py
+++ b/tests/unit/test_mcp_delegate.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from autosearch.core import delegate as delegate_module
+from autosearch.core.channel_runtime import get_channel_runtime
+from autosearch.mcp.server import create_server
+
+
+@pytest.mark.asyncio
+async def test_delegate_subtask_passes_shared_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The MCP delegate_subtask tool must call run_subtask with the same
+    runtime that get_channel_runtime() returns — otherwise the rate
+    limiter and cost tracker do not accumulate across delegate calls."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_run_subtask(
+        task_description: str,
+        channels: list[str],
+        query: str,
+        max_per_channel: int = 5,
+        *,
+        channel_runtime: Any,
+        **kwargs: Any,
+    ) -> delegate_module.SubtaskResult:
+        captured["channel_runtime"] = channel_runtime
+        captured["channels"] = channels
+        return delegate_module.SubtaskResult()
+
+    monkeypatch.setattr(delegate_module, "run_subtask", _fake_run_subtask)
+
+    server = create_server(pipeline_factory=lambda: None)  # type: ignore[arg-type]
+    await server._tool_manager.call_tool(
+        "delegate_subtask",
+        {
+            "task_description": "task",
+            "channels": ["alpha"],
+            "query": "q",
+        },
+    )
+
+    assert captured["channel_runtime"] is get_channel_runtime()
+    assert captured["channels"] == ["alpha"]


### PR DESCRIPTION
## Summary

Closes deep-scan **P0-4** (delegate_subtask bypassed shared `ChannelRuntime` → cost blowout, no rate limit, no concurrency cap, dup channel calls).

Three contract changes, each test-locked:

1. **`channel_runtime` is a required keyword-only argument** of `run_subtask`. No default. Removes `_build_channels()` self-construction. The MCP `delegate_subtask` tool passes `get_channel_runtime()`.
2. **Order-preserving dedupe** — `channels = list(dict.fromkeys(channels))`. Same name passed twice runs once.
3. **Concurrency cap** — `asyncio.Semaphore(N)`, default 5, override via `AUTOSEARCH_DELEGATE_CONCURRENCY` env var.

A `RateLimited` raised from the search path now correctly surfaces as `failed_channels[].status = "rate_limited"` (test `test_run_subtask_propagates_runtime_rate_limit`).

## Background

Plan: `docs/exec-plans/active/autosearch-0426-p0-deep-scan-fix.md` § F004.
Deep-scan source: `docs/security/autosearch-0426-p0-deep-scan-report.md` § P0-4.

**Note: F004 and F005 (PR #423) both touch `autosearch/mcp/server.py`.** Per the plan's Decision Log, F005 lands first (smaller); this PR will rebase after #423 merges.

## Test plan

- [x] `tests/unit/test_delegate.py` — 4 tests (signature requirement + rate-limit + dedupe + concurrency cap)
- [x] `tests/unit/test_mcp_delegate.py` — MCP boundary asserts shared runtime is passed
- [x] `tests/test_delegate.py` (existing) — 9 tests still pass (with `_UNUSED_RUNTIME` cast for tests using `_search_fn`)
- [x] `tests/unit/test_mcp_server.py` — 8 tests still pass
- [x] Ruff check + format-check clean
- [ ] Code-reviewer: pending background run

## Note on commits

5 commits exactly at the project's 5-cap: failing test scaffold → required-runtime feat → dedupe+cap+rate-limit feat (joint) → MCP test → docs. Each `feat` has paired tests.