### PR TITLE
fix(bench-judge): use as_posix() so test_judge metadata works on Windows

### DIFF
--- a/scripts/bench/judge.py
+++ b/scripts/bench/judge.py
@@ -265,8 +265,8 @@ def add_report_metadata(
             "sample_size": stats["total"],
             "a_label": stats["a_label"],
             "b_label": stats["b_label"],
-            "a_dir": str(a_dir),
-            "b_dir": str(b_dir),
+            "a_dir": a_dir.as_posix(),
+            "b_dir": b_dir.as_posix(),
         },
     }
 


### PR DESCRIPTION
## Summary

`add_report_metadata` (`scripts/bench/judge.py:268-269`) used `str(a_dir)` / `str(b_dir)` for the `test_config` block. On Windows that produces `reports\a` (backslash); the test (and downstream JSON consumers) expect `reports/a`. Switch to `Path.as_posix()` which always returns forward slashes.

## Background

Cross-Platform Tests workflow has been red on `main` since `2026-04-25T05:07Z`. The failure is pinned to:

```
tests/bench/test_judge.py::test_add_report_metadata_records_generation_context
AssertionError on test_config dict ('a_dir' = 'reports\\a' vs 'reports/a')
```

Per `docs/release-policy.md` § Nightly / out-of-band, Cross-Platform is a tier-2 weekly check that does not block PR or release — but it should be green.

## Test plan

- [x] `pytest tests/bench/test_judge.py -x -q` → 12 passed locally on macOS
- [x] Ruff check clean
- [ ] Cross-Platform Tests workflow re-run on the merged commit

## Note

Change is 2 lines (`str(...)` → `.as_posix()`). No behavior change on macOS / Linux (which already produced forward slashes). Windows now matches.