### PR TITLE
ci(pr-flow): add PR base guard — block stacked PRs

### DIFF
--- a/.github/workflows/assert-base-is-default-branch.yml
+++ b/.github/workflows/assert-base-is-default-branch.yml
@@ -1,0 +1,29 @@
+name: PR base guard
+
+# Reject PRs whose base is not the repo's default branch.
+# Stacked PRs (PR-on-PR) are not supported here: under squash merge the
+# downstream PR's base ref still points at the pre-squash commits, so the
+# chain silently desyncs. Branch from the default branch and merge serially.
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+permissions: {}
+
+jobs:
+  base-must-be-default:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject if base is not the default branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::PR #${PR_NUMBER} base is '${BASE_REF}', must be '${DEFAULT_BRANCH}'."
+            echo "Stacked PRs are not supported. Branch from '${DEFAULT_BRANCH}' and merge serially."
+            exit 1
+          fi
+          echo "OK: base '${BASE_REF}' matches default branch."


### PR DESCRIPTION
## Why
Sister project lazie had stacked PRs (#108/#109/#110) desync under squash + auto-merge today. Adding the same guard repo-wide.

Topology-aware auto-merge wouldn't fix it: squash merge produces new SHAs that downstream PR base refs don't reflect, so the chain breaks even with correct ordering.

## What
`.github/workflows/assert-base-is-default-branch.yml` — any PR whose `base.ref != repository.default_branch` fails. Branch from main, merge serially.

## Test plan
- [ ] This PR's base = `main` → check passes
- [ ] After merge, intentional stacked PR is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation to ensure pull requests use the repository's default branch as their base, strengthening development process controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->