### PR TITLE
fix(test-e2b): skip bench-command tests on Windows (POSIX shell only)

### DIFF
--- a/tests/scripts/test_e2b_bench_commands.py
+++ b/tests/scripts/test_e2b_bench_commands.py
@@ -7,6 +7,19 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
+# These tests assert that bench-command builders correctly escape shell
+# metacharacters when the resulting string is fed to a POSIX shell — the same
+# environment the e2b Linux sandbox uses in production. On Windows pytest
+# runners (Cross-Platform Tests workflow) the command relies on `$HOME` and
+# `.venv/bin/python` syntax that cmd.exe does not understand, so the tests
+# fail for environment reasons unrelated to the quoting behavior under test.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bench commands target POSIX shell (e2b Linux sandbox); cmd.exe cannot run them",
+)
+
 
 def _install_fake_e2b_module(monkeypatch) -> None:
     fake = types.ModuleType("e2b_code_interpreter")


### PR DESCRIPTION
## Summary

`tests/scripts/test_e2b_bench_commands.py` builds shell command strings that target the e2b Linux sandbox (bash). On Windows runners, pytest invokes `shell=True` → cmd.exe, which fails on `\$HOME` and `.venv/bin/python` syntax with `'system cannot find the path specified'` — completely unrelated to the shell-quoting behavior the test actually verifies.

Add module-level `pytestmark = pytest.mark.skipif(sys.platform == 'win32')`.

## Background

Cross-Platform Tests workflow run [24952635233](https://github.com/0xmariowu/Autosearch/actions/runs/24952635233) failed on this test. The previous Cross-Platform fix (#425) addressed `test_judge.py` Windows path-separator issue; this is the next casualty in the same workflow's Windows backlog.

## Test plan

- [x] `pytest tests/scripts/test_e2b_bench_commands.py -x -q` → 2 passed (macOS, no skip)
- [x] Ruff clean
- [ ] Cross-Platform Tests workflow re-run on the merged commit (Windows job will SKIP these tests)

## Note

These tests are valuable on Linux/macOS — they catch real shell-injection regressions in the bench-command builders. Skipping on Windows only loses coverage on a platform that doesn't run the production code path anyway (e2b sandbox is always Linux).