### PR TITLE
fix(test-smoke): set USERPROFILE alongside HOME for Windows Path.home() compat

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -66,12 +66,22 @@ def console_script_command(script_name: str, module_name: str) -> list[str]:
     return [sys.executable, "-m", module_name]
 
 
-def smoke_env(**overrides: str) -> dict[str, str]:
+def smoke_env(
+    *,
+    home: str | Path | None = None,
+    **overrides: str,
+) -> dict[str, str]:
     env = os.environ.copy()
     cwd = str(Path.cwd())
     pythonpath = env.get("PYTHONPATH")
     env["PYTHONPATH"] = cwd if not pythonpath else f"{cwd}{os.pathsep}{pythonpath}"
+    if home is not None:
+        home_value = str(home)
+        env["HOME"] = home_value
+        env["USERPROFILE"] = home_value
     env.update(overrides)
+    if "HOME" in overrides and "USERPROFILE" not in overrides:
+        env["USERPROFILE"] = overrides["HOME"]
     return env
 
 

--- a/tests/smoke/test_cli_configure_smoke.py
+++ b/tests/smoke/test_cli_configure_smoke.py
@@ -29,8 +29,7 @@ def test_cli_configure_rejects_no_value_no_stdin_in_non_tty() -> None:
 def test_cli_configure_inline_value_works_non_interactively(tmp_path) -> None:
     """v2: inline-value form is the supported automation path for install
     scripts; must work without a TTY."""
-    env = smoke_env()
-    env["HOME"] = str(tmp_path)
+    env = smoke_env(home=tmp_path)
     result = subprocess.run(
         [sys.executable, "-m", "autosearch.cli.main", "configure", "SMOKE_KEY", "smokeval"],
         input="",

--- a/tests/smoke/test_install_script.py
+++ b/tests/smoke/test_install_script.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.smoke.conftest import smoke_env
+
 
 ROOT = Path(__file__).resolve().parents[2]
 NPM_DIR = ROOT / "npm"
@@ -70,8 +72,7 @@ def test_install_then_run_e2e_smoke(tmp_path: Path) -> None:
     )
     fake_bash.chmod(0o755)
 
-    env = os.environ.copy()
-    env["HOME"] = str(home)
+    env = smoke_env(home=home)
     env["PATH"] = os.pathsep.join([str(fake_bin), "/usr/bin", "/bin"])
 
     result = subprocess.run(

--- a/tests/smoke/test_npm_wrapper.py
+++ b/tests/smoke/test_npm_wrapper.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.smoke.conftest import smoke_env
+
 
 ROOT = Path(__file__).resolve().parents[2]
 NPM_DIR = ROOT / "npm"
@@ -133,8 +135,7 @@ def test_path_after_install_finds_binary(tmp_path: Path) -> None:
     )
     fake_bash.chmod(0o755)
 
-    env = os.environ.copy()
-    env["HOME"] = str(home)
+    env = smoke_env(home=home)
     env["PATH"] = os.pathsep.join([str(fake_bin), "/usr/bin", "/bin"])
 
     result = subprocess.run(
@@ -179,8 +180,7 @@ def test_install_passes_no_init(tmp_path: Path) -> None:
     )
     fake_bash.chmod(0o755)
 
-    env = os.environ.copy()
-    env["HOME"] = str(home)
+    env = smoke_env(home=home)
     env["PATH"] = os.pathsep.join([str(fake_bin), "/usr/bin", "/bin"])
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary

Fixes the Cross-Platform Tests Windows regression on main: `tests/smoke/test_cli_configure_smoke.py::test_cli_configure_inline_value_works_non_interactively` was failing because the test sets only `env[\"HOME\"]` but on Windows `Path.home()` reads `%USERPROFILE%`, not `%HOME%`. The CLI subprocess wrote the secrets file to the real user home, while the test asserted against tmp_path.

## Changes

- `tests/smoke/conftest.py` `smoke_env()` (or new helper): when caller passes `home=...`, set BOTH `HOME` and `USERPROFILE`.
- Three smoke test files updated to use the new pattern: `test_cli_configure_smoke.py`, `test_npm_wrapper.py`, `test_install_script.py`.

## Test plan

- [x] `pytest tests/smoke/test_cli_configure_smoke.py tests/smoke/test_npm_wrapper.py tests/smoke/test_install_script.py` — 12 passed
- [x] `pytest tests/smoke/ -m \"not network and not real_llm\"` — 21 passed
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)