### PR TITLE
fix(tests): skip POSIX install.sh smoke tests on Windows

### DIFF
--- a/tests/smoke/test_install_script.py
+++ b/tests/smoke/test_install_script.py
@@ -23,6 +23,7 @@ def run_install_script(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only install.sh shell script")
 def test_install_script_dry_run_accepts_valid_version() -> None:
     result = run_install_script("--dry-run", "--version", "2026.04.25.1")
     combined_output = result.stdout + result.stderr
@@ -31,6 +32,7 @@ def test_install_script_dry_run_accepts_valid_version() -> None:
     assert "autosearch==2026.04.25.1" in combined_output
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only install.sh shell script")
 def test_install_script_rejects_injected_version_without_execution() -> None:
     result = run_install_script(
         "--dry-run",
@@ -43,6 +45,7 @@ def test_install_script_rejects_injected_version_without_execution() -> None:
     assert "PWNED" not in combined_output
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only install.sh shell script")
 def test_install_script_rejects_path_traversal_version() -> None:
     result = run_install_script("--dry-run", "--version", "../../etc/passwd")
     combined_output = result.stdout + result.stderr


### PR DESCRIPTION
## Summary

- 3 smoke tests in `tests/smoke/test_install_script.py` invoke `bash scripts/install.sh` but lacked the `@pytest.mark.skipif(os.name == "nt", ...)` decorator that the 4th test in the same file already has.
- On the GitHub Windows runner, `bash` resolves to the WSL entry point. Since the runner has no WSL distro installed, the call fails with `Windows Subsystem for Linux has no installed distributions` and the test errors out instead of being skipped.
- This is what caused Cross-Platform Tests run [#26270819408](https://github.com/0xmariowu/Autosearch/actions/runs/26270819408) (and every Windows run since) to fail.

## Fix

Add `@pytest.mark.skipif(os.name == "nt", reason="POSIX-only install.sh shell script")` to the 3 missing tests. `install.sh` is a POSIX shell installer — running it on Windows isn't meaningful.

## Test plan

- [x] Local: `pytest tests/smoke/test_install_script.py -x -q` → 4 passed
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI Cross-Platform Tests green on Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Install script tests now skip on Windows systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0xmariowu/Autosearch/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->