### PR TITLE
chore: remove weekly schedule triggers from cross-platform and codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,8 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+  # Weekly schedule removed to stop scheduled failure-notification emails.
+  # CodeQL still scans every push to main and every PR, so security coverage
+  # of all changed code is preserved.
 
 concurrency:
   group: codeql-${{ github.ref }}

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -4,8 +4,10 @@ name: Cross-Platform Tests
 # E2B sandboxes are Linux-only; this workflow provides real Windows/macOS coverage.
 
 on:
-  schedule:
-    - cron: "0 3 * * 1"   # UTC 03:00 every Monday
+  # Weekly schedule removed: these jobs hit external endpoints and Windows
+  # runners that produce false-alarm failure emails with no actionable signal.
+  # Coverage is preserved via the push trigger below (runs on every main change
+  # that touches package code) plus manual dispatch from the Actions tab.
   workflow_dispatch:       # manual trigger
   push:
     branches: [main]


### PR DESCRIPTION
## Problem

Two workflows run on a weekly Monday `cron` and email a failure notification on any red run — including transient or environment-specific failures (e.g. the Windows `Cross-Platform Tests` job) that carry no actionable signal. These are the only remaining scheduled workflows after #478 disabled the nightly cron.

## Change

Remove the `schedule` trigger from both:

- **`cross-platform.yml`** (`0 3 * * 1`) — still runs on push to `main` touching `autosearch/**` or `pyproject.toml`, and on manual dispatch.
- **`codeql.yml`** (`0 6 * * 1`) — still scans every push to `main` and every PR, so all changed code is still security-scanned.

No job logic changes; only the cron triggers are dropped. Coverage on real code changes is preserved; only the unsolicited weekly email is removed.

Workflow edit authorized by the repo owner (@0xmariowu).

https://claude.ai/code/session_01WJdXSEnHXZ8bhuV33vBN1R

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJdXSEnHXZ8bhuV33vBN1R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed scheduled triggers from GitHub Actions workflows. Security scanning and cross-platform testing now rely on event-based triggers (code pushes and pull requests to main) instead of periodic schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->