### PR TITLE
chore: stop nightly live tests from running on a daily schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,12 @@
 name: Nightly — Live Integration Tests
 
 on:
-  schedule:
-    - cron: "0 2 * * *"   # UTC 02:00 daily
-  workflow_dispatch:       # manual trigger
+  # Daily schedule removed: live tests hit ~14 real public endpoints from a
+  # shared CI IP, so transient upstream rate-limits/blocks (429/403/5xx)
+  # produced a false-alarm failure email nearly every night with no actionable
+  # signal. Run on demand from the Actions tab instead, where a human can read
+  # the result. The job still fails loudly on any real regression.
+  workflow_dispatch:       # manual trigger only
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The `Nightly — Live Integration Tests` workflow fired a failure email nearly every day. Root cause: it hits ~14 real public free endpoints (arxiv, reddit, dblp, pubmed, ddgs…) from a shared CI datacenter IP and asserts every one returns results. Public services routinely rate-limit (429), block datacenter traffic (403), or return transient 5xx — so at least one of the 14 fails on essentially every run. These are upstream conditions, **not regressions in AutoSearch**.

Reproduced locally: arxiv `429`, reddit `403`, dblp `500`.

## Change

Remove the daily `cron` trigger from `nightly.yml`. `workflow_dispatch` is kept, so the suite can still be run **on demand from the Actions tab**, where a human can read the result. When run, the job still fails loudly on any real regression — no test behaviour is changed.

This is the minimal change that stops the daily false-alarm emails.

> **Note on scope:** an earlier revision of this PR also added skip-on-transient logic to the live tests. Per review feedback (Codex/CodeRabbit correctly noted it could mask genuine parse/auth/method regressions) and since the suite is now manual-only, that logic was dropped — a manual run *should* surface every problem. The PR is now just the schedule removal.

## Trade-off

No daily auto-run means no automatic alert if a platform genuinely breaks our parsing. Run the workflow manually (or add a weekly cron later) when you want that regression check.

Workflow edit authorized by the repo owner (@0xmariowu) in lieu of an automated approval gate.

https://claude.ai/code/session_01WJdXSEnHXZ8bhuV33vBN1R